### PR TITLE
Adds support for a --config-file CLI flag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ node_modules
 npm-debug.log
 packages/**/LICENSE
 temp
+tmp-*
 /_site/

--- a/packages/workbox-cli/src/index.js
+++ b/packages/workbox-cli/src/index.js
@@ -23,7 +23,7 @@ const workboxBuild = require('workbox-build');
 const cliLogHelper = require('./lib/log-helper');
 const generateGlobPattern = require('./lib/utils/generate-glob-pattern');
 const saveConfigFile = require('./lib/utils/save-config');
-const getConfigFile = require('./lib/utils/get-config');
+const getConfig = require('./lib/utils/get-config');
 const errors = require('./lib/errors');
 
 const askForRootOfWebApp = require('./lib/questions/ask-root-of-web-app');
@@ -96,8 +96,15 @@ class SWCli {
    */
   _generateSW(flags) {
     let config = {};
+    let configFile = null;
+    if (flags) {
+      configFile = flags.configFile;
+      // Remove configFile from flags (if it was present) so that it doesn't
+      // trigger the 'config-supplied-missing-fields' error later on.
+      delete flags.configFile;
+    }
 
-    return getConfigFile()
+    return getConfig(configFile)
     .then((savedConfig) => {
       if (savedConfig) {
         config = savedConfig;
@@ -207,8 +214,15 @@ class SWCli {
    */
   _injectManifest(flags) {
     let config = {};
+    let configFile = null;
+    if (flags) {
+      configFile = flags.configFile;
+      // Remove configFile from flags (if it was present) so that it doesn't
+      // trigger the 'config-supplied-missing-fields' error later on.
+      delete flags.configFile;
+    }
 
-    return getConfigFile()
+    return getConfig(configFile)
     .then((savedConfig) => {
       if (savedConfig) {
         config = savedConfig;

--- a/packages/workbox-cli/src/lib/constants.js
+++ b/packages/workbox-cli/src/lib/constants.js
@@ -1,5 +1,5 @@
 module.exports = {
-  configName: 'workbox-cli-config.js',
+  defaultConfigName: 'workbox-cli-config.js',
   blacklistDirectoryNames: [
     'node_modules',
   ],

--- a/packages/workbox-cli/src/lib/errors.js
+++ b/packages/workbox-cli/src/lib/errors.js
@@ -18,4 +18,6 @@ module.exports = {
     'must be a string with at least one character.',
   'invalid-sw-src': 'The supplied service worker input file was invalid. It ' +
     'must be a string with at least one character.',
+  'invalid-config-file-flag': 'The --config-file flag refers to an invalid ' +
+    'or non-existent file.',
 };

--- a/packages/workbox-cli/src/lib/utils/get-config.js
+++ b/packages/workbox-cli/src/lib/utils/get-config.js
@@ -4,18 +4,31 @@ const constants = require('../constants');
 const errors = require('../errors');
 const logHelper = require('../log-helper');
 
-module.exports = () => {
+module.exports = (configFile) => {
+  const effectiveConfigFile = configFile || constants.defaultConfigName;
+
   return new Promise((resolve, reject) => {
-    const configPath = path.join(process.cwd(), constants.configName);
     let config = null;
     try {
+      const configPath = path.isAbsolute(effectiveConfigFile) ?
+        effectiveConfigFile :
+        path.join(process.cwd(), effectiveConfigFile);
+
       config = require(configPath);
+      logHelper.log(`Using configuration from ${effectiveConfigFile}.`);
+
       if (typeof config !== 'object' || Array.isArray(config)) {
         logHelper.warn(errors['config-not-an-object']);
         config = null;
       }
     } catch (err) {
-      // NOOP
+      // If the require() failed and the developer specified a configFile,
+      // treat that as a fatal error.
+      // Otherwise, if the default config file was being used, ignore the error.
+      if (configFile) {
+        logHelper.error(errors['invalid-config-file-flag']);
+        return reject(Error(errors['invalid-config-file-flag']));
+      }
     }
 
     resolve(config);

--- a/packages/workbox-cli/src/lib/utils/save-config.js
+++ b/packages/workbox-cli/src/lib/utils/save-config.js
@@ -7,7 +7,7 @@ const errors = require('../errors');
 
 module.exports = (configDetails) => {
   return new Promise((resolve, reject) => {
-    const configPath = path.join(process.cwd(), constants.configName);
+    const configPath = path.join(process.cwd(), constants.defaultConfigName);
 
     // Ignore the cli config if it's in the globDirectory.
     if (configDetails.globDirectory) {

--- a/packages/workbox-cli/test/node/generate-sw-e2e.js
+++ b/packages/workbox-cli/test/node/generate-sw-e2e.js
@@ -50,25 +50,25 @@ describe('Generate SW End-to-End Tests', function() {
     const SWCli = proxyquire('../../build/index', {
       './lib/questions/ask-root-of-web-app': () => {
         if (enforceNoQuestions) {
-          return Promise.reject('Injected Error - No Questions Expected');
+          return Promise.reject(Error('Injected Error - No Questions Expected'));
         }
         return Promise.resolve(tmpDirectory);
       },
       './lib/questions/ask-sw-dest': () => {
         if (enforceNoQuestions) {
-          return Promise.reject('Injected Error - No Questions Expected');
+          return Promise.reject(Error('Injected Error - No Questions Expected'));
         }
         return Promise.resolve(swDest);
       },
       './lib/questions/ask-save-config': () => {
         if (enforceNoQuestions) {
-          return Promise.reject('Injected Error - No Questions Expected');
+          return Promise.reject(Error('Injected Error - No Questions Expected'));
         }
         return Promise.resolve(true);
       },
       './lib/questions/ask-extensions-to-cache': () => {
         if (enforceNoQuestions) {
-          return Promise.reject('Injected Error - No Questions Expected');
+          return Promise.reject(Error('Injected Error - No Questions Expected'));
         }
         return Promise.resolve(FILE_EXTENSIONS);
       },

--- a/packages/workbox-cli/test/node/inject-manifest-e2e.js
+++ b/packages/workbox-cli/test/node/inject-manifest-e2e.js
@@ -23,7 +23,7 @@ describe('Generate SW End-to-End Tests', function() {
       .catch((error) => console.log(error));
   });
 
-  it('should be able to generate a service for example-1 with CLI', function() {
+  it('should be able to generate a service for example-2 with CLI', function() {
     this.timeout(120 * 1000);
 
     process.chdir(tmpDirectory);
@@ -39,31 +39,31 @@ describe('Generate SW End-to-End Tests', function() {
     const SWCli = proxyquire('../../build/index', {
       './lib/questions/ask-root-of-web-app': () => {
         if (enforceNoQuestions) {
-          return Promise.reject('Injected Error - No Questions Expected');
+          return Promise.reject(Error('Injected Error - No Questions Expected'));
         }
         return Promise.resolve(tmpDirectory);
       },
       './lib/questions/ask-sw-src': () => {
         if (enforceNoQuestions) {
-          return Promise.reject('Injected Error - No Questions Expected');
+          return Promise.reject(Error('Injected Error - No Questions Expected'));
         }
         return Promise.resolve(swSrc);
       },
       './lib/questions/ask-sw-dest': () => {
         if (enforceNoQuestions) {
-          return Promise.reject('Injected Error - No Questions Expected');
+          return Promise.reject(Error('Injected Error - No Questions Expected'));
         }
         return Promise.resolve(swDest);
       },
       './lib/questions/ask-save-config': () => {
         if (enforceNoQuestions) {
-          return Promise.reject('Injected Error - No Questions Expected');
+          return Promise.reject(Error('Injected Error - No Questions Expected'));
         }
         return Promise.resolve(true);
       },
       './lib/questions/ask-extensions-to-cache': () => {
         if (enforceNoQuestions) {
-          return Promise.reject('Injected Error - No Questions Expected');
+          return Promise.reject(Error('Injected Error - No Questions Expected'));
         }
         return Promise.resolve(FILE_EXTENSIONS);
       },

--- a/packages/workbox-cli/test/node/utils-get-config.js
+++ b/packages/workbox-cli/test/node/utils-get-config.js
@@ -15,7 +15,7 @@ describe('Test Get Config', function() {
   });
 
   it('should be able to handle readFile error', function() {
-    const configPath = path.join(process.cwd(), constants.configName);
+    const configPath = path.join(process.cwd(), constants.defaultConfigName);
     const proxyquireInput = {};
     proxyquireInput[configPath] = null;
     const getConfig = proxyquire('../../src/lib/utils/get-config',
@@ -29,7 +29,7 @@ describe('Test Get Config', function() {
   });
 
   it('should handle non-JS Object config file', function() {
-    const configPath = path.join(process.cwd(), constants.configName);
+    const configPath = path.join(process.cwd(), constants.defaultConfigName);
     const proxyquireInput = {};
     proxyquireInput[configPath] = [];
     const getConfig = proxyquire('../../src/lib/utils/get-config',
@@ -43,7 +43,8 @@ describe('Test Get Config', function() {
         throw new Error('Unexpected response from getConfig.');
       }
 
-      captured.consoleLogs.length.should.equal(0);
+      // There's a 'Using configuration from...' message that's expected.
+      captured.consoleLogs.length.should.equal(1);
       captured.consoleWarns.length.should.equal(1);
       captured.consoleErrors.length.should.equal(0);
 
@@ -60,25 +61,51 @@ describe('Test Get Config', function() {
     });
   });
 
-  it('should handle JS Object config file', function() {
-    const data = {
-      example: 'Hi.',
-    };
-    const configPath = path.join(process.cwd(), constants.configName);
-    const proxyquireInput = {};
-    proxyquireInput[configPath] = data;
-    const getConfig = proxyquire('../../src/lib/utils/get-config',
-      proxyquireInput);
+  const configFileTestCases = new Map([
+    [null, () => path.join(process.cwd(), constants.defaultConfigName)],
+    ['relative-path.js', () => path.join(process.cwd(), 'relative-path.js')],
+    ['/absolute/path.js', () => '/absolute/path.js'],
+  ]);
 
-    cliHelper.startLogCapture();
-    return getConfig()
-    .then((config) => {
-      const captured = cliHelper.endLogCapture();
-      captured.consoleLogs.length.should.equal(0);
-      captured.consoleWarns.length.should.equal(0);
-      captured.consoleErrors.length.should.equal(0);
+  for (const [configFile, configPathGenerator] of configFileTestCases) {
+    it(`should handle reading the JS config when the configFile parameter is ${configFile}`, function() {
+      const data = {
+        example: 'Hi.',
+      };
 
-      config.should.deep.equal(data);
+      const proxyquireInput = {};
+      proxyquireInput[configPathGenerator()] = data;
+      const getConfig = proxyquire('../../src/lib/utils/get-config',
+        proxyquireInput);
+
+      cliHelper.startLogCapture();
+      return getConfig(configFile)
+        .then((config) => {
+          const captured = cliHelper.endLogCapture();
+          // There's a 'Using configuration from...' message that's expected.
+          captured.consoleLogs.length.should.equal(1);
+          captured.consoleWarns.length.should.equal(0);
+          captured.consoleErrors.length.should.equal(0);
+
+          config.should.deep.equal(data);
+        });
     });
+  }
+
+  it(`should reject when passed a configFile that doesn't exist`, function() {
+    const getConfig = require('../../src/lib/utils/get-config');
+    cliHelper.startLogCapture();
+    return getConfig('does-not-exist.js')
+      .then(() => {
+        throw Error('Expected getConfig to reject.');
+      })
+      .catch((error) => {
+        const captured = cliHelper.endLogCapture();
+        captured.consoleLogs.length.should.equal(0);
+        captured.consoleWarns.length.should.equal(0);
+        captured.consoleErrors.length.should.equal(1);
+
+        error.message.should.eql(errors['invalid-config-file-flag']);
+      });
   });
 });

--- a/packages/workbox-cli/test/node/utils-get-config.js
+++ b/packages/workbox-cli/test/node/utils-get-config.js
@@ -61,20 +61,24 @@ describe('Test Get Config', function() {
     });
   });
 
+  // process.cwd() needs to be evaluated inside the it() callback, so just
+  // define a function that will eventually return the value we want.
   const configFileTestCases = new Map([
     [null, () => path.join(process.cwd(), constants.defaultConfigName)],
     ['relative-path.js', () => path.join(process.cwd(), 'relative-path.js')],
     ['/absolute/path.js', () => '/absolute/path.js'],
   ]);
 
-  for (const [configFile, configPathGenerator] of configFileTestCases) {
+  for (const [configFile, configPathFunc] of configFileTestCases) {
     it(`should handle reading the JS config when the configFile parameter is ${configFile}`, function() {
       const data = {
         example: 'Hi.',
       };
 
       const proxyquireInput = {};
-      proxyquireInput[configPathGenerator()] = data;
+      // Generate the config path here, to use the right process.cwd() value.
+      const configPath = configPathFunc();
+      proxyquireInput[configPath] = data;
       const getConfig = proxyquire('../../src/lib/utils/get-config',
         proxyquireInput);
 


### PR DESCRIPTION
R: @gauntface 

The general logic is:
- If `--config-file` isn't given, then attempt to read a `./workbox-cli-config.js` file.
  - If that doesn't exist, then continue with the previous flow.
  - If it does exist, then continue with the previous flow.
- If `--config-file` is given, then attempt to read it (supporting both relative and absolute paths).
  - If that doesn't exist, then treat it as a fatal error.
  - If it does exist, then treat it the same way we were previously treating the default config.

This also adds in a logging statement letting the developer know which config file is being read from, as a general heads-up.