### PR TITLE
Moving lerna tasks out into seperate file and fixing tests

### DIFF
--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -19,8 +19,7 @@ const chalk = require('chalk');
 const fse = require('fs-extra');
 const gulp = require('gulp');
 const path = require('path');
-const runSequence = require('run-sequence');
-const {taskHarness, buildJSBundle, lernaWrapper} = require('../utils/build');
+const {taskHarness, buildJSBundle} = require('../utils/build');
 const commonjs = require('rollup-plugin-commonjs');
 const resolve = require('rollup-plugin-node-resolve');
 
@@ -48,28 +47,6 @@ const buildPackage = (projectPath) => {
     .then(() => fse.copy(path.join(__dirname, '..', 'LICENSE'),
       path.join(projectPath, 'LICENSE')))
     .then(() => printBuildTime(`${(Date.now() - startTime) / 1000}s`));
-};
-
-/**
- * Updates the fields in package.json that contain version string to match
- * the latest version from lerna.json.
- *
- * @param {String} projectPath The path to a project directory.
- * @return {Promise} Resolves if updating succeeds, and rejects if it fails.
- */
-const updateVersionedBundles = (projectPath) => {
-  const packageJsonPath = path.join(projectPath, 'package.json');
-
-  return fse.readJson(packageJsonPath).then((pkg) => {
-    const regexp = /v\d+\.\d+\.\d+/;
-    for (let field of ['main', 'module']) {
-      if (field in pkg) {
-        pkg[field] = pkg[field].replace(regexp, `v${pkg.version}`);
-      }
-    }
-
-    return fse.writeJson(packageJsonPath, pkg, {spaces: 2});
-  });
 };
 
 gulp.task('build:shared', () => {
@@ -117,53 +94,4 @@ gulp.task('build', () => {
 gulp.task('build:watch', ['build'], (unusedCallback) => {
   gulp.watch(`packages/${global.projectOrStar}/src/**/*`, ['build']);
   gulp.watch(`lib/**/*`, ['build']);
-});
-
-gulp.task('lerna-bootstrap', () => {
-  return lernaWrapper('bootstrap');
-});
-
-gulp.task('lerna-bootstrap-scoped', () => {
-  return lernaWrapper('bootstrap', '--include-filtered-dependencies', '--scope',
-    global.projectOrStar);
-});
-
-/**
- * Helper task, used only within lerna-publish.
- */
-gulp.task('_lerna-publish-dry-run', () => {
-  return lernaWrapper('publish', '--skip-npm', '--skip-git');
-});
-
-/**
- * Helper task, used only within lerna-publish.
- */
-gulp.task('_update-versioned-bundles', () => {
-  return taskHarness(updateVersionedBundles, global.projectOrStar);
-});
-
-/**
- * Helper task, used only within lerna-publish.
- */
-gulp.task('_lerna-publish-repo-version', () => {
-  return fse.readJson('lerna.json').then((lernaConfig) => {
-    return lernaWrapper('publish', '--yes', '--repo-version',
-      lernaConfig.version);
-  });
-});
-
-/**
- * This is the task you should use to publish a new release of updated
- * modules to npm.
- */
-gulp.task('lerna-publish', (callback) => {
-  runSequence(
-    'lerna-bootstrap',
-    'test:dev',
-    'test:prod',
-    '_lerna-publish-dry-run',
-    '_update-versioned-bundles',
-    '_lerna-publish-repo-version',
-    callback
-  );
 });

--- a/gulp-tasks/lerna.js
+++ b/gulp-tasks/lerna.js
@@ -1,0 +1,94 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/* eslint-disable no-console */
+
+const fse = require('fs-extra');
+const gulp = require('gulp');
+const path = require('path');
+const runSequence = require('run-sequence');
+
+const {taskHarness, lernaWrapper} = require('../utils/build');
+
+/**
+ * Updates the fields in package.json that contain version string to match
+ * the latest version from lerna.json.
+ *
+ * @param {String} projectPath The path to a project directory.
+ * @return {Promise} Resolves if updating succeeds, and rejects if it fails.
+ */
+const updateVersionedBundles = (projectPath) => {
+  const packageJsonPath = path.join(projectPath, 'package.json');
+
+  return fse.readJson(packageJsonPath).then((pkg) => {
+    const regexp = /v\d+\.\d+\.\d+/;
+    for (let field of ['main', 'module']) {
+      if (field in pkg) {
+        pkg[field] = pkg[field].replace(regexp, `v${pkg.version}`);
+      }
+    }
+
+    return fse.writeJson(packageJsonPath, pkg, {spaces: 2});
+  });
+};
+
+gulp.task('lerna-bootstrap', () => {
+  return lernaWrapper('bootstrap');
+});
+
+gulp.task('lerna-bootstrap-scoped', () => {
+  return lernaWrapper('bootstrap', '--include-filtered-dependencies', '--scope',
+    global.projectOrStar);
+});
+
+/**
+ * Helper task, used only within lerna-publish.
+ */
+gulp.task('_lerna-publish-dry-run', () => {
+  return lernaWrapper('publish', '--skip-npm', '--skip-git');
+});
+
+/**
+ * Helper task, used only within lerna-publish.
+ */
+gulp.task('_update-versioned-bundles', () => {
+  return taskHarness(updateVersionedBundles, global.projectOrStar);
+});
+
+/**
+ * Helper task, used only within lerna-publish.
+ */
+gulp.task('_lerna-publish-repo-version', () => {
+  return fse.readJson('lerna.json').then((lernaConfig) => {
+    return lernaWrapper('publish', '--yes', '--repo-version',
+      lernaConfig.version);
+  });
+});
+
+/**
+ * This is the task you should use to publish a new release of updated
+ * modules to npm.
+ */
+gulp.task('lerna-publish', (callback) => {
+  runSequence(
+    'lerna-bootstrap',
+    'test:dev',
+    'test:prod',
+    '_lerna-publish-dry-run',
+    '_update-versioned-bundles',
+    '_lerna-publish-repo-version',
+    callback
+  );
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,6 +35,7 @@ global.projectOrStar = options.project || '*';
 global.cliOptions = options;
 
 require('./gulp-tasks/lint.js');
+require('./gulp-tasks/lerna.js');
 require('./gulp-tasks/build.js');
 require('./gulp-tasks/test.js');
 require('./gulp-tasks/serve.js');

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
   "lerna": "2.0.0-rc.5",
+  "version": "1.0.1",
   "packages": [
     "packages/*"
   ]

--- a/packages/workbox-precaching/test/sw/revisioned-caching.js
+++ b/packages/workbox-precaching/test/sw/revisioned-caching.js
@@ -139,7 +139,8 @@ describe('sw/revisioned-caching()', function() {
       if (!caughtError) {
         throw new Error('Expected file manifest to cause an error.');
       }
-      caughtError.message.indexOf(`The 'revision' parameter has the wrong type`).should.equal(0);
+
+      caughtError.message.indexOf(`The 'revision' parameter has the wrong type`).should.not.equal(-1);
     });
   });
 


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

Publishing is currently broken for test:dev. This PR also pulls out the available lerna tasks to a seperate file and resets the current lerna version.