### PR TITLE
Enable testing on supported versions of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
     - ~/.selenium-assistant
 
 node_js:
+  - '4'
+  - '6'
   - 'stable'
 
 env:


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

Should be merged before #670

This enables tests on Travis for Node 4, 6 and latest version of node (8.X)
