### PR TITLE
Moves to the current sinon syntax.

### DIFF
--- a/packages/workbox-cli/test/node/cli-file-extensions.js
+++ b/packages/workbox-cli/test/node/cli-file-extensions.js
@@ -183,7 +183,7 @@ describe('Ask for File Extensions to Cache', function() {
     };
 
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.reject(INJECTED_ERROR);
     });
 
@@ -218,7 +218,7 @@ describe('Ask for File Extensions to Cache', function() {
     };
 
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', (questions) => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake((questions) => {
       const results = {};
       results[questions[0].name] = [];
       return Promise.resolve(results);
@@ -255,7 +255,7 @@ describe('Ask for File Extensions to Cache', function() {
     };
 
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', (questions) => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake((questions) => {
       questions.length.should.be.gt(0);
       const choices = questions[0].choices;
       choices.length.should.equal(FILE_ONLY_INPUT.length);

--- a/packages/workbox-cli/test/node/cli-file-manifest-name.js
+++ b/packages/workbox-cli/test/node/cli-file-manifest-name.js
@@ -55,7 +55,7 @@ describe('Ask for File Manifest Name', function() {
 
   it('should handle failing inquirer', function() {
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.reject(INJECTED_ERROR);
     });
 
@@ -71,7 +71,7 @@ describe('Ask for File Manifest Name', function() {
 
   it('should handle empty filename', function() {
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.resolve({
         fileManifestName: '    ',
       });
@@ -90,7 +90,7 @@ describe('Ask for File Manifest Name', function() {
   it('should trim filename', function() {
     const EXAMPLE_FILENAME = 'example.json';
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.resolve({
         fileManifestName: `    ${EXAMPLE_FILENAME}    `,
       });
@@ -111,7 +111,7 @@ describe('Ask for File Manifest Name', function() {
   it('should return filename', function() {
     const EXAMPLE_FILENAME = 'example.json';
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.resolve({
         fileManifestName: EXAMPLE_FILENAME,
       });

--- a/packages/workbox-cli/test/node/cli-root-dir.js
+++ b/packages/workbox-cli/test/node/cli-root-dir.js
@@ -99,7 +99,7 @@ describe('Ask for Root Directory', function() {
     };
 
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.reject(INJECTED_ERROR);
     });
 
@@ -134,7 +134,7 @@ describe('Ask for Root Directory', function() {
     };
 
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', (questions) => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake((questions) => {
       questions.length.should.be.gt(0);
       const choices = questions[0].choices;
       choices.length.should.equal(VALID_DIRECTORY_CONTENTS.length + 2);

--- a/packages/workbox-cli/test/node/cli-save-config.js
+++ b/packages/workbox-cli/test/node/cli-save-config.js
@@ -54,7 +54,7 @@ describe('Ask to Save to Config File', function() {
 
   it('should handle failing inquirer', function() {
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.reject(INJECTED_ERROR);
     });
 
@@ -70,7 +70,7 @@ describe('Ask to Save to Config File', function() {
 
   it('should return correct value', function() {
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.resolve({
         saveConfig: true,
       });

--- a/packages/workbox-cli/test/node/cli-sw-dest.js
+++ b/packages/workbox-cli/test/node/cli-sw-dest.js
@@ -54,7 +54,7 @@ describe('Ask for Service Worker Dest', function() {
 
   it('should handle failing inquirer', function() {
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.reject(INJECTED_ERROR);
     });
 
@@ -70,7 +70,7 @@ describe('Ask for Service Worker Dest', function() {
 
   it('should handle empty filename', function() {
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.resolve({
         serviceWorkerName: '    ',
       });
@@ -89,7 +89,7 @@ describe('Ask for Service Worker Dest', function() {
   it('should trim filename', function() {
     const EXAMPLE_FILENAME = 'example.json';
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.resolve({
         serviceWorkerName: `    ${EXAMPLE_FILENAME}    `,
       });
@@ -110,7 +110,7 @@ describe('Ask for Service Worker Dest', function() {
   it('should return filename', function() {
     const EXAMPLE_FILENAME = 'example.json';
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.resolve({
         serviceWorkerName: EXAMPLE_FILENAME,
       });

--- a/packages/workbox-cli/test/node/cli-sw-src.js
+++ b/packages/workbox-cli/test/node/cli-sw-src.js
@@ -54,7 +54,7 @@ describe('Ask for Service Worker Src', function() {
 
   it('should handle failing inquirer', function() {
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.reject(INJECTED_ERROR);
     });
 
@@ -70,7 +70,7 @@ describe('Ask for Service Worker Src', function() {
 
   it('should handle empty filename', function() {
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.resolve({
         serviceWorkerName: '    ',
       });
@@ -89,7 +89,7 @@ describe('Ask for Service Worker Src', function() {
   it('should trim filename', function() {
     const EXAMPLE_FILENAME = 'example.json';
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.resolve({
         serviceWorkerName: `    ${EXAMPLE_FILENAME}    `,
       });
@@ -110,7 +110,7 @@ describe('Ask for Service Worker Src', function() {
   it('should return filename', function() {
     const EXAMPLE_FILENAME = 'example.json';
     const inquirer = require('inquirer');
-    const stub = sinon.stub(inquirer, 'prompt', () => {
+    const stub = sinon.stub(inquirer, 'prompt').callsFake(() => {
       return Promise.resolve({
         serviceWorkerName: EXAMPLE_FILENAME,
       });

--- a/packages/workbox-google-analytics/test/browser/replay-queued-requests.js
+++ b/packages/workbox-google-analytics/test/browser/replay-queued-requests.js
@@ -37,7 +37,7 @@ describe('replay-queued-requests', () => {
   beforeEach(function() {
     MockDate.set(initialTimestamp + timestampOffset);
     fetchedUrls = [];
-    fetchStub = sinon.stub(window, 'fetch', (requestUrl) => {
+    fetchStub = sinon.stub(window, 'fetch').callsFake((requestUrl) => {
       const regex = /^https:\/\/replay-queued-requests.com\//g;
       if (regex.test(requestUrl)) {
         fetchedUrls.push(requestUrl);

--- a/packages/workbox-precaching/test/static/duplicate-entries/duplicate-entries-revisioned-sw.js
+++ b/packages/workbox-precaching/test/static/duplicate-entries/duplicate-entries-revisioned-sw.js
@@ -6,7 +6,7 @@ importScripts('/packages/workbox-precaching/test/static/skip-and-claim.js');
 
 let requestsMade = [];
 
-sinon.stub(self, 'fetch', (requestUrl) => {
+sinon.stub(self, 'fetch').callsFake((requestUrl) => {
   requestsMade.push(requestUrl);
   return Promise.resolve(new Response());
 });

--- a/packages/workbox-precaching/test/static/duplicate-entries/duplicate-entries-unrevisioned-sw.js
+++ b/packages/workbox-precaching/test/static/duplicate-entries/duplicate-entries-unrevisioned-sw.js
@@ -6,7 +6,7 @@ importScripts('/packages/workbox-precaching/test/static/skip-and-claim.js');
 
 let requestsMade = [];
 
-sinon.stub(self, 'fetch', (requestUrl) => {
+sinon.stub(self, 'fetch').callsFake((requestUrl) => {
   requestsMade.push(requestUrl);
   return Promise.resolve(new Response());
 });

--- a/packages/workbox-runtime-caching/test/sw/network-first.js
+++ b/packages/workbox-runtime-caching/test/sw/network-first.js
@@ -56,7 +56,7 @@ describe('Test of the NetworkFirst handler', function() {
   it(`should return the cached response if the network request times out`, async function() {
     const networkTimeoutSeconds = 0.1;
 
-    globalStubs.push(sinon.stub(self, 'fetch', () => {
+    globalStubs.push(sinon.stub(self, 'fetch').callsFake(() => {
       return new Promise((resolve) => {
         setTimeout(() => resolve(new Response('')), (networkTimeoutSeconds * 1000) + 5);
       });

--- a/packages/workbox-runtime-caching/test/sw/network-only.js
+++ b/packages/workbox-runtime-caching/test/sw/network-only.js
@@ -38,7 +38,7 @@ describe('Test of the NetworkOnly handler', function() {
     const networkOnly = new workbox.runtimeCaching.NetworkOnly(
       {requestWrapper, waitOnCache: true});
 
-    globalStubs.push(sinon.stub(self, 'fetch', () => {
+    globalStubs.push(sinon.stub(self, 'fetch').callsFake(() => {
       throw new Error(message);
     }));
 

--- a/packages/workbox-runtime-caching/test/sw/stale-while-revalidate.js
+++ b/packages/workbox-runtime-caching/test/sw/stale-while-revalidate.js
@@ -65,7 +65,7 @@ describe('Test of the StaleWhileRevalidate handler', function() {
 
     const wrapperCache = await requestWrapper.getCache();
     const cachePutPromise = new Promise((resolve) => {
-      const cachePutStub = sinon.stub(wrapperCache, 'put', (request, response) => {
+      const cachePutStub = sinon.stub(wrapperCache, 'put').callsFake((request, response) => {
         resolve(response);
       });
       globalStubs.push(cachePutStub);
@@ -89,7 +89,7 @@ describe('Test of the StaleWhileRevalidate handler', function() {
 
     const wrapperCache = await requestWrapper.getCache();
     const cachePutPromise = new Promise((resolve) => {
-      const cachePutStub = sinon.stub(wrapperCache, 'put', (request, response) => {
+      const cachePutStub = sinon.stub(wrapperCache, 'put').callsFake((request, response) => {
         resolve(response);
       });
       globalStubs.push(cachePutStub);

--- a/packages/workbox-sw/test/sw/claim-clients-false.js
+++ b/packages/workbox-sw/test/sw/claim-clients-false.js
@@ -36,7 +36,7 @@ describe('Clients Claim parameter', function() {
 
   it('should not claim when passed in false (clientsClaim)', function() {
     let called = false;
-    const claimStub = sinon.stub(self.clients, 'claim', () => {
+    const claimStub = sinon.stub(self.clients, 'claim').callsFake(() => {
       called = true;
       return Promise.resolve();
     });

--- a/packages/workbox-sw/test/sw/claim-clients-true.js
+++ b/packages/workbox-sw/test/sw/claim-clients-true.js
@@ -36,7 +36,7 @@ describe('Clients Claim parameter', function() {
 
   it('should claim when passed in true (clientsClaim)', function() {
     let called = false;
-    const claimStub = sinon.stub(self.clients, 'claim', () => {
+    const claimStub = sinon.stub(self.clients, 'claim').callsFake(() => {
       called = true;
       return Promise.resolve();
     });

--- a/packages/workbox-sw/test/sw/directory-index-custom.js
+++ b/packages/workbox-sw/test/sw/directory-index-custom.js
@@ -27,7 +27,7 @@ describe('Test Directory Index', function() {
     const DIRECTORY_INDEX = 'custom.html';
 
     let calledWithIndex = false;
-    const claimStub = sinon.stub(Cache.prototype, 'match', (request) => {
+    const claimStub = sinon.stub(Cache.prototype, 'match').callsFake((request) => {
       if (request === new URL(`${EXAMPLE_URL}${DIRECTORY_INDEX}`, self.location).toString()) {
         calledWithIndex = true;
       }

--- a/packages/workbox-sw/test/sw/directory-index-default.js
+++ b/packages/workbox-sw/test/sw/directory-index-default.js
@@ -26,7 +26,7 @@ describe('Test Directory Index', function() {
     const EXAMPLE_URL = '/example/url/';
 
     let calledWithIndex = false;
-    const claimStub = sinon.stub(Cache.prototype, 'match', (request) => {
+    const claimStub = sinon.stub(Cache.prototype, 'match').callsFake((request) => {
       if (request === new URL(`${EXAMPLE_URL}index.html`, self.location).toString()) {
         calledWithIndex = true;
       }

--- a/packages/workbox-sw/test/sw/directory-index-false.js
+++ b/packages/workbox-sw/test/sw/directory-index-false.js
@@ -26,7 +26,7 @@ describe('Test Directory Index', function() {
     const EXAMPLE_URL = '/example/url/';
 
     let calledWithIndex = false;
-    const claimStub = sinon.stub(Cache.prototype, 'match', (request) => {
+    const claimStub = sinon.stub(Cache.prototype, 'match').callsFake((request) => {
       if (request === new URL(`${EXAMPLE_URL}index.html`, self.location).toString()) {
         calledWithIndex = true;
       }

--- a/packages/workbox-sw/test/sw/skip-waiting-false.js
+++ b/packages/workbox-sw/test/sw/skip-waiting-false.js
@@ -37,7 +37,7 @@ describe('Skip Waiting parameter - false', function() {
 
   it('should not claim when passed in false (clientsClaim)', function() {
     let called = false;
-    const claimStub = sinon.stub(self, 'skipWaiting', () => {
+    const claimStub = sinon.stub(self, 'skipWaiting').callsFake(() => {
       called = true;
       return Promise.resolve();
     });

--- a/packages/workbox-sw/test/sw/skip-waiting-true.js
+++ b/packages/workbox-sw/test/sw/skip-waiting-true.js
@@ -37,7 +37,7 @@ describe('Skip Waiting parameter - true', function() {
 
   it('should not claim when passed in true (clientsClaim)', function() {
     let called = false;
-    const claimStub = sinon.stub(self, 'skipWaiting', () => {
+    const claimStub = sinon.stub(self, 'skipWaiting').callsFake(() => {
       called = true;
       return Promise.resolve();
     });

--- a/packages/workbox-webpack-plugin/test/node/test.js
+++ b/packages/workbox-webpack-plugin/test/node/test.js
@@ -22,7 +22,7 @@ const webpackCompilation = {
 let webpackEventCallback;
 const webpackDoneCallback = sinon.spy();
 // Create webpack callback handler
-sinon.stub(webpackCompilation.compiler, 'plugin', (event, callback)=> {
+sinon.stub(webpackCompilation.compiler, 'plugin').callsFake((event, callback)=> {
   webpackEventCallback = callback;
 });
 
@@ -41,13 +41,13 @@ describe('Tests for webpack plugin', function() {
     };
 
     // Generate stub methods
-    sinon.stub(proxySwBuild, 'generateSW', function() {
+    sinon.stub(proxySwBuild, 'generateSW').callsFake(function() {
       return new Promise((resolve) => {
         resolve();
       });
     });
 
-    sinon.stub(proxySwBuild, 'injectManifest', function() {
+    sinon.stub(proxySwBuild, 'injectManifest').callsFake(function() {
       return new Promise((resolve) => {
         resolve();
       });


### PR DESCRIPTION
R: @addyosmani @gauntface

I ran https://github.com/hurrymaplelad/sinon-codemod against our codebase to automatically update to the currently-supported syntax.

This fixes the

```
sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the public API in a future version of sinon.
 Use stub(obj, 'meth').callsFake(fn).
 Codemod available at https://github.com/hurrymaplelad/sinon-codemod
```

noise in our test output.