### PR TITLE
Cleaner way to create generic Route instances via registerRoute()

### DIFF
--- a/packages/workbox-precaching/src/lib/controllers/base-cache-manager.js
+++ b/packages/workbox-precaching/src/lib/controllers/base-cache-manager.js
@@ -280,7 +280,7 @@ class BaseCacheManager {
    * @return {Promise} Returns a Promise that resolves once the work is done.
    */
   _onEntryDeleted(url) {
-    throw ErrorFactory.createError('should-override');
+    throw new WorkboxError('requires-overriding');
   }
 }
 

--- a/packages/workbox-sw/src/lib/error-factory.js
+++ b/packages/workbox-sw/src/lib/error-factory.js
@@ -17,8 +17,8 @@ import ErrorFactory from '../../../../lib/error-factory';
 
 const errors = {
   'not-in-sw': 'workbox-sw must be loaded in your service worker file.',
-  'unsupported-route-type': 'Routes must be either a express style route ' +
-    'string, a Regex to capture request URLs or a Route instance.',
+  'unsupported-route-type': 'The first parameter to registerRoute() should be' +
+    ' either an Express-style path string, a RegExp, or a function.',
   'empty-express-string': 'The Express style route string must have some ' +
     'characters, an empty string is invalid.',
   'bad-revisioned-cache-list': `The 'precache()' method expects` +

--- a/packages/workbox-sw/src/lib/workbox-sw.js
+++ b/packages/workbox-sw/src/lib/workbox-sw.js
@@ -24,7 +24,6 @@ import logHelper from '../../../../lib/log-helper';
 import {BroadcastCacheUpdatePlugin} from
   '../../../workbox-broadcast-cache-update/src/index.js';
 import {RevisionedCacheManager} from '../../../workbox-precaching/src/index.js';
-import {Route} from '../../../workbox-routing/src/index.js';
 import {
   getDefaultCacheName} from '../../../workbox-runtime-caching/src/index.js';
 

--- a/packages/workbox-sw/src/lib/workbox-sw.js
+++ b/packages/workbox-sw/src/lib/workbox-sw.js
@@ -303,29 +303,27 @@ class WorkboxSW {
       plugins,
     });
 
-    const route = new Route({
-      match: ({url}) => {
-        const cachedUrls = this._revisionedCacheManager.getCachedUrls();
-        if (cachedUrls.indexOf(url.href) !== -1) {
-          return true;
-        }
+    const capture = ({url}) => {
+      const cachedUrls = this._revisionedCacheManager.getCachedUrls();
+      if (cachedUrls.indexOf(url.href) !== -1) {
+        return true;
+      }
 
-        let strippedUrl =
-          this._removeIgnoreUrlParams(url.href, ignoreUrlParametersMatching);
-        if (cachedUrls.indexOf(strippedUrl.href) !== -1) {
-          return true;
-        }
+      let strippedUrl =
+        this._removeIgnoreUrlParams(url.href, ignoreUrlParametersMatching);
+      if (cachedUrls.indexOf(strippedUrl.href) !== -1) {
+        return true;
+      }
 
-        if (directoryIndex && strippedUrl.pathname.endsWith('/')) {
-          url.pathname += directoryIndex;
-          return cachedUrls.indexOf(url.href) !== -1;
-        }
+      if (directoryIndex && strippedUrl.pathname.endsWith('/')) {
+        url.pathname += directoryIndex;
+        return cachedUrls.indexOf(url.href) !== -1;
+      }
 
-        return false;
-      },
-      handler: cacheFirstHandler,
-    });
-    this.router.registerRoute(route);
+      return false;
+    };
+
+    this.router.registerRoute(capture, cacheFirstHandler);
   }
 
   /**

--- a/packages/workbox-sw/test/sw/router.js
+++ b/packages/workbox-sw/test/sw/router.js
@@ -134,7 +134,7 @@ describe('Test workboxSW.router', function() {
   it(`should use the valid method passed in to registerRoute()`, function() {
     const workboxSW = new WorkboxSW();
     const method = 'POST';
-    const route =workboxSW.router.registerRoute(/123/, () => {}, method);
+    const route = workboxSW.router.registerRoute(/123/, () => {}, method);
     expect(route.method).to.eql(method);
   });
 

--- a/packages/workbox-sw/test/sw/router.js
+++ b/packages/workbox-sw/test/sw/router.js
@@ -119,4 +119,28 @@ describe('Test workboxSW.router', function() {
     expect(thrownError).to.exist;
     expect(thrownError.name).to.equal('navigation-route-url-string');
   });
+
+  it(`should throw when the method passed in to registerRoute() isn't valid`, function() {
+    const workboxSW = new WorkboxSW();
+    try {
+      workboxSW.router.registerRoute(/123/, () => {}, 'INVALID_METHOD');
+      throw new Error();
+    } catch(error) {
+      expect(error.name).to.eql('assertion-failed',
+        `The expected assertion-failed error wasn't thrown.`);
+    }
+  });
+
+  it(`should use the valid method passed in to registerRoute()`, function() {
+    const workboxSW = new WorkboxSW();
+    const method = 'POST';
+    const route =workboxSW.router.registerRoute(/123/, () => {}, method);
+    expect(route.method).to.eql(method);
+  });
+
+  it(`should support calling registerRoute() with a function as the capture parameter`, function() {
+    const workboxSW = new WorkboxSW();
+    const route = workboxSW.router.registerRoute(() => {}, () => {});
+    expect(route).to.exist;
+  });
 });


### PR DESCRIPTION
R: @addyosmani @gauntface
CC: @jmtt89 @mikefowler

This is an alternative to https://github.com/GoogleChrome/workbox/pull/639, as discussed in that PR.

Fixes #385 and fixes #636