### PR TITLE
Support for unregistering routes & returning routes registered by workbox-sw

### DIFF
--- a/packages/workbox-routing/src/lib/router.js
+++ b/packages/workbox-routing/src/lib/router.js
@@ -248,6 +248,67 @@ class Router {
 
     this.registerRoutes({routes: [route]});
   }
+
+  /**
+   * Unregisters an array of routes with the router.
+   *
+   * @example
+   * const firstRoute = new RegExpRoute({ ... });
+   * const secondRoute = new RegExpRoute({ ... });
+   * router.registerRoutes({routes: [firstRoute, secondRoute]});
+   *
+   * // Later, if you no longer want the routes to be used:
+   * router.unregisterRoutes({routes: [firstRoute, secondRoute]});
+   *
+   * @param {Object} input
+   * @param {Array<module:workbox-routing.Route>} input.routes An array of
+   * routes to unregister.
+   */
+  unregisterRoutes({routes} = {}) {
+    isArrayOfClass({routes}, Route);
+
+    for (let route of routes) {
+      if (!this._routes.has(route.method)) {
+        logHelper.error({
+          that: this,
+          message: `Can't unregister route; there are no ${route.method}
+            routes registered.`,
+          data: {route},
+        });
+      }
+
+      const routeIndex = this._routes.get(route.method).indexOf(route);
+      if (routeIndex > -1) {
+        this._routes.get(route.method).splice(routeIndex, 1);
+      } else {
+        logHelper.error({
+          that: this,
+          message: `Can't unregister route; the route wasn't previously
+            registered.`,
+          data: {route},
+        });
+      }
+    }
+  }
+
+  /**
+   * Unregisters a single route with the router.
+   *
+   * @example
+   * const route = new RegExpRoute({ ... });
+   * router.registerRoute({route});
+   *
+   * // Later, if you no longer want the route to be used:
+   * router.unregisterRoute({route});
+   *
+   * @param {Object} input
+   * @param {module:workbox-routing.Route} input.route The route to unregister.
+   */
+  unregisterRoute({route} = {}) {
+    isInstance({route}, Route);
+
+    this.unregisterRoutes({routes: [route]});
+  }
 }
 
 export default Router;

--- a/packages/workbox-routing/test/sw/router.js
+++ b/packages/workbox-routing/test/sw/router.js
@@ -1,0 +1,59 @@
+importScripts('/__test/mocha/sw-utils.js');
+importScripts('/__test/bundle/workbox-routing');
+
+describe('Test of the Router class', function() {
+  const MATCH = () => {};
+  const HANDLER = () => {};
+
+  let globalStubs = [];
+  afterEach(function() {
+    globalStubs.forEach((stub) => stub.restore());
+    globalStubs = [];
+  });
+
+  it(`should call _addFetchListener() when Router() is called without any parameters`, function() {
+    const _addFetchListener = sinon.spy(workbox.routing.Router.prototype, '_addFetchListener');
+    globalStubs.push(_addFetchListener);
+
+    new workbox.routing.Router();
+    expect(_addFetchListener.calledOnce).to.be.true;
+  });
+
+  it(`should call _addFetchListener() when Router() is called with handleFetch: true`, function() {
+    const _addFetchListener = sinon.spy(workbox.routing.Router.prototype, '_addFetchListener');
+    globalStubs.push(_addFetchListener);
+
+    new workbox.routing.Router({handleFetch: true});
+    expect(_addFetchListener.calledOnce).to.be.true;
+  });
+
+  it(`should call _addFetchListener() when Router() is called with handleFetch: false`, function() {
+    const _addFetchListener = sinon.spy(workbox.routing.Router.prototype, '_addFetchListener');
+    globalStubs.push(_addFetchListener);
+
+    new workbox.routing.Router({handleFetch: false});
+    expect(_addFetchListener.calledOnce).to.be.false;
+  });
+
+  it(`should modify the internal arrays of routes when register/unregister is called`, function() {
+    const router = new workbox.routing.Router();
+
+    // Routes without an explicit method will default to GET.
+    const getRoute1 = new workbox.routing.Route({match: MATCH, handler: HANDLER});
+    const getRoute2 = new workbox.routing.Route({match: MATCH, handler: HANDLER, method: 'GET'});
+    const putRoute1 = new workbox.routing.Route({match: MATCH, handler: HANDLER, method: 'PUT'});
+    const putRoute2 = new workbox.routing.Route({match: MATCH, handler: HANDLER, method: 'PUT'});
+
+    router.registerRoute({route: getRoute1});
+    router.registerRoutes({routes: [getRoute2, putRoute1, putRoute2]});
+
+    expect(router._routes.get('GET')).to.have.members([getRoute1, getRoute2]);
+    expect(router._routes.get('PUT')).to.have.members([putRoute1, putRoute2]);
+
+    router.unregisterRoutes({routes: [getRoute2]});
+    router.unregisterRoute({route: putRoute2});
+
+    expect(router._routes.get('GET')).to.have.members([getRoute1]);
+    expect(router._routes.get('PUT')).to.have.members([putRoute1]);
+  });
+});

