### PR TITLE
Change payload.updatedUrl to payload.url

### DIFF
--- a/packages/workbox-broadcast-cache-update/demo/index.html
+++ b/packages/workbox-broadcast-cache-update/demo/index.html
@@ -16,7 +16,7 @@
 
       const cacheUpdatesChannel = new BroadcastChannel('cache-updates');
       cacheUpdatesChannel.addEventListener('message', event => {
-        console.log(`There was an update to ${event.data.payload.updatedUrl}`);
+        console.log(`There was an update to ${event.data.payload.url}`);
       });
     </script>
   </body>

--- a/packages/workbox-broadcast-cache-update/src/index.js
+++ b/packages/workbox-broadcast-cache-update/src/index.js
@@ -52,7 +52,7 @@
  *
  * const updateChannel = new BroadcastChannel('cache-updates');
  * updateChannel.addEventListener('message', event => {
- *   console.log(`Cache updated: ${event.data.payload.updatedUrl}`);
+ *   console.log(`Cache updated: ${event.data.payload.url}`);
  * });
  *
  * @module workbox-broadcast-cache-update

--- a/packages/workbox-broadcast-cache-update/src/lib/broadcast-update.js
+++ b/packages/workbox-broadcast-cache-update/src/lib/broadcast-update.js
@@ -35,7 +35,7 @@ import {cacheUpdatedMessageType} from './constants';
  *   meta: 'workbox-broadcast-cache-update',
  *   payload: {
  *     cacheName: 'the-cache-name',
- *     updatedUrl: 'https://example.com/'
+ *     url: 'https://example.com/'
  *   }
  * }
  * ```
@@ -72,7 +72,7 @@ function broadcastUpdate({channel, cacheName, url, source}) {
     meta: source,
     payload: {
       cacheName: cacheName,
-      updatedUrl: url,
+      url,
     },
   });
 }

--- a/packages/workbox-broadcast-cache-update/test/sw/broadcast-update.js
+++ b/packages/workbox-broadcast-cache-update/test/sw/broadcast-update.js
@@ -30,7 +30,7 @@ describe('Test of the broadcastUpdate function', function() {
         meta: source,
         payload: {
           cacheName,
-          updatedUrl: url,
+          url,
         },
       });
       done();

--- a/packages/workbox-routing/demo/index.html
+++ b/packages/workbox-routing/demo/index.html
@@ -16,7 +16,7 @@
 
       const cacheUpdatesChannel = new BroadcastChannel('cache-updates');
       cacheUpdatesChannel.addEventListener('message', event => {
-        console.log(`There was an update to ${event.data.payload.updatedUrl}`);
+        console.log(`There was an update to ${event.data.payload.url}`);
       });
     </script>
   </body>

--- a/packages/workbox-runtime-caching/demo/index.html
+++ b/packages/workbox-runtime-caching/demo/index.html
@@ -16,7 +16,7 @@
 
       const cacheUpdatesChannel = new BroadcastChannel('cache-updates');
       cacheUpdatesChannel.addEventListener('message', event => {
-        console.log(`There was an update to ${event.data.payload.updatedUrl}`);
+        console.log(`There was an update to ${event.data.payload.url}`);
       });
     </script>
   </body>


### PR DESCRIPTION
R: @addyosmani @gauntface

After using the cache update `BroadcastChannel` thing more, I realized that the naming `payload.url` is a lot more intuitive than `payload.updatedUrl`.

I might have initially went with `updatedUrl` because I though there might eventually be another `url` field used for something else, but that concern didn't play out.