### PR TITLE
Precaching sweep

### DIFF
--- a/packages/workbox-precaching/src/index.js
+++ b/packages/workbox-precaching/src/index.js
@@ -16,14 +16,17 @@
 /**
  * # workbox-precaching
  *
- * The precaching module provides helpers that make it easy to cache files
+ * The precaching library intelligently caches and updates files
  * during the install step of your service worker.
  *
- * **Install:** `npm install --save-dev workbox-precaching`
+ * When given a list of URL's to precache, this module will go through
+ * each URL and check if the URL is already cached and, if it is, compare
+ * the hash to see if revision hash has changed.
  *
- * The revisioned caching will cache bust requests where appropriate and
- * only cache assets that have a changed revision asset compared to
- * the currently cached value.
+ * If the revision is old or the entry isn't cached, this library will make
+ * a request for the asset and cache it, ensuring the the browsers HTTP cache
+ * is skipped by using `Request.cache = 'reload'` or adding a cache busting
+ * search parameter to the request.
  *
  * @example
  * importScripts('/<Path to Module>/build/workbox-precaching.min.js');
@@ -39,28 +42,16 @@
  *   ],
  * });
  *
- * const unrevCacheManager = new workbox.precaching.UnrevisionedCacheManager();
- * unrevCacheManager.addToCacheList({
- *   unrevisionedFiles: [
- *     '/',
- *     '/images/logo.png'
- *   ]
- * });
- *
  * self.addEventListener('install', (event) => {
- *   const promiseChain = Promise.all([
- *     revCacheManager.install(),
- *     unrevCacheManager.install(),
- *   ]);
- *   event.waitUntil(promiseChain);
+ *   event.waitUntil(
+ *     revCacheManager.install()
+ *   );
  * });
  *
  * self.addEventListener('activate', (event) => {
- *   const promiseChain = Promise.all([
- *     revCacheManager.cleanup(),
- *     unrevCacheManager.cleanup()
- *   ]);
- *   event.waitUntil(promiseChain);
+ *   event.waitUntil(
+ *     revCacheManager.cleanup()
+ *   );
  * });
  *
  * @module workbox-precaching
@@ -68,8 +59,6 @@
 import ErrorFactory from './lib/error-factory';
 import RevisionedCacheManager from
   './lib/controllers/revisioned-cache-manager.js';
-import UnrevisionedCacheManager from
-  './lib/controllers/unrevisioned-cache-manager.js';
 
 import environment from '../../../lib/environment.js';
 
@@ -80,5 +69,4 @@ if (!environment.isServiceWorkerGlobalScope()) {
 
 export {
   RevisionedCacheManager,
-  UnrevisionedCacheManager,
 };

--- a/packages/workbox-precaching/src/lib/controllers/base-cache-manager.js
+++ b/packages/workbox-precaching/src/lib/controllers/base-cache-manager.js
@@ -3,7 +3,7 @@ import {RequestWrapper} from '../../../../workbox-runtime-caching/src/index';
 /**
  * This class handles the shared logic for caching revisioned and unrevisioned
  * assets.
- * @private
+ *
  * @memberof module:workbox-precaching
  */
 class BaseCacheManager {
@@ -54,8 +54,8 @@ class BaseCacheManager {
   }
 
   /**
-   * Gives access to the cache name used by thie caching manager.
-   * @return {String} The cache name used for this manager.
+   * Gives access to the cache name used by this caching manager.
+   * @return {String} The cache name used by this manager.
    */
   getCacheName() {
     return this._requestWrapper.cacheName;
@@ -64,6 +64,7 @@ class BaseCacheManager {
   /**
    * Returns an array of fully qualified URL's that will be cached by this
    * cache manager.
+   *
    * @return {Array<String>} An array of URLs that will be cached.
    */
   getCachedUrls() {
@@ -106,11 +107,11 @@ class BaseCacheManager {
   }
 
   /**
-   * Manages the service worker install event and caches the revisioned
-   * assets.
+   * This method will go through each asset added to the cache list and
+   * fetch and update the cache for assets which have a new revision hash.
    *
    * @return {Promise} The promise resolves when all the desired assets are
-   * cached.
+   * cached and up -to-date.
    */
   async install() {
     if (this._entriesToCache.size === 0) {

--- a/packages/workbox-precaching/test/browser/cache-testing.js
+++ b/packages/workbox-precaching/test/browser/cache-testing.js
@@ -154,7 +154,7 @@ describe('workbox-precaching Test Revisioned Caching', function() {
     });
   });
 
-  it('should cache and fetch unrevisioned urls', function() {
+  it.skip('should cache and fetch unrevisioned urls', function() {
     const sw1 = `${STATIC_ASSETS_PATH}/basic-cache/basic-unrevisioned-cache-sw.js`;
     const sw2 = `${STATIC_ASSETS_PATH}/basic-cache/basic-unrevisioned-cache-sw-2.js`;
     return window.goog.swUtils.activateSW(sw1)
@@ -187,7 +187,7 @@ describe('workbox-precaching Test Revisioned Caching', function() {
     });
   });
 
-  it('should manage unrevisioned cache deletion', function() {
+  it.skip('should manage unrevisioned cache deletion', function() {
     const sw1 = `${STATIC_ASSETS_PATH}/basic-cache/basic-unrevisioned-cache-sw.js`;
     const sw2 = `${STATIC_ASSETS_PATH}/basic-cache/basic-unrevisioned-cache-sw-2.js`;
     return window.goog.swUtils.activateSW(sw1)
@@ -251,7 +251,7 @@ describe('workbox-precaching Test Revisioned Caching', function() {
     });
   });
 
-  it('should only request unrevisioned duplicate entries once', function() {
+  it.skip('should only request unrevisioned duplicate entries once', function() {
     let allEntries = [];
     workbox.__TEST_DATA['duplicate-entries'].forEach((entries) => {
       allEntries = allEntries.concat(entries);
@@ -304,7 +304,7 @@ describe('workbox-precaching Test Revisioned Caching', function() {
     });
   });
 
-  it('should manage redirected unrevisioned requests', function() {
+  it.skip('should manage redirected unrevisioned requests', function() {
     return window.goog.swUtils.activateSW(`${STATIC_ASSETS_PATH}/response-types/redirect-unrevisioned-sw.js`)
     .then((iframe) => {
       const promises = workbox.__TEST_DATA['redirect'].map((redirectPath) => {

--- a/packages/workbox-precaching/test/sw/basic.js
+++ b/packages/workbox-precaching/test/sw/basic.js
@@ -21,7 +21,7 @@ describe('Test Library Surface', function() {
     expect(workbox.precaching.RevisionedCacheManager).to.exist;
   });
 
-  it('should have UnrevisionedCacheManager via workbox.precaching', function() {
+  it.skip('should have UnrevisionedCacheManager via workbox.precaching', function() {
     expect(workbox.precaching.UnrevisionedCacheManager).to.exist;
   });
 
@@ -63,7 +63,7 @@ describe('Test Library Surface', function() {
     });
   });
 
-  it('should be able to get the unrevisioned cache manager via workbox.precaching', function() {
+  it.skip('should be able to get the unrevisioned cache manager via workbox.precaching', function() {
     const unrevisionedManager = new workbox.precaching.UnrevisionedCacheManager();
     expect(unrevisionedManager).to.exist;
 

--- a/packages/workbox-precaching/test/sw/cookies.js
+++ b/packages/workbox-precaching/test/sw/cookies.js
@@ -14,32 +14,32 @@ mocha.setup({
 describe('Test Cookies with Precache', function() {
   it('should cache asset with appropriate cookies with revisions asset', function() {
     const revManager = new workbox.precaching.RevisionedCacheManager();
-    const unrevManager = new workbox.precaching.UnrevisionedCacheManager();
+    // const unrevManager = new workbox.precaching.UnrevisionedCacheManager();
     revManager.addToCacheList({
       revisionedFiles: [
         `/__test/cookie/1/`,
       ],
     });
-    unrevManager.addToCacheList({
+    /** unrevManager.addToCacheList({
       unrevisionedFiles: [
         `/__test/cookie/2/`,
       ],
-    });
+    });**/
 
     return Promise.all([
       revManager.install(),
-      unrevManager.install(),
+      // unrevManager.install(),
     ])
     .then(() => {
       return Promise.all([
         revManager.cleanup(),
-        unrevManager.cleanup(),
+        // unrevManager.cleanup(),
       ]);
     })
     .then(() => {
       return Promise.all([
         caches.match(`/__test/cookie/1/`),
-        caches.match(`/__test/cookie/2/`),
+        // caches.match(`/__test/cookie/2/`),
       ]);
     })
     .then((responses) => {

--- a/packages/workbox-precaching/test/sw/failing-cache-tests.js
+++ b/packages/workbox-precaching/test/sw/failing-cache-tests.js
@@ -30,7 +30,7 @@ describe('Test Failing Cache Behavior', function() {
     });
   });
 
-  it('should fail to install unrevisioned with 404 cache request', function() {
+  it.skip('should fail to install unrevisioned with 404 cache request', function() {
     const unrevisionedCacheManager = new workbox.precaching.UnrevisionedCacheManager();
     unrevisionedCacheManager.addToCacheList({
       unrevisionedFiles: [
@@ -60,7 +60,7 @@ describe('Test Failing Cache Behavior', function() {
     });
   });
 
-  it('should fail to cache unrevisioned opaque responses by default', function() {
+  it.skip('should fail to cache unrevisioned opaque responses by default', function() {
     const unrevisionedCacheManager = new workbox.precaching.UnrevisionedCacheManager();
     unrevisionedCacheManager.addToCacheList({
       unrevisionedFiles: workbox.__TEST_DATA['opaque'],

--- a/packages/workbox-precaching/test/sw/unrevisioned-caching.js
+++ b/packages/workbox-precaching/test/sw/unrevisioned-caching.js
@@ -13,7 +13,7 @@ mocha.setup({
   reporter: null,
 });
 
-describe('sw/unrevisioned-caching.js', function() {
+describe.skip('sw/unrevisioned-caching.js', function() {
   let cacheManager;
 
   const VALID_PATH_REL = '/__echo/date/example.txt';


### PR DESCRIPTION
R: @jeffposnick @addyosmani @jpmedley 

Only possibly contentious aspect of this PR is that it removes the unrevisioned cache manager. It's not used anywhere and frankly has limited use. Rather than support it when it's not needed I've removed it and we can see if it serves a purpose and re-add in after launch if needed. 