--- a/packages/workbox-sw/src/lib/router.js
+++ b/packages/workbox-sw/src/lib/router.js
@@ -82,6 +82,8 @@ class Router extends SWRoutingRouter {
    * @param {function|module:workbox-runtime-caching.Handler} handler The
    * handler to use to provide a response if the route matches. The handler
    * argument is ignored if you pass in a Route object, otherwise it's required.
+   * @return {module:workbox-routing.Route} The Route object that was
+   * registered.
    */
   registerRoute(capture, handler) {
     if (typeof handler === 'function') {
@@ -90,23 +92,22 @@ class Router extends SWRoutingRouter {
       };
     }
 
+    let route;
     if (typeof capture === 'string') {
       if (capture.length === 0) {
         throw ErrorFactory.createError('empty-express-string');
       }
-
-      super.registerRoute({
-        route: new ExpressRoute({path: capture, handler}),
-      });
+      route = new ExpressRoute({path: capture, handler});
     } else if (capture instanceof RegExp) {
-      super.registerRoute({
-        route: new RegExpRoute({regExp: capture, handler}),
-      });
+      route = new RegExpRoute({regExp: capture, handler});
     } else if (capture instanceof Route) {
-      super.registerRoute({route: capture});
+      route = capture;
     } else {
       throw ErrorFactory.createError('unsupported-route-type');
     }
+
+    super.registerRoute({route});
+    return route;
   }
 
   /**

--- a/packages/workbox-sw/test/sw/router.js
+++ b/packages/workbox-sw/test/sw/router.js
@@ -62,8 +62,8 @@ describe('Test workboxSW.router', function() {
     const exampleRoute = `/${date}/${fakeID}/test/`;
     const workboxSW = new WorkboxSW();
 
-    return new Promise((resolve, reject) => {
-      workboxSW.router.registerRoute(expressRoute, (args) => {
+    return new Promise((resolve) => {
+      const route = workboxSW.router.registerRoute(expressRoute, (args) => {
         (args.event instanceof FetchEvent).should.equal(true);
         args.url.toString().should.equal(new URL(exampleRoute, location).toString());
         Object.keys(args.params).length.should.equal(2);
@@ -72,6 +72,8 @@ describe('Test workboxSW.router', function() {
 
         resolve();
       });
+      expect(route).to.exist;
+
       const fetchEvent = new FetchEvent('fetch', {
         request: new Request(self.location.origin + exampleRoute),
       });
@@ -82,12 +84,12 @@ describe('Test workboxSW.router', function() {
 
   it('should be able to register a valid regex route', function() {
     const capturingGroup = 'test';
-    const regexRoute = /\/1234567890\/(\w+)\//;
+    const regExp = /\/1234567890\/(\w+)\//;
     const exampleRoute = `/1234567890/${capturingGroup}/`;
     const workboxSW = new WorkboxSW();
 
-    return new Promise((resolve, reject) => {
-      workboxSW.router.registerRoute(regexRoute, (args) => {
+    return new Promise((resolve) => {
+      const route = workboxSW.router.registerRoute(regExp, (args) => {
         (args.event instanceof FetchEvent).should.equal(true);
         args.url.toString().should.equal(new URL(exampleRoute, location).toString());
         args.params.length.should.equal(1);
@@ -95,6 +97,8 @@ describe('Test workboxSW.router', function() {
 
         resolve();
       });
+      expect(route).to.exist;
+
       const fetchEvent = new FetchEvent('fetch', {
         request: new Request(self.location.origin + exampleRoute),
       });


### PR DESCRIPTION
R: @addyosmani @gauntface

There weren't any existing unit tests for `Router`, so I added a few of those, too.

Fixes #390 
