### PR TITLE
More robust runtimeCaching conversion.

### DIFF
--- a/packages/workbox-build/src/lib/errors.js
+++ b/packages/workbox-build/src/lib/errors.js
@@ -75,4 +75,10 @@ module.exports = {
     `staticFileGlobs are set. Please fully migrate to globPatterns.`,
   'both-templated-urls-dynamic-urls': `Both templatedUrls and ` +
     `dynamicUrlToDependencies are set. Please fully migrate to templatedUrls.`,
+  'method-not-supported': `Using a method other than 'GET' in runtimeCaching is 
+    not supported.`,
+  'urlPattern-is-required': `The urlPattern option is required when using
+    runtimeCaching.`,
+  'handler-is-required': `The handler option is required when using
+    runtimeCaching.`,
 };

--- a/packages/workbox-build/src/lib/utils/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/utils/runtime-caching-converter.js
@@ -27,8 +27,9 @@ function getOptionsString(options) {
   }
 
   // Everything should be copied to the corresponding new option names at this
-  // point, so delete the old-style `cache` property if it's present.
-  delete effectiveOptions.cache;
+  // point, so set the old-style `cache` property to undefined so that it
+  // doesn't show up in the JSON output.
+  effectiveOptions.cache = undefined;
 
   // JSON.stringify() will automatically omit any properties that are set to
   // undefined values.

--- a/packages/workbox-build/src/lib/utils/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/utils/runtime-caching-converter.js
@@ -51,6 +51,9 @@ module.exports = (runtimeCaching) => {
       throw new Error(errors['handler-is-required']);
     }
 
+    // urlPattern might be either a string or a RegExp object.
+    // If it's a string, it needs to be quoted. If it's a RegExp, it should
+    // be used as-is.
     const matcher = typeof entry.urlPattern === 'string' ?
       `'${entry.urlPattern}'` :
       entry.urlPattern;

--- a/packages/workbox-build/src/lib/utils/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/utils/runtime-caching-converter.js
@@ -1,0 +1,73 @@
+const errors = require('../errors');
+
+/**
+ * Given a set of options that configures `sw-toolbox`'s behavior, convert it
+ * into a string that would configure equivalent `workbox-sw` behavior.
+ *
+ * @param {Object} options See
+ *        https://googlechrome.github.io/sw-toolbox/api.html#options
+ * @return {String} A JSON string representing the equivalent options.
+ */
+function getOptionsString(options) {
+  const cacheOptions = options.cache || {};
+  // Start with a base of a few properties that need to be renamed, as well
+  // as copying over all the other source properties as-is.
+  const effectiveOptions = Object.assign({
+    cacheName: cacheOptions.name,
+  }, options);
+
+  // Only create the cacheExpiration object if either maxEntries or
+  // maxAgeSeconds is set.
+  if (cacheOptions.maxEntries || cacheOptions.maxAgeSeconds) {
+    effectiveOptions.cacheExpiration =
+      Object.assign(effectiveOptions.cacheExpiration || {}, {
+        maxEntries: cacheOptions.maxEntries,
+        maxAgeSeconds: cacheOptions.maxAgeSeconds,
+      });
+  }
+
+  // Everything should be copied to the corresponding new option names at this
+  // point, so delete the old-style `cache` property if it's present.
+  delete effectiveOptions.cache;
+
+  // JSON.stringify() will automatically omit any properties that are set to
+  // undefined values.
+  return JSON.stringify(effectiveOptions, null, 2);
+}
+
+module.exports = (runtimeCaching) => {
+  return runtimeCaching.map((entry) => {
+    if (entry.method && entry.method !== 'GET') {
+      throw new Error(errors['method-not-supported']);
+    }
+
+    if (!entry.urlPattern) {
+      throw new Error(errors['urlPattern-is-required']);
+    }
+
+    if (!entry.handler) {
+      throw new Error(errors['handler-is-required']);
+    }
+
+    const matcher = typeof entry.urlPattern === 'string' ?
+      `'${entry.urlPattern}'` :
+      entry.urlPattern;
+
+    if (typeof entry.handler === 'string') {
+      const handlerName = entry.handler === 'fastest' ?
+        'staleWhileRevalidate' :
+        entry.handler;
+
+      const optionsString = getOptionsString(entry.options || {});
+
+      const strategyString =
+        `workboxSW.strategies.${handlerName}(${optionsString})`;
+
+      return `workboxSW.router.registerRoute(` +
+        `${matcher}, ${strategyString});`;
+    } else if (typeof entry.handler === 'function') {
+      return `workboxSW.router.registerRoute(` +
+        `${matcher}, ${entry.handler});`;
+    }
+  }).filter((entry) => Boolean(entry)); // Remove undefined map() return values.
+};

