### PR TITLE
Support for registering non-GET via runtimeCaching

### DIFF
--- a/packages/workbox-build/src/lib/errors.js
+++ b/packages/workbox-build/src/lib/errors.js
@@ -77,8 +77,6 @@ module.exports = {
     `staticFileGlobs are set. Please fully migrate to globPatterns.`,
   'both-templated-urls-dynamic-urls': `Both templatedUrls and ` +
     `dynamicUrlToDependencies are set. Please fully migrate to templatedUrls.`,
-  'method-not-supported': `Using a method other than 'GET' in runtimeCaching is 
-    not supported.`,
   'urlPattern-is-required': `The urlPattern option is required when using
     runtimeCaching.`,
   'handler-is-required': `The handler option is required when using

--- a/packages/workbox-build/src/lib/utils/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/utils/runtime-caching-converter.js
@@ -39,9 +39,7 @@ function getOptionsString(options) {
 module.exports = (runtimeCaching) => {
   runtimeCaching = runtimeCaching || [];
   return runtimeCaching.map((entry) => {
-    if (entry.method && entry.method !== 'GET') {
-      throw new Error(errors['method-not-supported']);
-    }
+    const method = entry.method || 'GET';
 
     if (!entry.urlPattern) {
       throw new Error(errors['urlPattern-is-required']);
@@ -69,10 +67,10 @@ module.exports = (runtimeCaching) => {
         `workboxSW.strategies.${handlerName}(${optionsString})`;
 
       return `workboxSW.router.registerRoute(` +
-        `${matcher}, ${strategyString});`;
+        `${matcher}, ${strategyString}, '${method}');`;
     } else if (typeof entry.handler === 'function') {
       return `workboxSW.router.registerRoute(` +
-        `${matcher}, ${entry.handler});`;
+        `${matcher}, ${entry.handler}, '${method}');`;
     }
   }).filter((entry) => Boolean(entry)); // Remove undefined map() return values.
 };

--- a/packages/workbox-build/test/node/lib-write-sw.js
+++ b/packages/workbox-build/test/node/lib-write-sw.js
@@ -714,15 +714,15 @@ const fileManifest = [
 
 const workboxSW = new self.WorkboxSW();
 workboxSW.precache(fileManifest);
-workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.cacheFirst({}));
-workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.cacheOnly({}));
-workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.networkFirst({}));
-workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.networkOnly({}));
-workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.staleWhileRevalidate({}));
-workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.staleWhileRevalidate({}));
+workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.cacheFirst({}), 'GET');
+workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.cacheOnly({}), 'GET');
+workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.networkFirst({}), 'GET');
+workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.networkOnly({}), 'GET');
+workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.staleWhileRevalidate({}), 'GET');
+workboxSW.router.registerRoute(/^https:\\/\\/example\\.com\\/api/, workboxSW.strategies.staleWhileRevalidate({}), 'GET');
 workboxSW.router.registerRoute('/images/:size/:name.jpg', (request, values, options) => {
               return new Promise('params: ' + values.join(','));
-            });
+            }, 'GET');
 workboxSW.router.registerRoute(/\\/articles\\//, workboxSW.strategies.staleWhileRevalidate({
   "cacheName": "example-cache",
   "cacheExpiration": {
@@ -743,7 +743,7 @@ workboxSW.router.registerRoute(/\\/articles\\//, workboxSW.strategies.staleWhile
       "Example-Header-2": "Header-Value-2"
     }
   }
-}));
+}), 'GET');
 `;
     const writeSw = proxyquire('../../src/lib/write-sw', {
       'mkdirp': {

--- a/packages/workbox-build/test/node/utils-runtime-caching-converter.js
+++ b/packages/workbox-build/test/node/utils-runtime-caching-converter.js
@@ -38,6 +38,12 @@ function validate(runtimeCachingOptions, convertedOptions) {
     const registerRouteCall = globalScope.workboxSW.router.registerRoute.getCall(i);
     expect(registerRouteCall.args[0]).to.eql(runtimeCachingOption.urlPattern);
 
+    if (runtimeCachingOption.method) {
+      expect(registerRouteCall.args[2]).to.eql(runtimeCachingOption.method);
+    } else {
+      expect(registerRouteCall.args[2]).to.eql('GET');
+    }
+
     if (typeof runtimeCachingOption.handler === 'function') {
       // We can't make assumptions about what custom function handlers will do.
       return;
@@ -72,18 +78,6 @@ function validate(runtimeCachingOptions, convertedOptions) {
 }
 
 describe('src/lib/utils/runtime-caching-converter.js', function() {
-  it(`should throw when a method other than GET is used`, function() {
-    const runtimeCachingOptions = [{
-      urlPattern: /xyz/,
-      handler: 'cacheFirst',
-      method: 'POST',
-    }];
-
-    expect(() => {
-      runtimeCachingConverter(runtimeCachingOptions);
-    }).to.throw(errors['method-not-supported']);
-  });
-
   it(`should throw when urlPattern isn't set`, function() {
     const runtimeCachingOptions = [{
       handler: 'cacheFirst',
@@ -161,6 +155,17 @@ describe('src/lib/utils/runtime-caching-converter.js', function() {
     const runtimeCachingOptions = [{
       urlPattern: '/path/to/file',
       handler: () => {},
+    }];
+
+    const convertedOptions = runtimeCachingConverter(runtimeCachingOptions);
+    validate(runtimeCachingOptions, convertedOptions);
+  });
+
+  it(`should support registering non-GET methods`, function() {
+    const runtimeCachingOptions = [{
+      urlPattern: '/path/to/file',
+      handler: 'cacheFirst',
+      method: 'POST',
     }];
 
     const convertedOptions = runtimeCachingConverter(runtimeCachingOptions);


### PR DESCRIPTION
R: @addyosmani @gauntface
CC: @samthor 

Fixes #661

This follows from #644, since we can now support passing in non-GET methods via `workboxSW.registerRoute()`.