### PR TITLE
allow single string globIgnores as per JSDoc

### DIFF
--- a/packages/workbox-build/src/lib/generate-sw.js
+++ b/packages/workbox-build/src/lib/generate-sw.js
@@ -96,6 +96,9 @@ const generateSW = function(input) {
   }
 
   // Type check input so that defaults can be used if appropriate.
+  if (typeof input.globIgnores === 'string') {
+    input.globIgnores = [input.globIgnores];
+  }
   if (input.globIgnores && !(Array.isArray(input.globIgnores))) {
     return Promise.reject(
       new Error(errors['invalid-glob-ignores']));


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface 

JSDoc says we allow a single string for `globIgnores`, but we currently don't.