--- a/packages/workbox-build/src/lib/utils/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/utils/runtime-caching-converter.js
@@ -36,6 +36,7 @@ function getOptionsString(options) {
 }
 
 module.exports = (runtimeCaching) => {
+  runtimeCaching = runtimeCaching || [];
   return runtimeCaching.map((entry) => {
     if (entry.method && entry.method !== 'GET') {
       throw new Error(errors['method-not-supported']);

--- a/packages/workbox-build/src/lib/write-sw.js
+++ b/packages/workbox-build/src/lib/write-sw.js
@@ -2,7 +2,7 @@ const errors = require('./errors');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
 const path = require('path');
-const runtimeCachingConverter = require('utils/runtime-caching-converter');
+const runtimeCachingConverter = require('./utils/runtime-caching-converter');
 const template = require('lodash.template');
 
 module.exports =

--- a/packages/workbox-build/src/lib/write-sw.js
+++ b/packages/workbox-build/src/lib/write-sw.js
@@ -1,9 +1,9 @@
-const path = require('path');
-const mkdirp = require('mkdirp');
-const fs = require('fs');
-const template = require('lodash.template');
-
 const errors = require('./errors');
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+const path = require('path');
+const runtimeCachingConverter = require('utils/runtime-caching-converter');
+const template = require('lodash.template');
 
 module.exports =
   (swSrc, manifestEntries, wbSWPathRelToSW, globDirectory, options) => {
@@ -50,29 +50,8 @@ module.exports =
       // inject it in the workboxSWOptionsString.
       workboxSWOptions.ignoreUrlParametersMatching = [];
     }
-    let runtimeCaching = [];
-    if (options.runtimeCaching) {
-      options.runtimeCaching.forEach((cachingEntry) => {
-        if (typeof cachingEntry.handler === 'string') {
-          let handlerName = cachingEntry.handler === 'fastest' ?
-            'staleWhileRevalidate' : cachingEntry.handler;
-          let optionsString = cachingEntry.options ?
-            JSON.stringify(cachingEntry.options, null, 2) : '';
-          let stratString =
-            `workboxSW.strategies.${handlerName}(${optionsString})`;
-          runtimeCaching.push(
-            `workboxSW.router.registerRoute(${cachingEntry.urlPattern}, ` +
-            `${stratString});`
-          );
-        } else if (typeof cachingEntry.handler === 'function') {
-          let handlerString = cachingEntry.handler.toString();
-          runtimeCaching.push(
-            `workboxSW.router.registerRoute(${cachingEntry.urlPattern}, ` +
-            `${handlerString});`
-          );
-        }
-      });
-    }
+
+    const runtimeCaching = runtimeCachingConverter(options.runtimeCaching);
 
     try {
       let workboxSWOptionsString = '';

--- a/packages/workbox-build/test/node/lib-write-sw.js
+++ b/packages/workbox-build/test/node/lib-write-sw.js
@@ -692,13 +692,13 @@ const fileManifest = [
 
 const workboxSW = new self.WorkboxSW();
 workboxSW.precache(fileManifest);
-workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.cacheFirst());
-workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.cacheOnly());
-workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.networkFirst());
-workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.networkOnly());
-workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.staleWhileRevalidate());
-workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.staleWhileRevalidate());
-workboxSW.router.registerRoute(/images/:size/:name.jpg, (request, values, options) => {
+workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.cacheFirst({}));
+workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.cacheOnly({}));
+workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.networkFirst({}));
+workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.networkOnly({}));
+workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.staleWhileRevalidate({}));
+workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.staleWhileRevalidate({}));
+workboxSW.router.registerRoute('/images/:size/:name.jpg', (request, values, options) => {
               return new Promise('params: ' + values.join(','));
             });
 workboxSW.router.registerRoute(/\\/articles\\//, workboxSW.strategies.staleWhileRevalidate({

--- a/packages/workbox-build/test/node/utils-runtime-caching-converter.js
+++ b/packages/workbox-build/test/node/utils-runtime-caching-converter.js
@@ -1,0 +1,169 @@
+const chai = require('chai');
+const errors = require('../../src/lib/errors');
+const runtimeCachingConverter =
+  require('../../src/lib/utils/runtime-caching-converter');
+const sinon = require('sinon');
+const vm = require('vm');
+
+const expect = chai.expect;
+
+/**
+ * Validates the method calls for a given set of runtimeCachingOptions.
+ *
+ * @param {Array<Object>} runtimeCachingOptions
+ * @param {Array<String>} convertedOptions
+ */
+function validate(runtimeCachingOptions, convertedOptions) {
+  expect(convertedOptions).to.have.lengthOf(runtimeCachingOptions.length);
+
+  const globalScope = {
+    workboxSW: {
+      router: {
+        registerRoute: sinon.spy(),
+      },
+      strategies: {
+        cacheFirst: sinon.spy(),
+        cacheOnly: sinon.spy(),
+        networkFirst: sinon.spy(),
+        networkOnly: sinon.spy(),
+        staleWhileRevalidate: sinon.spy(),
+      },
+    },
+  };
+
+  const script = new vm.Script(convertedOptions.join('\n'));
+  script.runInNewContext(globalScope);
+
+  runtimeCachingOptions.forEach((runtimeCachingOption, i) => {
+    const registerRouteCall = globalScope.workboxSW.router.registerRoute.getCall(i);
+    expect(registerRouteCall.args[0]).to.eql(runtimeCachingOption.urlPattern);
+
+    if (typeof runtimeCachingOption.handler === 'function') {
+      // We can't make assumptions about what custom function handlers will do.
+      return;
+    }
+
+    const handlerName = runtimeCachingOption.handler === 'fastest' ?
+      'staleWhileRevalidate' :
+      runtimeCachingOption.handler;
+    // This validation assumes that there's only going to be one call to each
+    // named strategy per test.
+    const strategiesCall = globalScope.workboxSW.strategies[handlerName].firstCall;
+    const strategiesOptions = strategiesCall.args[0];
+
+    const expectedOptions = {};
+    if (runtimeCachingOption.options) {
+      if (runtimeCachingOption.options.networkTimeoutSeconds) {
+        expectedOptions.networkTimeoutSeconds = runtimeCachingOption.options.networkTimeoutSeconds;
+      }
+      if (runtimeCachingOption.options.cache) {
+        if (runtimeCachingOption.options.cache.name) {
+          expectedOptions.cacheName = runtimeCachingOption.options.cache.name;
+        }
+        if (runtimeCachingOption.options.cache.maxEntries || runtimeCachingOption.options.cache.maxAgeSeconds) {
+          expectedOptions.cacheExpiration = Object.assign({}, runtimeCachingOption.options.cache);
+          delete expectedOptions.cacheExpiration.name;
+        }
+      }
+    }
+
+    expect(strategiesOptions).to.eql(expectedOptions);
+  });
+}
+
+describe('src/lib/utils/runtime-caching-converter.js', function() {
+  it(`should throw when a method other than GET is used`, function() {
+    const runtimeCachingOptions = [{
+      urlPattern: /xyz/,
+      handler: 'cacheFirst',
+      method: 'POST',
+    }];
+
+    expect(() => {
+      runtimeCachingConverter(runtimeCachingOptions);
+    }).to.throw(errors['method-not-supported']);
+  });
+
+  it(`should throw when urlPattern isn't set`, function() {
+    const runtimeCachingOptions = [{
+      handler: 'cacheFirst',
+    }];
+
+    expect(() => {
+      runtimeCachingConverter(runtimeCachingOptions);
+    }).to.throw(errors['urlPattern-is-required']);
+  });
+
+  it(`should throw when handler isn't set`, function() {
+    const runtimeCachingOptions = [{
+      urlPattern: /xyz/,
+    }];
+
+    expect(() => {
+      runtimeCachingConverter(runtimeCachingOptions);
+    }).to.throw(errors['handler-string-is-required']);
+  });
+
+  it(`should support an empty array of runtimeCaching options`, function() {
+    const runtimeCachingOptions = [];
+    const convertedOptions = runtimeCachingConverter(runtimeCachingOptions);
+    validate(runtimeCachingOptions, convertedOptions);
+  });
+
+  it('should support a single option, using mostly defaults', function() {
+    const runtimeCachingOptions = [{
+      urlPattern: /xyz/,
+      handler: 'cacheFirst',
+    }];
+
+    const convertedOptions = runtimeCachingConverter(runtimeCachingOptions);
+    validate(runtimeCachingOptions, convertedOptions);
+  });
+
+  // See https://github.com/GoogleChrome/workbox/issues/574#issue-230170963
+  it(`should support multiple options, each setting multiple properties`, function() {
+    const runtimeCachingOptions = [{
+      urlPattern: /abc/,
+      handler: 'networkFirst',
+      options: {
+        networkTimeoutSeconds: 20,
+        cache: {
+          name: 'abc-cache',
+          maxEntries: 5,
+          maxAgeSeconds: 50,
+        },
+      },
+    }, {
+      urlPattern: /def/,
+      handler: 'fastest',
+      options: {
+        cache: {
+          maxEntries: 10,
+        },
+      },
+    }];
+
+    const convertedOptions = runtimeCachingConverter(runtimeCachingOptions);
+    validate(runtimeCachingOptions, convertedOptions);
+  });
+
+  it(`should support a string urlPattern, using mostly defaults`, function() {
+    const runtimeCachingOptions = [{
+      urlPattern: '/path/to/file',
+      handler: 'cacheFirst',
+    }];
+
+    const convertedOptions = runtimeCachingConverter(runtimeCachingOptions);
+    validate(runtimeCachingOptions, convertedOptions);
+  });
+
+  it(`should support handler being a function`, function() {
+    const runtimeCachingOptions = [{
+      urlPattern: '/path/to/file',
+      handler: () => {},
+    }];
+
+    const convertedOptions = runtimeCachingConverter(runtimeCachingOptions);
+    validate(runtimeCachingOptions, convertedOptions);
+  });
+});


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #574 

This should give us parity with the full set of options that `runtimeCaching` in `sw-precache` supported.
