### PR TITLE
Pass through options to the Handler constructor.

### DIFF
--- a/packages/workbox-sw/src/lib/strategies.js
+++ b/packages/workbox-sw/src/lib/strategies.js
@@ -168,9 +168,10 @@ class Strategies {
       });
     }
 
-    return new HandlerClass({
-      requestWrapper: new RequestWrapper(wrapperOptions),
-    });
+    options.requestWrapper = new RequestWrapper(wrapperOptions);
+    // Pass through the initial options to the underlying Handler constructor
+    // to allow for Handler-specific customization.
+    return new HandlerClass(options);
   }
 }
 

--- a/packages/workbox-sw/test/sw/caching-strategies.js
+++ b/packages/workbox-sw/test/sw/caching-strategies.js
@@ -115,4 +115,11 @@ describe('Test caching strategies.', function() {
       expect(handler.requestWrapper.plugins.has('cacheWillUpdate')).to.be.true;
     });
   });
+
+  it(`should use the networkTimeoutSeconds parameter passed to workboxSW.strategies.networkFirst()`, function() {
+    const networkTimeoutSeconds = 5;
+    const workboxSW = new WorkboxSW();
+    const handler = workboxSW.strategies.networkFirst({networkTimeoutSeconds});
+    expect(handler.networkTimeoutSeconds).to.eql(networkTimeoutSeconds);
+  });
 });


### PR DESCRIPTION
R: @addyosmani @gauntface

The `NetworkFirst` constructor takes a `networkTimeoutSeconds` parameter, which wasn't being passed through when it was constructed via `workboxSW.strategies.networkFirst({networkTimeoutSeconds})`.

This PR causes the options that are passed in to `workboxSW.strategies.<strategy>(options)` to be passed through to the underlying Handler's constructor.