### PR TITLE
Bg sync replay fix

### DIFF
--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -56,7 +56,7 @@ gulp.task('mocha', ['build'], () => {
     });
 });
 
-gulp.task('test', [], (callback) => {
+gulp.task('test', ['lint', 'download-browsers'], (callback) => {
   runSequence('mocha', callback);
 });
 

--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -56,7 +56,7 @@ gulp.task('mocha', ['build'], () => {
     });
 });
 
-gulp.task('test', ['lint', 'download-browsers'], (callback) => {
+gulp.task('test', [], (callback) => {
   runSequence('mocha', callback);
 });
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "babel-preset-babili": "0.0.12",
-    "chai": "^3.5.0",
+    "chai": "^4.0.2",
     "chromedriver": "^2.26.1",
     "clear-require": "^2.0.0",
     "cookie-parser": "^1.4.3",

--- a/packages/workbox-background-sync/src/lib/request-manager.js
+++ b/packages/workbox-background-sync/src/lib/request-manager.js
@@ -57,7 +57,7 @@ class RequestManager {
         idbRequestObject: reqData.request});
       const response = await fetch(request);
       if(!response.ok) {
-        return Promise.reject();
+        return Promise.reject(response.status);
       } else {
         // not blocking on putResponse.
         putResponse({
@@ -72,7 +72,7 @@ class RequestManager {
     } catch(err) {
       this._globalCallbacks.onRetryFailure
         && this._globalCallbacks.onRetryFailure(hash, err);
-        return Promise.reject(err);
+      return Promise.reject(err);
     }
   }
 
@@ -85,15 +85,17 @@ class RequestManager {
    * @private
    */
   async replayRequests() {
-    let failedItems = 0;
+    let failedItems = [];
     for (let hash of this._queue.queue) {
       try {
         await this.replayRequest(hash);
-      } catch (e) {
+      } catch (err) {
+        failedItems.push(err);
         failedItems++;
       }
     }
-    return failedItems > 0 ? Promise.reject() : Promise.resolve();
+    return failedItems.length > 0 ?
+      Promise.reject(failedItems) : Promise.resolve();
   }
 }
 

--- a/packages/workbox-background-sync/src/lib/request-manager.js
+++ b/packages/workbox-background-sync/src/lib/request-manager.js
@@ -63,7 +63,7 @@ class RequestManager {
       });
       const response = await fetch(request);
       if(!response.ok) {
-        return Promise.reject(response.status);
+        return Promise.reject(response);
       } else {
         // not blocking on putResponse.
         putResponse({
@@ -76,7 +76,7 @@ class RequestManager {
           this._globalCallbacks.onResponse(hash, response);
       }
     } catch(err) {
-      return Promise.reject(err);
+      return Promise.reject(err.stack);
     }
   }
 
@@ -90,7 +90,7 @@ class RequestManager {
    * @private
    */
   async replayRequests() {
-    let failedItems = [];
+    const failedItems = [];
     for (let hash of this._queue.queue) {
       try {
         await this.replayRequest(hash);

--- a/packages/workbox-background-sync/src/lib/request-manager.js
+++ b/packages/workbox-background-sync/src/lib/request-manager.js
@@ -42,54 +42,58 @@ class RequestManager {
   }
 
   /**
+   * function to play one single request
+   * given its hash
+   * @param {String=} hash
+   * @return {Promise}
+   *
+   * @memberOf RequestManager
+   * @private
+   */
+  async replayRequest(hash) {
+    try {
+      const reqData = await this._queue.getRequestFromQueue({hash});
+      const request = await getFetchableRequest({
+        idbRequestObject: reqData.request});
+      const response = await fetch(request);
+      if(!response.ok) {
+        return Promise.reject();
+      } else {
+        // not blocking on putResponse.
+        putResponse({
+          hash,
+          idbObject: reqData,
+          response: response.clone(),
+          idbQDb: this._queue.idbQDb,
+        });
+        this._globalCallbacks.onResponse
+          && this._globalCallbacks.onResponse(hash, response);
+      }
+    } catch(err) {
+      this._globalCallbacks.onRetryFailure
+        && this._globalCallbacks.onRetryFailure(hash, err);
+        return Promise.reject(err);
+    }
+  }
+
+  /**
    * function to start playing requests
    * in sequence
-   * @return {void}
+   * @return {Promise}
    *
    * @memberOf RequestManager
    * @private
    */
   async replayRequests() {
-    let allRequestsStatus = [];
-    await this._queue.queue.reduce((promise, hash) => {
-      return promise
-        .then(async (item) => {
-          const reqData = await this._queue.getRequestFromQueue({hash});
-          if(reqData.response) {
-            // check if request is not played already
-            return;
-          }
-
-          const request = await getFetchableRequest({
-            idbRequestObject: reqData.request,
-          });
-
-          return fetch(request)
-            .then((response)=>{
-              if(!response.ok) {
-                allRequestsStatus.push(Promise.reject());
-                return Promise.resolve();
-              } else {
-                // not blocking on putResponse.
-                putResponse({
-                  hash,
-                  idbObject: reqData,
-                  response: response.clone(),
-                  idbQDb: this._queue.idbQDb,
-                });
-                this._globalCallbacks.onResponse
-                  && this._globalCallbacks.onResponse(hash, response);
-                allRequestsStatus.push(Promise.resolve());
-              }
-            })
-            .catch((err)=>{
-              allRequestsStatus.push(Promise.reject());
-              this._globalCallbacks.onRetryFailure
-                && this._globalCallbacks.onRetryFailure(hash, err);
-            });
-        });
-    }, Promise.resolve());
-    return Promise.all(allRequestsStatus);
+    let failedItems = 0;
+    for (let hash of this._queue.queue) {
+      try {
+        await this.replayRequest(hash);
+      } catch (e) {
+        failedItems++;
+      }
+    }
+    return failedItems > 0 ? Promise.reject() : Promise.resolve();
   }
 }
 

--- a/packages/workbox-background-sync/src/lib/request-manager.js
+++ b/packages/workbox-background-sync/src/lib/request-manager.js
@@ -55,8 +55,12 @@ class RequestManager {
   async replayRequest(hash) {
     try {
       const reqData = await this._queue.getRequestFromQueue({hash});
+      if(reqData.response) {
+        return;
+      }
       const request = await getFetchableRequest({
-        idbRequestObject: reqData.request});
+        idbRequestObject: reqData.request,
+      });
       const response = await fetch(request);
       if(!response.ok) {
         return Promise.reject(response.status);

--- a/packages/workbox-background-sync/src/lib/request-manager.js
+++ b/packages/workbox-background-sync/src/lib/request-manager.js
@@ -76,7 +76,7 @@ class RequestManager {
           this._globalCallbacks.onResponse(hash, response);
       }
     } catch(err) {
-      return Promise.reject(err.stack);
+      return Promise.reject(err);
     }
   }
 
@@ -86,7 +86,6 @@ class RequestManager {
    * @return {Promise} Resolves if all requests are played successfully,
    * rejects if any of the request fails during the replay
    *
-   * @memberOf RequestManager
    * @private
    */
   async replayRequests() {

--- a/packages/workbox-background-sync/src/lib/request-manager.js
+++ b/packages/workbox-background-sync/src/lib/request-manager.js
@@ -16,7 +16,6 @@ class RequestManager {
    * attaches event handler
    * @param {Object=} config
    *
-   * @memberOf RequestManager
    * @private
    */
   constructor({callbacks, queue}) {
@@ -29,7 +28,6 @@ class RequestManager {
    * attaches sync handler to replay requests when
    * sync event is fired
    *
-   * @memberOf RequestManager
    * @private
    */
   attachSyncHandler() {
@@ -49,7 +47,7 @@ class RequestManager {
    * @return {Promise} Resolves if the request corresponding to the hash is
    * played successfully, rejects if it fails during the replay
    *
-   * @memberOf RequestManager
+   *
    * @private
    */
   async replayRequest(hash) {
@@ -81,7 +79,9 @@ class RequestManager {
   }
 
   /**
-   * function to start playing requests in sequence
+   * This function is to be called to replay all the requests
+   * in the current queue. It will play all the requests and return a promise
+   * based on the successfull execution of the requests.
    *
    * @return {Promise} Resolves if all requests are played successfully,
    * rejects if any of the request fails during the replay

--- a/packages/workbox-background-sync/src/lib/request-queue.js
+++ b/packages/workbox-background-sync/src/lib/request-queue.js
@@ -140,7 +140,8 @@ class RequestQueue {
     assert.isType({hash}, 'string');
 
     if(this._queue.includes(hash)) {
-      return await this._idbQDb.get(hash);
+      const req = await this._idbQDb.get(hash);
+      return req;
     }
   }
 

--- a/packages/workbox-background-sync/test/browser/background-sync-queue-plugin.js
+++ b/packages/workbox-background-sync/test/browser/background-sync-queue-plugin.js
@@ -17,7 +17,6 @@
 'use strict';
 
 describe('background-sync-queue-plugin test', () => {
-  console.log(workbox.backgroundSync.test);
   const backgroundSyncQueue
     = new workbox.backgroundSync.test.BackgroundSyncQueuePlugin({});
 

--- a/packages/workbox-background-sync/test/browser/background-sync-queue.js
+++ b/packages/workbox-background-sync/test/browser/background-sync-queue.js
@@ -86,6 +86,17 @@ describe('background sync queue test', () => {
     chai.assert.equal(responseAchieved, 2);
   });
 
+  it('check replay failure with rejected promise', async function() {
+    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://localhost:3000/__echo/counter')});
+    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://localhost:3002/__echo/counter')});
+    try {
+      await backgroundSyncQueue.replayRequests();
+      throw new Error('Replay should have failed because of invalid URL');
+    } catch (err) {
+      chai.assert.equal('TypeError: Failed to fetch', err);
+    }
+  });
+
   it('test queue cleanup', async () => {
     /* code for clearing everything from IDB */
     const backgroundSyncQueue

--- a/packages/workbox-background-sync/test/browser/background-sync-queue.js
+++ b/packages/workbox-background-sync/test/browser/background-sync-queue.js
@@ -31,6 +31,9 @@ describe('background sync queue test', () => {
   }
   function onRetryFail() {}
 
+  beforeEach(()=>{
+    responseAchieved = 0;
+  });
   const QUEUE_NAME = 'QUEUE_NAME';
   const MAX_AGE = 6;
   const CALLBACKS = {
@@ -71,13 +74,14 @@ describe('background sync queue test', () => {
 
   it('check push proxy', async () => {
     const currentLen = backgroundSyncQueue._queue.queue.length;
-    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://lipsum.com')});
+    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://localhost:3000/__echo/counter')});
+    await backgroundSyncQueue.replayRequests();
     chai.assert.equal(backgroundSyncQueue._queue.queue.length, currentLen + 1);
   });
 
   it('check replay', async function() {
-    await backgroundSyncQueue.pushIntoQueue({request: new Request('https://jsonplaceholder.typicode.com/posts/1')});
-    await backgroundSyncQueue.pushIntoQueue({request: new Request('https://jsonplaceholder.typicode.com/posts/2')});
+    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://localhost:3000/__echo/counter')});
+    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://localhost:3000/__echo/counter')});
     await backgroundSyncQueue.replayRequests();
     chai.assert.equal(responseAchieved, 2);
   });
@@ -97,9 +101,9 @@ describe('background sync queue test', () => {
 
     await backgroundSyncQueue.cleanupQueue();
     await backgroundSyncQueue2.cleanupQueue();
-    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://lipsum1.com')});
-    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://lipsum2.com')});
-    await backgroundSyncQueue2.pushIntoQueue({request: new Request('http://lipsum.com')});
+    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://localhost:3000/__echo/counter')});
+    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://localhost:3000/__echo/counter')});
+    await backgroundSyncQueue2.pushIntoQueue({request: new Request('http://localhost:3000/__echo/counter')});
     const queue1Keys = (await backgroundSyncQueue._queue._idbQDb.getAllKeys());
     const queue2Keys = (await backgroundSyncQueue2._queue._idbQDb.getAllKeys());
     await delay(100);

--- a/packages/workbox-background-sync/test/browser/request-manager.js
+++ b/packages/workbox-background-sync/test/browser/request-manager.js
@@ -15,36 +15,8 @@
 /* global chai, workbox */
 
 'use strict';
-const testServerGen = require('../../../../utils/test-server-generator.js');
-const path = require('path');
-const fs = require('fs');
-const fsExtra = require('fs-extra');
-const IDBHelper = require('../../../../lib/idb-helper');
 describe('request-manager test', () => {
-  let tmpDirectory;
-  let testServer;
-  let baseTestUrl;
   let responseAchieved = 0;
-  before(function() {
-    tmpDirectory = fs.mkdtempSync(
-      path.join(__dirname, 'tmp-')
-    );
-
-    testServer = testServerGen();
-    return testServer.start(tmpDirectory, 5050)
-    .then((portNumber) => {
-      baseTestUrl = `http://localhost:${portNumber}`;
-    });
-  });
-
-  // Kill the web server once all tests are complete.
-  after(function() {
-    this.timeout(10 * 1000);
-
-    fsExtra.removeSync(tmpDirectory);
-
-    return testServer.stop();
-  });
   const callbacks = {
     onResponse: function() {
       responseAchieved ++;
@@ -54,7 +26,7 @@ describe('request-manager test', () => {
   let queue;
   let reqManager;
 
-  const idbHelper = new IDBHelper(
+  const idbHelper = new workbox.backgroundSync.test.IdbHelper(
     'bgQueueSyncDB', 1, 'QueueStore');
 
   before( (done) => {
@@ -88,8 +60,8 @@ describe('request-manager test', () => {
       = new workbox.backgroundSync.test.BackgroundSyncQueue({
         callbacks,
       });
-    await backgroundSyncQueue.pushIntoQueue({request: new Request(`${baseTestUrl}/__echo/counter`)});
-    await backgroundSyncQueue.pushIntoQueue({request: new Request(`${baseTestUrl}/__echo/counter`)});
+    await backgroundSyncQueue.pushIntoQueue({request: new Request('/__echo/counter')});
+    await backgroundSyncQueue.pushIntoQueue({request: new Request('/__echo/counter')});
     await backgroundSyncQueue._requestManager.replayRequests();
     chai.assert.equal(responseAchieved, 2);
   });

--- a/packages/workbox-background-sync/test/browser/request-manager.js
+++ b/packages/workbox-background-sync/test/browser/request-manager.js
@@ -15,9 +15,36 @@
 /* global chai, workbox */
 
 'use strict';
-
+const testServerGen = require('../../../../utils/test-server-generator.js');
+const path = require('path');
+const fs = require('fs');
+const fsExtra = require('fs-extra');
+const IDBHelper = require('../../../../lib/idb-helper');
 describe('request-manager test', () => {
+  let tmpDirectory;
+  let testServer;
+  let baseTestUrl;
   let responseAchieved = 0;
+  before(function() {
+    tmpDirectory = fs.mkdtempSync(
+      path.join(__dirname, 'tmp-')
+    );
+
+    testServer = testServerGen();
+    return testServer.start(tmpDirectory, 5050)
+    .then((portNumber) => {
+      baseTestUrl = `http://localhost:${portNumber}`;
+    });
+  });
+
+  // Kill the web server once all tests are complete.
+  after(function() {
+    this.timeout(10 * 1000);
+
+    fsExtra.removeSync(tmpDirectory);
+
+    return testServer.stop();
+  });
   const callbacks = {
     onResponse: function() {
       responseAchieved ++;
@@ -27,11 +54,15 @@ describe('request-manager test', () => {
   let queue;
   let reqManager;
 
+  const idbHelper = new IDBHelper(
+    'bgQueueSyncDB', 1, 'QueueStore');
+
   before( (done) => {
     const QUEUE_NAME = 'QUEUE_NAME';
     const MAX_AGE = 6;
     queue =
       new workbox.backgroundSync.test.RequestQueue({
+        idbQDb: idbHelper,
         config: {maxAge: MAX_AGE},
         queueName: QUEUE_NAME,
       });
@@ -57,8 +88,8 @@ describe('request-manager test', () => {
       = new workbox.backgroundSync.test.BackgroundSyncQueue({
         callbacks,
       });
-    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://localhost:3000/__echo/counter')});
-    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://localhost:3000/__echo/counter')});
+    await backgroundSyncQueue.pushIntoQueue({request: new Request(`${baseTestUrl}/__echo/counter`)});
+    await backgroundSyncQueue.pushIntoQueue({request: new Request(`${baseTestUrl}/__echo/counter`)});
     await backgroundSyncQueue._requestManager.replayRequests();
     chai.assert.equal(responseAchieved, 2);
   });

--- a/packages/workbox-background-sync/test/browser/request-manager.js
+++ b/packages/workbox-background-sync/test/browser/request-manager.js
@@ -57,8 +57,8 @@ describe('request-manager test', () => {
       = new workbox.backgroundSync.test.BackgroundSyncQueue({
         callbacks,
       });
-    await backgroundSyncQueue.pushIntoQueue({request: new Request('https://jsonplaceholder.typicode.com/posts/1')});
-    await backgroundSyncQueue.pushIntoQueue({request: new Request('https://jsonplaceholder.typicode.com/posts/2')});
+    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://localhost:3000/__echo/counter')});
+    await backgroundSyncQueue.pushIntoQueue({request: new Request('http://localhost:3000/__echo/counter')});
     await backgroundSyncQueue._requestManager.replayRequests();
     chai.assert.equal(responseAchieved, 2);
   });

--- a/packages/workbox-background-sync/test/browser/request-manager.js
+++ b/packages/workbox-background-sync/test/browser/request-manager.js
@@ -45,7 +45,9 @@ describe('request-manager test', () => {
   it('check constructor', () => {
     chai.assert.isObject(reqManager);
     chai.assert.isFunction(reqManager.attachSyncHandler);
+    chai.assert.isFunction(reqManager.replayRequest);
     chai.assert.isFunction(reqManager.replayRequests);
+
     chai.assert.equal(reqManager._globalCallbacks, callbacks);
     chai.assert.equal(reqManager._queue, queue);
   });

--- a/packages/workbox-background-sync/test/browser/request-queue.js
+++ b/packages/workbox-background-sync/test/browser/request-queue.js
@@ -15,12 +15,13 @@
 /* global chai, workbox */
 
 'use strict';
+const IDBHelper = require('../../../../lib/idb-helper');
 
 describe('request-queue tests', () => {
   const QUEUE_NAME = 'QUEUE_NAME';
   const MAX_AGE = 6;
-  const idbHelper = new workbox.backgroundSync.test.IdbHelper(
-      'bgQueueSyncDB', 1, 'QueueStore');
+  const idbHelper = new IDBHelper(
+    'bgQueueSyncDB', 1, 'QueueStore');
   let queue =
     new workbox.backgroundSync.test.RequestQueue({
       idbQDb: idbHelper,
@@ -54,8 +55,12 @@ describe('request-queue tests', () => {
   });
 
   it('default config is correct', () => {
-    let tempQueue = new workbox.backgroundSync.test.RequestQueue({});
-    let tempQueue2 = new workbox.backgroundSync.test.RequestQueue({});
+    let tempQueue = new workbox.backgroundSync.test.RequestQueue({
+      idbQDb: idbHelper,
+    });
+    let tempQueue2 = new workbox.backgroundSync.test.RequestQueue({
+      idbQDb: idbHelper,
+    });
     chai.assert.equal(tempQueue._config, undefined);
     chai.assert.equal(tempQueue._queueName,
       workbox.backgroundSync.test.Constants.defaultQueueName + '_0');

--- a/packages/workbox-background-sync/test/browser/request-queue.js
+++ b/packages/workbox-background-sync/test/browser/request-queue.js
@@ -19,8 +19,11 @@
 describe('request-queue tests', () => {
   const QUEUE_NAME = 'QUEUE_NAME';
   const MAX_AGE = 6;
+  const idbHelper = new workbox.backgroundSync.test.IdbHelper(
+      'bgQueueSyncDB', 1, 'QueueStore');
   let queue =
     new workbox.backgroundSync.test.RequestQueue({
+      idbQDb: idbHelper,
       config: {maxAge: MAX_AGE},
       queueName: QUEUE_NAME,
     });

--- a/packages/workbox-background-sync/test/browser/request-queue.js
+++ b/packages/workbox-background-sync/test/browser/request-queue.js
@@ -15,12 +15,11 @@
 /* global chai, workbox */
 
 'use strict';
-const IDBHelper = require('../../../../lib/idb-helper');
 
 describe('request-queue tests', () => {
   const QUEUE_NAME = 'QUEUE_NAME';
   const MAX_AGE = 6;
-  const idbHelper = new IDBHelper(
+  const idbHelper = new workbox.backgroundSync.test.IdbHelper(
     'bgQueueSyncDB', 1, 'QueueStore');
   let queue =
     new workbox.backgroundSync.test.RequestQueue({


### PR DESCRIPTION
R: @jeffposnick 

Fixes #597

After this PR if during the entire replay process any request fails, we'll be passing a rejected promise to `event.waitUntil` of `sync` event, so that browser can replay the failed requests