### PR TITLE
Don't calculate the relative path twice

### DIFF
--- a/packages/workbox-build/src/lib/templates/sw.js.tmpl
+++ b/packages/workbox-build/src/lib/templates/sw.js.tmpl
@@ -1,4 +1,4 @@
-importScripts('<%= workboxSWPath %>');
+importScripts('<%= wbSWPathRelToSW %>');
 
 /**
  * DO NOT EDIT THE FILE MANIFEST ENTRY

--- a/packages/workbox-build/src/lib/write-sw.js
+++ b/packages/workbox-build/src/lib/write-sw.js
@@ -6,7 +6,7 @@ const template = require('lodash.template');
 const errors = require('./errors');
 
 module.exports =
-  (swSrc, manifestEntries, workboxSWPath, rootDirectory, options) => {
+  (swSrc, manifestEntries, wbSWPathRelToSW, globDirectory, options) => {
   options = options || {};
   try {
     mkdirp.sync(path.dirname(swSrc));
@@ -88,7 +88,7 @@ module.exports =
       }
       return template(templateString)({
         manifestEntries: manifestEntries,
-        workboxSWPath,
+        wbSWPathRelToSW,
         navigateFallback: options.navigateFallback,
         navigateFallbackWhitelist: options.navigateFallbackWhitelist,
         workboxSWOptionsString,

--- a/packages/workbox-build/src/lib/write-sw.js
+++ b/packages/workbox-build/src/lib/write-sw.js
@@ -29,8 +29,6 @@ module.exports =
     });
   })
   .then((templateString) => {
-    const relSwlibPath = path.relative(rootDirectory, workboxSWPath);
-
     const workboxSWOptions = {};
     if (options.cacheId) {
       workboxSWOptions.cacheId = options.cacheId;
@@ -90,7 +88,7 @@ module.exports =
       }
       return template(templateString)({
         manifestEntries: manifestEntries,
-        workboxSWPath: relSwlibPath,
+        workboxSWPath,
         navigateFallback: options.navigateFallback,
         navigateFallbackWhitelist: options.navigateFallbackWhitelist,
         workboxSWOptionsString,

--- a/packages/workbox-build/test/node/lib-write-sw.js
+++ b/packages/workbox-build/test/node/lib-write-sw.js
@@ -64,7 +64,7 @@ describe('lib/write-sw.js', function() {
           revision: '1234',
         },
       ],
-      'fake-path/workbox-sw.min.js',
+      'workbox-sw.min.js',
       'fake-path/')
     .then(() => {
       throw new Error('Expected error to be thrown');
@@ -101,7 +101,7 @@ describe('lib/write-sw.js', function() {
           revision: '1234',
         },
       ],
-      'fake-path/workbox-sw.min.js',
+      'workbox-sw.min.js',
       'fake-path/')
     .then(() => {
       throw new Error('Expected error to be thrown');
@@ -143,7 +143,7 @@ describe('lib/write-sw.js', function() {
           revision: '1234',
         },
       ],
-      'fake-path/workbox-sw.min.js',
+      'workbox-sw.min.js',
       'fake-path/')
     .then(() => {
       throw new Error('Expected error to be thrown');
@@ -210,7 +210,7 @@ workboxSW.precache(fileManifest);
           revision: '1234',
         },
       ],
-      'fake-path/workbox-sw.min.js',
+      'workbox-sw.min.js',
       'fake-path/');
   });
 
@@ -272,7 +272,7 @@ workboxSW.precache(fileManifest);
           revision: '1234',
         },
       ],
-      'fake-path/workbox-sw.min.js',
+      'workbox-sw.min.js',
       'fake-path/', {
         cacheId: 'cache-id-example',
       });
@@ -336,7 +336,7 @@ workboxSW.precache(fileManifest);
           revision: '1234',
         },
       ],
-      'fake-path/workbox-sw.min.js',
+      'workbox-sw.min.js',
       'fake-path/', {
         directoryIndex: 'custom.html',
       });
@@ -400,7 +400,7 @@ workboxSW.precache(fileManifest);
           revision: '1234',
         },
       ],
-      'fake-path/workbox-sw.min.js',
+      'workbox-sw.min.js',
       'fake-path/', {
         handleFetch: false,
       });
@@ -464,7 +464,7 @@ workboxSW.precache(fileManifest);
           revision: '1234',
         },
       ],
-      'fake-path/workbox-sw.min.js',
+      'workbox-sw.min.js',
       'fake-path/', {
         skipWaiting: true,
       });
@@ -528,7 +528,7 @@ workboxSW.precache(fileManifest);
           revision: '1234',
         },
       ],
-      'fake-path/workbox-sw.min.js',
+      'workbox-sw.min.js',
       'fake-path/', {
         clientsClaim: true,
       });
@@ -591,7 +591,7 @@ workboxSW.router.registerNavigationRoute("/shell");
           revision: '1234',
         },
       ],
-      'fake-path/workbox-sw.min.js',
+      'workbox-sw.min.js',
       'fake-path/', {
         navigateFallback: '/shell',
       });
@@ -656,7 +656,7 @@ workboxSW.router.registerNavigationRoute("/shell", {
             revision: '1234',
           },
         ],
-        'fake-path/workbox-sw.min.js',
+        'workbox-sw.min.js',
         'fake-path/', {
           navigateFallback: '/shell',
           navigateFallbackWhitelist: [/^\/guide\//, /^\/lolz\//],
@@ -749,7 +749,7 @@ workboxSW.router.registerRoute(/\\/articles\\//, workboxSW.strategies.staleWhile
           revision: '1234',
         },
       ],
-      'fake-path/workbox-sw.min.js',
+      'workbox-sw.min.js',
       'fake-path/', {
         runtimeCaching: [
           {
@@ -858,7 +858,7 @@ workboxSW.precache(fileManifest);
           revision: '1234',
         },
       ],
-      'fake-path/workbox-sw.min.js',
+      'workbox-sw.min.js',
       'fake-path/', {
         ignoreUrlParametersMatching: [/^example/, /^other/],
       });

--- a/packages/workbox-build/test/node/lib-write-sw.js
+++ b/packages/workbox-build/test/node/lib-write-sw.js
@@ -863,4 +863,65 @@ workboxSW.precache(fileManifest);
         ignoreUrlParametersMatching: [/^example/, /^other/],
       });
   });
+
+  it('should correctly handle diff sw output from globDirectory output', function() {
+      const EXPECTED_RESULT = `importScripts('workbox-sw.min.js');
+
+/**
+ * DO NOT EDIT THE FILE MANIFEST ENTRY
+ *
+ * The method precache() does the following:
+ * 1. Cache URLs in the manifest to a local cache.
+ * 2. When a network request is made for any of these URLs the response
+ *    will ALWAYS comes from the cache, NEVER the network.
+ * 3. When the service worker changes ONLY assets with a revision change are
+ *    updated, old cache entries are left as is.
+ *
+ * By changing the file manifest manually, your users may end up not receiving
+ * new versions of files because the revision hasn't changed.
+ *
+ * Please use workbox-build or some other tool / approach to generate the file
+ * manifest which accounts for changes to local files and update the revision
+ * accordingly.
+ */
+const fileManifest = [
+  {
+    "url": "/",
+    "revision": "1234"
+  }
+];
+
+const workboxSW = new self.WorkboxSW();
+workboxSW.precache(fileManifest);
+`;
+    const writeSw = proxyquire('../../src/lib/write-sw', {
+      'mkdirp': {
+        sync: () => {
+          return;
+        },
+      },
+      'fs': {
+        writeFile: (filepath, stringToWrite, cb) => {
+          if (stringToWrite === EXPECTED_RESULT) {
+            cb();
+          } else {
+            stringToWrite.should.equal(EXPECTED_RESULT);
+            cb(new Error('Unexpected result from fs.'));
+          }
+        },
+      },
+    });
+
+    return writeSw(
+      'sw-path/diff-to-glob-directory/sw.js',
+      [
+        {
+          url: '/',
+          revision: '1234',
+        },
+      ],
+      'workbox-sw.min.js',
+      'glob-path/diff-to-sw-directory/'
+    );
+  });
 });


### PR DESCRIPTION
R: @gauntface

Fixes #535

I'm not sure if it was the switch from `rootDirectory` to `globDirectory`, or my fiddling with [`copy-workbox-sw.js`](https://github.com/GoogleChrome/workbox/blob/1697b830fb2b315d5a60f3e7eef0bad000ee1058/packages/workbox-build/src/lib/utils/copy-workbox-sw.js) that led to the breakage in #535 to begin with.

There's already a `path.relative()` performed at https://github.com/GoogleChrome/workbox/blob/1697b830fb2b315d5a60f3e7eef0bad000ee1058/packages/workbox-build/src/lib/generate-sw.js#L112, and the one I'm removing seems like it was actively causing trouble.

This *seems* to do the right thing for me now, in that when testing locally, basic use cases result in a generated service worker file that has a correct path in `importScripts()`

That being said, I'd really appreciate it if @gauntface could take a close look at what's changing, and confirm my assumptions. I've been poking around at this code without all the full context and I might be missing something important.