### PR TITLE
Looking at minor size optimisations.

### DIFF
--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -21,6 +21,8 @@ const gulp = require('gulp');
 const path = require('path');
 const runSequence = require('run-sequence');
 const {taskHarness, buildJSBundle, lernaWrapper} = require('../utils/build');
+const commonjs = require('rollup-plugin-commonjs');
+const resolve = require('rollup-plugin-node-resolve');
 
 const printHeading = (heading) => {
   process.stdout.write(chalk.inverse(`  ⚒  ${heading}  `));
@@ -71,15 +73,40 @@ const updateVersionedBundles = (projectPath) => {
 };
 
 gulp.task('build:shared', () => {
+  const basePlugins = [
+    resolve({
+      jsnext: true,
+      main: true,
+      browser: true,
+    }),
+    commonjs(),
+  ];
+
   return buildJSBundle({
     rollupConfig: {
       entry: path.join(__dirname, '..', 'lib', 'log-helper.js'),
-      format: 'umd',
-      moduleName: 'goog.logHelper',
       plugins: [],
     },
-    buildPath: 'build/log-helper.js',
-    projectDir: path.join(__dirname, '..'),
+    writeConfig: {
+      sourceMap: true,
+      format: 'umd',
+      moduleName: 'goog.logHelper',
+      dest: path.join(__dirname, '..', 'build', 'log-helper.js'),
+    },
+  })
+  .then(() => {
+    return buildJSBundle({
+      rollupConfig: {
+        entry: path.join(__dirname, '..', 'lib', 'assert.js'),
+        plugins: basePlugins,
+      },
+      writeConfig: {
+        sourceMap: true,
+        format: 'umd',
+        moduleName: 'goog.assert',
+        dest: path.join(__dirname, '..', 'build', 'assert.js'),
+      },
+    });
   });
 });
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -17,7 +17,7 @@
 
 import ErrorStackParser from 'error-stack-parser';
 
-function atLeastOne(object) {
+export function atLeastOne(object) {
   const parameters = Object.keys(object);
   if (!parameters.some((parameter) => object[parameter] !== undefined)) {
     throwError('Please set at least one of the following parameters: ' +
@@ -25,7 +25,7 @@ function atLeastOne(object) {
   }
 }
 
-function hasMethod(object, expectedMethod) {
+export function hasMethod(object, expectedMethod) {
   const parameter = Object.keys(object).pop();
   const type = typeof object[parameter][expectedMethod];
   if (type !== 'function') {
@@ -34,7 +34,7 @@ function hasMethod(object, expectedMethod) {
   }
 }
 
-function isInstance(object, expectedClass) {
+export function isInstance(object, expectedClass) {
   const parameter = Object.keys(object).pop();
   if (!(object[parameter] instanceof expectedClass)) {
     throwError(`The '${parameter}' parameter must be an instance of
@@ -42,7 +42,7 @@ function isInstance(object, expectedClass) {
   }
 }
 
-function isOneOf(object, values) {
+export function isOneOf(object, values) {
   const parameter = Object.keys(object).pop();
   if (!values.includes(object[parameter])) {
     throwError(`The '${parameter}' parameter must be set to one of the
@@ -50,7 +50,7 @@ function isOneOf(object, values) {
   }
 }
 
-function isType(object, expectedType) {
+export function isType(object, expectedType) {
   const parameter = Object.keys(object).pop();
   const actualType = typeof object[parameter];
   if (actualType !== expectedType) {
@@ -59,7 +59,7 @@ function isType(object, expectedType) {
   }
 }
 
-function isArrayOfType(object, expectedType) {
+export function isArrayOfType(object, expectedType) {
   const parameter = Object.keys(object).pop();
   const message = `The '${parameter}' parameter should be an array containing
     one or more '${expectedType}' elements.`;
@@ -75,7 +75,7 @@ function isArrayOfType(object, expectedType) {
   }
 }
 
-function isArrayOfClass(object, expectedClass) {
+export function isArrayOfClass(object, expectedClass) {
   const parameter = Object.keys(object).pop();
   const message = `The '${parameter}' parameter should be an array containing
     one or more '${expectedClass.name}' instances.`;
@@ -91,11 +91,11 @@ function isArrayOfClass(object, expectedClass) {
   }
 }
 
-function isValue(object, expectedValue) {
+export function isValue(object, expectedValue) {
   const parameter = Object.keys(object).pop();
   const actualValue = object[parameter];
   if (actualValue !== expectedValue) {
-    throwError(`The '${parameter}' parameter has the wrong value. (Expected: 
+    throwError(`The '${parameter}' parameter has the wrong value. (Expected:
       ${expectedValue}, actual: ${actualValue})`);
   }
 }
@@ -106,6 +106,7 @@ function throwError(message) {
 
   const error = new Error(message);
   error.name = 'assertion-failed';
+
   const stackFrames = ErrorStackParser.parse(error);
 
   // If, for some reason, we don't have all the stack information we need,
@@ -120,14 +121,3 @@ function throwError(message) {
 
   throw error;
 }
-
-export default {
-  atLeastOne,
-  hasMethod,
-  isInstance,
-  isOneOf,
-  isType,
-  isValue,
-  isArrayOfType,
-  isArrayOfClass,
-};

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -18,7 +18,7 @@
  * @return {boolean} True, if we're running in the service worker global scope.
  * False otherwise.
  */
-function isServiceWorkerGlobalScope() {
+export function isServiceWorkerGlobalScope() {
   return ('ServiceWorkerGlobalScope' in self &&
           self instanceof ServiceWorkerGlobalScope);
 }
@@ -28,7 +28,7 @@ function isServiceWorkerGlobalScope() {
  * @return {boolean} True, if we're running a development bundle.
  * False otherwise.
  */
-function isDevBuild() {
+export function isDevBuild() {
   // `BUILD_PROCESS_REPLACE::BUILD_TARGET` is replaced during the build process.
   return `BUILD_PROCESS_REPLACE::BUILD_TARGET` === `dev`;
 }
@@ -38,7 +38,7 @@ function isDevBuild() {
  * @return {boolean} True, if we're running on localhost or the equivalent IP
  * address. False otherwise.
  */
-function isLocalhost() {
+export function isLocalhost() {
   return Boolean(
     location.hostname === 'localhost' ||
     // [::1] is the IPv6 localhost address.
@@ -49,9 +49,3 @@ function isLocalhost() {
     )
   );
 }
-
-export default {
-  isDevBuild,
-  isLocalhost,
-  isServiceWorkerGlobalScope,
-};

--- a/lib/log-group.js
+++ b/lib/log-group.js
@@ -6,24 +6,34 @@
 class LogGroup {
   /**
    * @param {object} input
-   * @param {string} input.title
-   * @param {boolean} input.isPrimary
    */
-  constructor({title, isPrimary} = {}) {
-    this._isPrimary = isPrimary || false;
-    this._groupTitle = title || '';
+  constructor() {
     this._logs = [];
     this._childGroups = [];
 
-    this._isFirefox = false;
-    if (/Firefox\/\d*\.\d*/.exec(navigator.userAgent)) {
-      this._isFirefox = true;
+    this._isFallbackMode = false;
+    const ffRegex = /Firefox\/(\d*)\.\d*/.exec(navigator.userAgent);
+    if (ffRegex) {
+      try {
+        const ffVersion = parseInt(ffRegex[1], 10);
+        if (ffVersion < 55) {
+          this._isFallbackMode = true;
+        }
+      } catch(err) {
+        this._isFallbackMode = true;
+      }
     }
 
-    this._isEdge = false;
     if (/Edge\/\d*\.\d*/.exec(navigator.userAgent)) {
-      this._isEdge = true;
+      this._isFallbackMode = true;
     }
+  }
+
+  /**
+   *@param {object} logDetails
+   */
+  addPrimaryLog(logDetails) {
+    this._primaryLog = logDetails;
   }
 
   /**
@@ -48,12 +58,18 @@ class LogGroup {
    * prints out this log group to the console.
    */
   print() {
-    if (this._isEdge) {
-      this._printEdgeFriendly();
+    if (this._logs.length === 0 && this._childGroups.length === 0) {
+      this._printLogDetails(this._primaryLog);
       return;
     }
 
-    this._openGroup();
+    if (this._primaryLog) {
+      if(!this._isFallbackMode) {
+        console.groupCollapsed(...this._getLogContent(this._primaryLog));
+      } else {
+        this._printLogDetails(this._primaryLog);
+      }
+    }
 
     this._logs.forEach((logDetails) => {
       this._printLogDetails(logDetails);
@@ -63,37 +79,9 @@ class LogGroup {
       group.print();
     });
 
-    this._closeGroup();
-  }
-
-  /**
-   * This prints a simpler log for Edge which has poor group support.
-   * For more details see:
-   * https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11363242/
-   */
-  _printEdgeFriendly() {
-    // Edge has no support for colors at all and poor support for groups.
-    this._logs.forEach((logDetails, index) => {
-      // Message can be an object - i.e. an error.
-      let message = logDetails.message;
-      if (typeof message === 'string') {
-        // Replace the %c value with an empty string.
-        message = message.replace(/%c/g, '');
-      }
-      const logArgs = [message];
-      if (logDetails.error) {
-        logArgs.push(logDetails.error);
-      }
-      if (logDetails.args) {
-        logArgs.push(logDetails.args);
-      }
-      const logFunc = logDetails.logFunc || console.log;
-      logFunc(...logArgs);
-    });
-
-    this._childGroups.forEach((group, index) => {
-       group.print();
-    });
+    if (this._primaryLog && !this._isFallbackMode) {
+      console.groupEnd();
+    }
   }
 
   /**
@@ -102,52 +90,32 @@ class LogGroup {
    */
   _printLogDetails(logDetails) {
     const logFunc = logDetails.logFunc ? logDetails.logFunc : console.log;
+    logFunc(...this._getLogContent(logDetails));
+  }
+
+  /**
+   * Returns a flattened array of message with colors and args.
+   * @param {object} logDetails
+   * @return {Array} Returns an array of arguments to pass to a console
+   * function.
+   */
+  _getLogContent(logDetails) {
     let message = logDetails.message;
+    if (this._isFallbackMode && typeof message === 'string') {
+      // Replace the %c value with an empty string.
+      message = message.replace(/%c/g, '');
+    }
+
     let allArguments = [message];
-    if (logDetails.colors && !this._isEdge) {
+
+    if (!this._isFallbackMode && logDetails.colors) {
       allArguments = allArguments.concat(logDetails.colors);
     }
+
     if (logDetails.args) {
       allArguments = allArguments.concat(logDetails.args);
     }
-    logFunc(...allArguments);
-  }
-
-  /**
-   * Opens a console group - managing differences in Firefox.
-   */
-  _openGroup() {
-    if (this._isPrimary) {
-      // Only start a group is there are child groups
-      if (this._childGroups.length === 0) {
-        return;
-      }
-
-      const logDetails = this._logs.shift();
-      if (this._isFirefox) {
-        // Firefox doesn't support colors logs in console.group.
-        this._printLogDetails(logDetails);
-        return;
-      }
-
-      // Print the colored message with console.group
-      logDetails.logFunc = console.group;
-      this._printLogDetails(logDetails);
-    } else {
-      console.groupCollapsed(this._groupTitle);
-    }
-  }
-
-  /**
-   * Closes a console group
-   */
-  _closeGroup() {
-    // Only close a group if there was a child group opened
-    if (this._isPrimary && this._childGroups.length === 0) {
-      return;
-    }
-
-    console.groupEnd();
+    return allArguments;
   }
 }
 

--- a/lib/log-helper.js
+++ b/lib/log-helper.js
@@ -16,7 +16,7 @@
 /* eslint-disable no-console */
 
 import LogGroup from './log-group';
-import environment from './environment';
+import {isDevBuild} from './environment';
 
 self.workbox = self.workbox || {};
 self.workbox.LOG_LEVEL = self.workbox.LOG_LEVEL || {
@@ -51,7 +51,7 @@ class LogHelper {
    * LogHelper constructor.
    */
   constructor() {
-    this._defaultLogLevel = environment.isDevBuild() ?
+    this._defaultLogLevel = isDevBuild() ?
       self.workbox.LOG_LEVEL.debug :
       self.workbox.LOG_LEVEL.warn;
   }
@@ -114,13 +114,10 @@ class LogHelper {
    * @return {LogGroup} Returns a log group to print to the console.
    */
   _getAllLogGroups(logLevel, logOptions) {
-    const topLogGroup = new LogGroup({
-      isPrimary: true,
-      title: 'workbox log.',
-    });
+    const topLogGroup = new LogGroup();
 
     const primaryMessage = this._getPrimaryMessageDetails(logLevel, logOptions);
-    topLogGroup.addLog(primaryMessage);
+    topLogGroup.addPrimaryLog(primaryMessage);
 
     if (logOptions.error) {
       const errorMessage = {
@@ -130,7 +127,7 @@ class LogHelper {
       topLogGroup.addLog(errorMessage);
     }
 
-    const extraInfoGroup = new LogGroup({title: 'Extra Information.'});
+    const extraInfoGroup = new LogGroup();
     if (logOptions.that && logOptions.that.constructor &&
       logOptions.that.constructor.name) {
       const className = logOptions.that.constructor.name;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "clear-require": "^2.0.0",
     "cookie-parser": "^1.4.3",
     "depcheck": "^0.6.7",
-    "error-stack-parser": "^2.0.0",
+    "error-stack-parser": "^2.0.1",
     "eslint-config-google": "^0.7.0",
     "express": "^4.14.0",
     "fs-extra": "^3.0.1",

--- a/packages/workbox-background-sync/src/lib/background-sync-queue.js
+++ b/packages/workbox-background-sync/src/lib/background-sync-queue.js
@@ -1,7 +1,7 @@
 import RequestManager from './request-manager';
 import RequestQueue from './request-queue';
 import {maxAge, defaultDBName} from './constants';
-import assert from '../../../../lib/assert';
+import {isType, isInstance} from '../../../../lib/assert';
 import IDBHelper from '../../../../lib/idb-helper';
 import {cleanupQueue} from './queue-utils';
 import {getResponse} from './response-manager';
@@ -45,18 +45,18 @@ class Queue {
   constructor({maxRetentionTime = maxAge, callbacks, queueName,
     broadcastChannel, dbName = defaultDBName} = {}) {
       if(queueName) {
-        assert.isType({queueName}, 'string');
+        isType({queueName}, 'string');
       }
 
       if(maxRetentionTime) {
-        assert.isType({maxRetentionTime}, 'number');
+        isType({maxRetentionTime}, 'number');
       }
 
       if(broadcastChannel) {
-        assert.isInstance({broadcastChannel}, BroadcastChannel);
+        isInstance({broadcastChannel}, BroadcastChannel);
       }
 
-      assert.isType({dbName}, 'string');
+      isType({dbName}, 'string');
 
       this._dbName = dbName;
       this._queue = new RequestQueue({
@@ -94,7 +94,7 @@ class Queue {
    * the queue.
    */
   pushIntoQueue({request}) {
-    assert.isInstance({request}, Request);
+    isInstance({request}, Request);
     return this._queue.push({request});
   }
 

--- a/packages/workbox-background-sync/src/lib/broadcast-manager.js
+++ b/packages/workbox-background-sync/src/lib/broadcast-manager.js
@@ -1,5 +1,5 @@
 import {broadcastMeta} from './constants';
-import assert from '../../../../lib/assert';
+import {isType, isInstance} from '../../../../lib/assert';
 
 /**
  * broadcasts the message with the given type and url
@@ -15,9 +15,9 @@ function broadcastMessage({broadcastChannel, type, url}) {
   if(!broadcastChannel)
     return;
 
-  assert.isInstance({broadcastChannel}, BroadcastChannel);
-  assert.isType({type}, 'string');
-  assert.isType({url}, 'string');
+  isInstance({broadcastChannel}, BroadcastChannel);
+  isType({type}, 'string');
+  isType({url}, 'string');
 
   broadcastChannel.postMessage({
     type: type,

--- a/packages/workbox-background-sync/src/lib/request-queue.js
+++ b/packages/workbox-background-sync/src/lib/request-queue.js
@@ -7,7 +7,7 @@ import {
   tagNamePrefix,
   allQueuesPlaceholder,
 } from './constants';
-import assert from '../../../../lib/assert';
+import {isInstance, isType} from '../../../../lib/assert';
 
 let _requestCounter = 0;
 let _queueCounter = 0;
@@ -91,7 +91,7 @@ class RequestQueue {
    * @private
    */
   async push({request}) {
-    assert.isInstance({request}, Request);
+    isInstance({request}, Request);
 
     const hash = `${request.url}!${Date.now()}!${_requestCounter++}`;
     const queuableRequest =
@@ -137,7 +137,7 @@ class RequestQueue {
    * @private
    */
   async getRequestFromQueue({hash}) {
-    assert.isType({hash}, 'string');
+    isType({hash}, 'string');
 
     if(this._queue.includes(hash)) {
       return await this._idbQDb.get(hash);

--- a/packages/workbox-broadcast-cache-update/src/lib/broadcast-cache-update-plugin.js
+++ b/packages/workbox-broadcast-cache-update/src/lib/broadcast-cache-update-plugin.js
@@ -14,7 +14,7 @@
 */
 
 import BroadcastCacheUpdate from './broadcast-cache-update';
-import assert from '../../../../lib/assert';
+import {isType, isInstance} from '../../../../lib/assert';
 
 /**
  * Can be used to compare two [Responses](https://developer.mozilla.org/en-US/docs/Web/API/Response)
@@ -64,8 +64,8 @@ class BroadcastCacheUpdatePlugin extends BroadcastCacheUpdate {
    * @param {string} input.url The cache key URL.
    */
   cacheDidUpdate({cacheName, oldResponse, newResponse, url}) {
-    assert.isType({cacheName}, 'string');
-    assert.isInstance({newResponse}, Response);
+    isType({cacheName}, 'string');
+    isInstance({newResponse}, Response);
 
     if (oldResponse) {
       this.notifyIfUpdated({

--- a/packages/workbox-broadcast-cache-update/src/lib/broadcast-cache-update.js
+++ b/packages/workbox-broadcast-cache-update/src/lib/broadcast-cache-update.js
@@ -14,7 +14,7 @@
 */
 
 import ErrorFactory from './error-factory';
-import assert from '../../../../lib/assert';
+import {isType} from '../../../../lib/assert';
 import broadcastUpdate from './broadcast-update';
 import responsesAreSame from './responses-are-same';
 import {defaultHeadersToCheck, defaultSource} from './constants';
@@ -125,7 +125,7 @@ class BroadcastCacheUpdate {
    * @param {string} input.url The URL of the updates request.
    */
   notifyIfUpdated({first, second, cacheName, url}) {
-    assert.isType({cacheName}, 'string');
+    isType({cacheName}, 'string');
 
     if (
       !responsesAreSame({first, second, headersToCheck: this.headersToCheck})) {

--- a/packages/workbox-broadcast-cache-update/src/lib/broadcast-update.js
+++ b/packages/workbox-broadcast-cache-update/src/lib/broadcast-update.js
@@ -13,7 +13,7 @@
  limitations under the License.
 */
 
-import assert from '../../../../lib/assert';
+import {isType, isInstance} from '../../../../lib/assert';
 import {cacheUpdatedMessageType} from './constants';
 
 /**
@@ -63,10 +63,10 @@ import {cacheUpdatedMessageType} from './constants';
  *        of the update message.
  */
 function broadcastUpdate({channel, cacheName, url, source}) {
-  assert.isInstance({channel}, BroadcastChannel);
-  assert.isType({cacheName}, 'string');
-  assert.isType({source}, 'string');
-  assert.isType({url}, 'string');
+  isInstance({channel}, BroadcastChannel);
+  isType({cacheName}, 'string');
+  isType({source}, 'string');
+  isType({url}, 'string');
 
   channel.postMessage({
     type: cacheUpdatedMessageType,

--- a/packages/workbox-cache-expiration/src/lib/cache-expiration-plugin.js
+++ b/packages/workbox-cache-expiration/src/lib/cache-expiration-plugin.js
@@ -14,7 +14,7 @@
 */
 
 import CacheExpiration from './cache-expiration';
-import assert from '../../../../lib/assert';
+import {isType, isInstance} from '../../../../lib/assert';
 
 /**
  * The `CacheExpirationPlugin` class allows you define an expiration and / or
@@ -73,8 +73,8 @@ class CacheExpirationPlugin extends CacheExpiration {
    * @param {Number} [input.now] A timestamp. Defaults to the current time.
    */
   async cacheDidUpdate({cacheName, newResponse, url, now} = {}) {
-    assert.isType({cacheName}, 'string');
-    assert.isInstance({newResponse}, Response);
+    isType({cacheName}, 'string');
+    isInstance({newResponse}, Response);
 
     if (typeof now === 'undefined') {
       now = Date.now();

--- a/packages/workbox-cache-expiration/src/lib/cache-expiration.js
+++ b/packages/workbox-cache-expiration/src/lib/cache-expiration.js
@@ -14,7 +14,7 @@
 */
 
 import idb from 'idb';
-import assert from '../../../../lib/assert';
+import {isType, isInstance, isArrayOfType} from '../../../../lib/assert';
 import logHelper from '../../../../lib/log-helper';
 import {
   idbName,
@@ -86,7 +86,7 @@ class CacheExpiration {
    * @return {DB} An open DB instance.
    */
   async getDB({cacheName} = {}) {
-    assert.isType({cacheName}, 'string');
+    isType({cacheName}, 'string');
 
     const idbId = `${idbName}-${cacheName}`;
     if (!this._dbs.has(idbId)) {
@@ -111,7 +111,7 @@ class CacheExpiration {
    * @return {Cache} An open Cache instance.
    */
   async getCache({cacheName} = {}) {
-    assert.isType({cacheName}, 'string');
+    isType({cacheName}, 'string');
 
     if (!this._caches.has(cacheName)) {
       const openCache = await caches.open(cacheName);
@@ -149,7 +149,7 @@ class CacheExpiration {
     // Only bother checking for freshness if we have a valid response and if
     // maxAgeSeconds is set. Otherwise, skip the check and always return true.
     if (cachedResponse && this.maxAgeSeconds) {
-      assert.isInstance({cachedResponse}, Response);
+      isInstance({cachedResponse}, Response);
 
       const dateHeader = cachedResponse.headers.get('date');
       if (dateHeader) {
@@ -194,8 +194,8 @@ class CacheExpiration {
    *
    */
   async updateTimestamp({cacheName, url, now} = {}) {
-    assert.isType({url}, 'string');
-    assert.isType({cacheName}, 'string');
+    isType({url}, 'string');
+    isType({cacheName}, 'string');
 
     if (typeof now === 'undefined') {
       now = Date.now();
@@ -248,7 +248,7 @@ class CacheExpiration {
     }
     this._expirationMutex = true;
 
-    assert.isType({cacheName}, 'string');
+    isType({cacheName}, 'string');
 
     if (typeof now === 'undefined') {
       now = Date.now();
@@ -298,8 +298,8 @@ class CacheExpiration {
    * @return {Array<string>} A list of the URLs that were expired.
    */
   async findOldEntries({cacheName, now} = {}) {
-    assert.isType({cacheName}, 'string');
-    assert.isType({now}, 'number');
+    isType({cacheName}, 'string');
+    isType({now}, 'number');
 
     const expireOlderThan = now - (this.maxAgeSeconds * 1000);
     const urls = [];
@@ -337,7 +337,7 @@ class CacheExpiration {
    *   expiration.
    */
   async findExtraEntries({cacheName} = {}) {
-    assert.isType({cacheName}, 'string');
+    isType({cacheName}, 'string');
 
     const urls = [];
     const db = await this.getDB({cacheName});
@@ -379,8 +379,8 @@ class CacheExpiration {
    * @param {Array<string>} urls The URLs to delete.
    */
   async deleteFromCacheAndIDB({cacheName, urls} = {}) {
-    assert.isType({cacheName}, 'string');
-    assert.isArrayOfType({urls}, 'string');
+    isType({cacheName}, 'string');
+    isArrayOfType({urls}, 'string');
 
     if (urls.length > 0) {
       const cache = await this.getCache({cacheName});

--- a/packages/workbox-cacheable-response/src/lib/cacheable-response.js
+++ b/packages/workbox-cacheable-response/src/lib/cacheable-response.js
@@ -13,7 +13,8 @@
  limitations under the License.
 */
 
-import assert from '../../../../lib/assert';
+import {atLeastOne, isArrayOfType, isType, isInstance} from
+  '../../../../lib/assert';
 import logHelper from '../../../../lib/log-helper.js';
 
 /**
@@ -49,12 +50,12 @@ class CacheableResponse {
    *        checked when determining whether a `Response` is cacheable.
    */
   constructor({statuses, headers} = {}) {
-    assert.atLeastOne({statuses, headers});
+    atLeastOne({statuses, headers});
     if (statuses !== undefined) {
-      assert.isArrayOfType({statuses}, 'number');
+      isArrayOfType({statuses}, 'number');
     }
     if (headers !== undefined) {
-      assert.isType({headers}, 'object');
+      isType({headers}, 'object');
     }
 
     this.statuses = statuses;
@@ -73,7 +74,7 @@ class CacheableResponse {
    *          configuration of this object, and `false` otherwise.
    */
   isResponseCacheable({request, response} = {}) {
-    assert.isInstance({response}, Response);
+    isInstance({response}, Response);
 
     let cacheable = true;
 

--- a/packages/workbox-precaching/src/index.js
+++ b/packages/workbox-precaching/src/index.js
@@ -60,9 +60,9 @@ import ErrorFactory from './lib/error-factory';
 import RevisionedCacheManager from
   './lib/controllers/revisioned-cache-manager.js';
 
-import environment from '../../../lib/environment.js';
+import {isServiceWorkerGlobalScope} from '../../../lib/environment.js';
 
-if (!environment.isServiceWorkerGlobalScope()) {
+if (!isServiceWorkerGlobalScope()) {
   // We are not running in a service worker, print error message
   throw ErrorFactory.createError('not-in-sw');
 }

--- a/packages/workbox-precaching/src/lib/controllers/revisioned-cache-manager.js
+++ b/packages/workbox-precaching/src/lib/controllers/revisioned-cache-manager.js
@@ -6,7 +6,7 @@ import StringPrecacheEntry from
   '../models/precache-entries/string-precache-entry';
 import ObjectPrecacheEntry from
   '../models/precache-entries/object-precache-entry';
-import assert from '../../../../../lib/assert';
+import {isInstance} from '../../../../../lib/assert';
 import logHelper from '../../../../../lib/log-helper';
 
 /**
@@ -73,7 +73,7 @@ class RevisionedCacheManager extends BaseCacheManager {
    * });
    */
   addToCacheList({revisionedFiles} = {}) {
-    assert.isInstance({revisionedFiles}, Array);
+    isInstance({revisionedFiles}, Array);
     super._addEntries(revisionedFiles);
 
     const urlsWithoutRevisionFields = revisionedFiles

--- a/packages/workbox-precaching/src/lib/controllers/unrevisioned-cache-manager.js
+++ b/packages/workbox-precaching/src/lib/controllers/unrevisioned-cache-manager.js
@@ -3,7 +3,7 @@ import BaseCacheManager from './base-cache-manager';
 import RequestCacheEntry from '../models/precache-entries/request-entry';
 import StringPrecacheEntry from
   '../models/precache-entries/string-precache-entry';
-import assert from '../../../../../lib/assert';
+import {isInstance} from '../../../../../lib/assert';
 
 /**
  * This class extends a lot of the internal methods from BaseCacheManager
@@ -48,7 +48,7 @@ class UnrevisionedCacheManager extends BaseCacheManager {
    * parsed into a BaseCacheEntry.
    */
    addToCacheList({unrevisionedFiles} = {}) {
-     assert.isInstance({unrevisionedFiles}, Array);
+     isInstance({unrevisionedFiles}, Array);
      super._addEntries(unrevisionedFiles);
    }
 

--- a/packages/workbox-precaching/src/lib/models/precache-entries/object-precache-entry.js
+++ b/packages/workbox-precaching/src/lib/models/precache-entries/object-precache-entry.js
@@ -1,6 +1,6 @@
 import ErrorFactory from '../../error-factory';
 import BaseCacheEntry from './base-precache-entry';
-import assert from '../../../../../../lib/assert';
+import {isType} from '../../../../../../lib/assert';
 
 /**
  * This class will take an object of parameters, validate the input and
@@ -30,28 +30,28 @@ class DefaultsCacheEntry extends BaseCacheEntry {
       entryID = new URL(url, location).toString();
     }
 
-    assert.isType({revision}, 'string');
+    isType({revision}, 'string');
     if (revision.length === 0) {
       throw ErrorFactory.createError('invalid-revisioned-entry',
         new Error('Bad revision Parameter. It should be a string with at ' +
           'least one character: ' + JSON.stringify(revision)));
     }
 
-    assert.isType({url}, 'string');
+    isType({url}, 'string');
     if (url.length === 0) {
       throw ErrorFactory.createError('invalid-revisioned-entry',
         new Error('Bad url Parameter. It should be a string:' +
           JSON.stringify(url)));
     }
 
-    assert.isType({entryID}, 'string');
+    isType({entryID}, 'string');
     if (entryID.length === 0) {
       throw ErrorFactory.createError('invalid-revisioned-entry',
         new Error('Bad entryID Parameter. It should be a string with at ' +
           'least one character: ' + JSON.stringify(entryID)));
     }
 
-    assert.isType({cacheBust}, 'boolean');
+    isType({cacheBust}, 'boolean');
 
     super({
       entryID,

--- a/packages/workbox-precaching/src/lib/models/precache-entries/string-precache-entry.js
+++ b/packages/workbox-precaching/src/lib/models/precache-entries/string-precache-entry.js
@@ -1,6 +1,6 @@
 import ErrorFactory from '../../error-factory';
 import BaseCacheEntry from './base-precache-entry';
-import assert from '../../../../../../lib/assert';
+import {isType} from '../../../../../../lib/assert';
 
 /**
  * This class will take a string and parse it as a BaseCacheEntry.
@@ -16,7 +16,7 @@ class StringCacheEntry extends BaseCacheEntry {
    * @param {String} url A URL to cache.
    */
   constructor(url) {
-    assert.isType({url}, 'string');
+    isType({url}, 'string');
     if (url.length === 0) {
       throw ErrorFactory.createError('invalid-revisioned-entry',
         new Error('Bad url Parameter. It should be a string:' +

--- a/packages/workbox-routing/src/lib/navigation-route.js
+++ b/packages/workbox-routing/src/lib/navigation-route.js
@@ -14,7 +14,7 @@
  */
 
 import Route from './route';
-import assert from '../../../../lib/assert';
+import {isArrayOfClass} from '../../../../lib/assert';
 import logHelper from '../../../../lib/log-helper';
 
 /**
@@ -68,9 +68,9 @@ class NavigationRoute extends Route {
    * definition.
    */
   constructor({whitelist, blacklist, handler} = {}) {
-    assert.isArrayOfClass({whitelist}, RegExp);
+    isArrayOfClass({whitelist}, RegExp);
     if (blacklist) {
-      assert.isArrayOfClass({blacklist}, RegExp);
+      isArrayOfClass({blacklist}, RegExp);
     } else {
       blacklist = [];
     }

--- a/packages/workbox-routing/src/lib/normalize-handler.js
+++ b/packages/workbox-routing/src/lib/normalize-handler.js
@@ -1,4 +1,4 @@
-import assert from '../../../../lib/assert';
+import {hasMethod, isType} from '../../../../lib/assert';
 
 /**
  * @param {function|module:workbox-runtime-caching.Handler} handler The
@@ -8,10 +8,10 @@ import assert from '../../../../lib/assert';
  */
 export default function normalizeHandler(handler) {
   if (typeof handler === 'object') {
-    assert.hasMethod({handler}, 'handle');
+    hasMethod({handler}, 'handle');
     return handler;
   } else {
-    assert.isType({handler}, 'function');
+    isType({handler}, 'function');
     return {handle: handler};
   }
 }

--- a/packages/workbox-routing/src/lib/regexp-route.js
+++ b/packages/workbox-routing/src/lib/regexp-route.js
@@ -14,7 +14,7 @@
 */
 
 import Route from './route';
-import assert from '../../../../lib/assert';
+import {isInstance} from '../../../../lib/assert';
 import logHelper from '../../../../lib/log-helper.js';
 
 /**
@@ -83,7 +83,7 @@ class RegExpRoute extends Route {
    * HTTP method. Defaults to `'GET'` if not specified.
    */
   constructor({regExp, handler, method}) {
-    assert.isInstance({regExp}, RegExp);
+    isInstance({regExp}, RegExp);
 
     const match = ({url}) => {
       const result = regExp.exec(url.href);

--- a/packages/workbox-routing/src/lib/route.js
+++ b/packages/workbox-routing/src/lib/route.js
@@ -13,7 +13,7 @@
  limitations under the License.
 */
 
-import assert from '../../../../lib/assert';
+import {isType, isOneOf} from '../../../../lib/assert';
 import normalizeHandler from './normalize-handler';
 import {defaultMethod, validMethods} from './constants';
 
@@ -121,11 +121,11 @@ class Route {
   constructor({match, handler, method} = {}) {
     this.handler = normalizeHandler(handler);
 
-    assert.isType({match}, 'function');
+    isType({match}, 'function');
     this.match = match;
 
     if (method) {
-      assert.isOneOf({method}, validMethods);
+      isOneOf({method}, validMethods);
       this.method = method;
     } else {
       this.method = defaultMethod;

--- a/packages/workbox-routing/src/lib/router.js
+++ b/packages/workbox-routing/src/lib/router.js
@@ -14,7 +14,7 @@
 */
 
 import Route from './route';
-import assert from '../../../../lib/assert';
+import {isArrayOfClass, isInstance} from '../../../../lib/assert';
 import logHelper from '../../../../lib/log-helper.js';
 import normalizeHandler from './normalize-handler';
 
@@ -220,7 +220,7 @@ class Router {
    * routes to register.
    */
   registerRoutes({routes} = {}) {
-    assert.isArrayOfClass({routes}, Route);
+    isArrayOfClass({routes}, Route);
 
     for (let route of routes) {
       if (!this._routes.has(route.method)) {
@@ -244,7 +244,7 @@ class Router {
    * @param {module:workbox-routing.Route} input.route The route to register.
    */
   registerRoute({route} = {}) {
-    assert.isInstance({route}, Route);
+    isInstance({route}, Route);
 
     this.registerRoutes({routes: [route]});
   }

--- a/packages/workbox-runtime-caching/src/lib/cache-first.js
+++ b/packages/workbox-runtime-caching/src/lib/cache-first.js
@@ -14,7 +14,7 @@
 */
 
 import Handler from './handler';
-import assert from '../../../../lib/assert';
+import {isInstance} from '../../../../lib/assert';
 
 /**
  * An implementation of a [cache-first](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#cache-falling-back-to-network)
@@ -53,7 +53,7 @@ class CacheFirst extends Handler {
    *          the network and the result will be cached for future use.
    */
   async handle({event} = {}) {
-    assert.isInstance({event}, FetchEvent);
+    isInstance({event}, FetchEvent);
 
     const cachedResponse = await this.requestWrapper.match({
       request: event.request,

--- a/packages/workbox-runtime-caching/src/lib/cache-only.js
+++ b/packages/workbox-runtime-caching/src/lib/cache-only.js
@@ -14,7 +14,7 @@
 */
 
 import Handler from './handler';
-import assert from '../../../../lib/assert';
+import {isInstance} from '../../../../lib/assert';
 
 /**
  * An implementation of a [cache-only](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#cache-only)
@@ -51,7 +51,7 @@ class CacheOnly extends Handler {
    * @return {Promise.<Response>} The response from the cache or null.
    */
   async handle({event} = {}) {
-    assert.isInstance({event}, FetchEvent);
+    isInstance({event}, FetchEvent);
 
     return await this.requestWrapper.match({request: event.request});
   }

--- a/packages/workbox-runtime-caching/src/lib/clean-response-copy.js
+++ b/packages/workbox-runtime-caching/src/lib/clean-response-copy.js
@@ -13,7 +13,7 @@
  limitations under the License.
 */
 
-import assert from '../../../../lib/assert';
+import {isInstance} from '../../../../lib/assert';
 
 /**
  * Helper method to "clean" a redirected response, so that it could be used
@@ -27,7 +27,7 @@ import assert from '../../../../lib/assert';
  * @return {Promise<Response>} A clone of the response, with `redirected` false.
  */
 export default ({response}) => {
-  assert.isInstance({response}, Response);
+  isInstance({response}, Response);
 
   const clonedResponse = response.clone();
 

--- a/packages/workbox-runtime-caching/src/lib/network-first.js
+++ b/packages/workbox-runtime-caching/src/lib/network-first.js
@@ -17,7 +17,7 @@ import {CacheableResponsePlugin} from
   '../../../workbox-cacheable-response/src/index';
 import ErrorFactory from './error-factory';
 import Handler from './handler';
-import assert from '../../../../lib/assert';
+import {isType, isInstance} from '../../../../lib/assert';
 
 /**
  * An implementation of a [network first](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#network-falling-back-to-cache)
@@ -67,7 +67,7 @@ class NetworkFirst extends Handler {
 
     const {networkTimeoutSeconds} = input;
     if (networkTimeoutSeconds) {
-      assert.isType({networkTimeoutSeconds}, 'number');
+      isType({networkTimeoutSeconds}, 'number');
       this.networkTimeoutSeconds = networkTimeoutSeconds;
     }
   }
@@ -84,7 +84,7 @@ class NetworkFirst extends Handler {
    *          not available, a previously cached response.
    */
   async handle({event} = {}) {
-    assert.isInstance({event}, FetchEvent);
+    isInstance({event}, FetchEvent);
 
     const promises = [];
     let timeoutId;

--- a/packages/workbox-runtime-caching/src/lib/network-only.js
+++ b/packages/workbox-runtime-caching/src/lib/network-only.js
@@ -14,7 +14,7 @@
 */
 
 import Handler from './handler';
-import assert from '../../../../lib/assert';
+import {isInstance} from '../../../../lib/assert';
 
 /**
  * An implementation of a [network-only](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#network-only)
@@ -50,7 +50,7 @@ class NetworkOnly extends Handler {
    * @return {Promise.<Response>} The response from the network.
    */
   async handle({event} = {}) {
-    assert.isInstance({event}, FetchEvent);
+    isInstance({event}, FetchEvent);
 
     return await this.requestWrapper.fetch({request: event.request});
   }

--- a/packages/workbox-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/workbox-runtime-caching/src/lib/request-wrapper.js
@@ -14,7 +14,8 @@
 */
 
 import ErrorFactory from './error-factory';
-import assert from '../../../../lib/assert';
+import {isArrayOfType, isType, atLeastOne, isInstance} from
+  '../../../../lib/assert';
 import {CacheableResponsePlugin} from
   '../../../workbox-cacheable-response/src/index';
 import {pluginCallbacks, getDefaultCacheName} from './constants';
@@ -65,7 +66,7 @@ class RequestWrapper {
     }
 
     if (cacheName) {
-      assert.isType({cacheName}, 'string');
+      isType({cacheName}, 'string');
       this.cacheName = cacheName;
       if (cacheId) {
         this.cacheName = `${cacheId}-${this.cacheName}`;
@@ -75,19 +76,19 @@ class RequestWrapper {
     }
 
     if (fetchOptions) {
-      assert.isType({fetchOptions}, 'object');
+      isType({fetchOptions}, 'object');
       this.fetchOptions = fetchOptions;
     }
 
     if (matchOptions) {
-      assert.isType({matchOptions}, 'object');
+      isType({matchOptions}, 'object');
       this.matchOptions = matchOptions;
     }
 
     this.plugins = new Map();
 
     if (plugins) {
-      assert.isArrayOfType({plugins}, 'object');
+      isArrayOfType({plugins}, 'object');
 
       plugins.forEach((plugin) => {
         for (let callbackName of pluginCallbacks) {
@@ -167,7 +168,7 @@ class RequestWrapper {
    * @return {Promise.<Response>} The cached response.
    */
   async match({request}) {
-    assert.atLeastOne({request});
+    atLeastOne({request});
 
     const cache = await this.getCache();
     let cachedResponse = await cache.match(request, this.matchOptions);
@@ -205,7 +206,7 @@ class RequestWrapper {
     if (typeof request === 'string') {
       request = new Request(request);
     } else {
-      assert.isInstance({request}, Request);
+      isInstance({request}, Request);
     }
 
     // If there is a fetchDidFail plugin, we need to save a clone of the
@@ -217,9 +218,9 @@ class RequestWrapper {
     if (this.plugins.has('requestWillFetch')) {
       for (let plugin of this.plugins.get('requestWillFetch')) {
         const returnedPromise = plugin.requestWillFetch({request});
-        assert.isInstance({returnedPromise}, Promise);
+        isInstance({returnedPromise}, Promise);
         const returnedRequest = await returnedPromise;
-        assert.isInstance({returnedRequest}, Request);
+        isInstance({returnedRequest}, Request);
         request = returnedRequest;
       }
     }
@@ -278,7 +279,7 @@ class RequestWrapper {
    */
   async fetchAndCache(
     {request, waitOnCache, cacheKey, cacheResponsePlugin, cleanRedirects}) {
-    assert.atLeastOne({request});
+    atLeastOne({request});
 
     let cachingComplete;
     const response = await this.fetch({request});

--- a/packages/workbox-runtime-caching/src/lib/stale-while-revalidate.js
+++ b/packages/workbox-runtime-caching/src/lib/stale-while-revalidate.js
@@ -16,7 +16,7 @@
 import {CacheableResponsePlugin} from
   '../../../workbox-cacheable-response/src/index';
 import Handler from './handler';
-import assert from '../../../../lib/assert';
+import {isInstance} from '../../../../lib/assert';
 
 /**
  * An implementation of a [stale-while-revalidate](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate)
@@ -79,7 +79,7 @@ class StaleWhileRevalidate extends Handler {
    *          from the network if not.
    */
   async handle({event} = {}) {
-    assert.isInstance({event}, FetchEvent);
+    isInstance({event}, FetchEvent);
 
     const fetchAndCacheResponse = this.requestWrapper.fetchAndCache({
       request: event.request,

--- a/packages/workbox-sw/src/lib/workbox-sw.js
+++ b/packages/workbox-sw/src/lib/workbox-sw.js
@@ -18,7 +18,8 @@
 import ErrorFactory from './error-factory.js';
 import Router from './router.js';
 import Strategies from './strategies';
-import environment from '../../../../lib/environment.js';
+import {isServiceWorkerGlobalScope, isDevBuild, isLocalhost} from
+  '../../../../lib/environment.js';
 import logHelper from '../../../../lib/log-helper';
 import {BroadcastCacheUpdatePlugin} from
   '../../../workbox-broadcast-cache-update/src/index.js';
@@ -64,13 +65,13 @@ class WorkboxSW {
                directoryIndex = 'index.html',
                precacheChannelName = 'precache-updates',
                ignoreUrlParametersMatching = [/^utm_/]} = {}) {
-    if (!environment.isServiceWorkerGlobalScope()) {
+    if (!isServiceWorkerGlobalScope()) {
       // If we are not running in a service worker, fail early.
       throw ErrorFactory.createError('not-in-sw');
     }
 
-    if (environment.isDevBuild()) {
-      if (environment.isLocalhost()) {
+    if (isDevBuild()) {
+      if (isLocalhost()) {
         // If this is a dev bundle on localhost, print a welcome message.
         logHelper.debug({
           message: 'Welcome to Workbox!',

--- a/test/browser/assertion.html
+++ b/test/browser/assertion.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Log Helper Test</title>
+    <script src="/build/assert.js"></script>
+    <script>
+    const assert = goog.assert;
+
+    function testAssertion(input) {
+      assert.isInstance({input}, Array);
+    }
+
+    function nestingTwo(input) {
+      testAssertion(input);
+    }
+
+    function nesting(input) {
+      nestingTwo(input);
+    }
+
+    nesting('example');
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/browser/log-helper.html
+++ b/test/browser/log-helper.html
@@ -7,7 +7,7 @@
     <script>
     const logHelper = goog.logHelper;
 
-    goog.logLevel = goog.LOG_LEVEL.verbose;
+    workbox.logLevel = self.workbox.LOG_LEVEL.verbose;
 
     const _printVariants = (input) => {
       console.clear();

--- a/utils/build.js
+++ b/utils/build.js
@@ -165,7 +165,7 @@ function generateBuildConfigs({formatToPath, baseDir, moduleName,
     buildConfigs.push({
       rollupConfig: {
         entry: entry || path.join(baseDir, 'src', 'index.js'),
-        plugins: [devReplacePlugin, ...basePlugins],
+        plugins: [devReplacePlugin, ...basePlugins, babelPlugin],
       },
       writeConfig: {
         banner: LICENSE_HEADER,


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

This PR does the following:
- Adds Babili back into the dev build.
- Moves assert and environment into individual exports (this helps reduce file size slightly)
- Tidies / simplifies the log helpers (and bring some basic manual tests back in for assert and log helper)
- Removes the error-stack-parser. While the logs are helpful it's size isn't worth it (looking at the logs from assert example is /test/assert.html the error stack trace does go back up to the source, so I'd rather explore how we keep that error useful (i.e. ensure maps are working or configuring babili for dev not to manipulate function names).

for workbox-precaching prod goes from 23KB -> 21.4KB. Dev goes from 86.9KB -> 21.4KB