### PR TITLE
Adding ignoreUrlParamsMatching to workbox-build

### DIFF
--- a/packages/workbox-build/src/lib/generate-sw.js
+++ b/packages/workbox-build/src/lib/generate-sw.js
@@ -64,6 +64,8 @@ const errors = require('./errors');
  * of regexs to restrict which URL's use the navigateFallback cached response.
  * @param {Array<Object>} [input.runtimeCaching] An optional Array
  * of objects to define run time caching strategies.
+ * @param {Array<RegExp>} [input.ignoreUrlParametersMatching] An array of
+ * regex's to remove search params when looking for a cache match.
  * @return {Promise} Resolves once the service worker has been generated
  * with a precache list.
  *

--- a/packages/workbox-build/src/lib/templates/sw.js.tmpl
+++ b/packages/workbox-build/src/lib/templates/sw.js.tmpl
@@ -19,7 +19,7 @@ importScripts('<%= swlibPath %>');
  */
 const fileManifest = <%= JSON.stringify(manifestEntries, null, 2) %>;
 
-const swlib = new self.goog.SWLib(<% if(swlibOptions && Object.keys(swlibOptions).length > 0) { %><%= JSON.stringify(swlibOptions, null, 2) %><% } %>);
+const swlib = new self.goog.SWLib(<%= swlibOptionsString %>);
 swlib.precache(fileManifest);
 <% if(navigateFallback) { %>swlib.router.registerNavigationRoute("<%= navigateFallback %>"<% if(navigateFallbackWhitelist) { %>, {
   whitelist: [<%= navigateFallbackWhitelist %>],

--- a/packages/workbox-build/src/lib/write-sw.js
+++ b/packages/workbox-build/src/lib/write-sw.js
@@ -47,6 +47,11 @@ module.exports =
     if (options.directoryIndex) {
       swlibOptions.directoryIndex = options.directoryIndex;
     }
+    if (options.ignoreUrlParametersMatching) {
+      // JSON.stringify can't output regexes so instead we'll
+      // inject it in the swlibOptionsString.
+      swlibOptions.ignoreUrlParametersMatching = [];
+    }
     let runtimeCaching = [];
     if (options.runtimeCaching) {
       options.runtimeCaching.forEach((cachingEntry) => {
@@ -71,12 +76,23 @@ module.exports =
     }
 
     try {
+      let swlibOptionsString = '';
+      if (Object.keys(swlibOptions).length > 0) {
+        swlibOptionsString = JSON.stringify(swlibOptions, null, 2);
+      }
+      if (options.ignoreUrlParametersMatching) {
+        swlibOptionsString = swlibOptionsString.replace(
+          '"ignoreUrlParametersMatching": []',
+          `"ignoreUrlParametersMatching": [` +
+              options.ignoreUrlParametersMatching.join(', ') + `]`
+        );
+      }
       return template(templateString)({
         manifestEntries: manifestEntries,
         swlibPath: relSwlibPath,
         navigateFallback: options.navigateFallback,
         navigateFallbackWhitelist: options.navigateFallbackWhitelist,
-        swlibOptions,
+        swlibOptionsString,
         runtimeCaching,
       }).trim() + '\n';
     } catch (err) {

--- a/packages/workbox-build/test/node/lib-write-sw.js
+++ b/packages/workbox-build/test/node/lib-write-sw.js
@@ -799,4 +799,68 @@ swlib.router.registerRoute(/\\/articles\\//, swlib.strategies.staleWhileRevalida
         ],
       });
   });
+
+  it('should be able to generate sw for template with navigateFallback and whitelist', function() {
+      const EXPECTED_RESULT = `importScripts('workbox-sw.min.js');
+
+/**
+ * DO NOT EDIT THE FILE MANIFEST ENTRY
+ *
+ * The method precache() does the following:
+ * 1. Cache URLs in the manifest to a local cache.
+ * 2. When a network request is made for any of these URLs the response
+ *    will ALWAYS comes from the cache, NEVER the network.
+ * 3. When the service worker changes ONLY assets with a revision change are
+ *    updated, old cache entries are left as is.
+ *
+ * By changing the file manifest manually, your users may end up not receiving
+ * new versions of files because the revision hasn't changed.
+ *
+ * Please use workbox-build or some other tool / approach to generate the file
+ * manifest which accounts for changes to local files and update the revision
+ * accordingly.
+ */
+const fileManifest = [
+  {
+    "url": "/",
+    "revision": "1234"
+  }
+];
+
+const swlib = new self.goog.SWLib({
+  "ignoreUrlParametersMatching": [/^example/, /^other/]
+});
+swlib.precache(fileManifest);
+`;
+    const writeSw = proxyquire('../../src/lib/write-sw', {
+      'mkdirp': {
+        sync: () => {
+          return;
+        },
+      },
+      'fs': {
+        writeFile: (filepath, stringToWrite, cb) => {
+          if (stringToWrite === EXPECTED_RESULT) {
+            cb();
+          } else {
+            stringToWrite.should.equal(EXPECTED_RESULT);
+            cb(new Error('Unexpected result from fs.'));
+          }
+        },
+      },
+    });
+
+    return writeSw(
+      'fake-path/sw.js',
+      [
+        {
+          url: '/',
+          revision: '1234',
+        },
+      ],
+      'fake-path/workbox-sw.min.js',
+      'fake-path/', {
+        ignoreUrlParametersMatching: [/^example/, /^other/],
+      });
+  });
 });


### PR DESCRIPTION
R: @jeffposnick @addyosmani

Realised I'd added this option to workbox-sw and *not* workbox-build.

Because JSON.stringify() prints regexes as "{}" I've had to do some hackery to get the right output.
