### PR TITLE
Fixes a bug with cacheFirst handler + maxAgeSeconds + CORS request

### DIFF
--- a/packages/workbox-cache-expiration/src/lib/cache-expiration-plugin.js
+++ b/packages/workbox-cache-expiration/src/lib/cache-expiration-plugin.js
@@ -47,14 +47,15 @@ class CacheExpirationPlugin extends CacheExpiration {
    *
    * @private
    * @param {Object} input
+   * @param {string} input.cacheName Name of the cache the responses belong to.
    * @param {Response} input.cachedResponse The `Response` object that's been
    *        read from a cache and whose freshness should be checked.
    * @param {Number} [input.now] A timestamp. Defaults to the current time.
-   * @return {Response|null} Either the `cachedResponse`, if it's fresh, or
-   *          `null` if the `Response` is older than `maxAgeSeconds`.
+   * @return {Promise<Response|null>} Either the `cachedResponse`, if it's
+   *         fresh, or `null` if the `Response` is older than `maxAgeSeconds`.
    */
-  cacheWillMatch({cachedResponse, now} = {}) {
-    if (this.isResponseFresh({cachedResponse, now})) {
+  async cacheWillMatch({cacheName, cachedResponse, now} = {}) {
+    if (await this.isResponseFresh({cacheName, cachedResponse, now})) {
       return cachedResponse;
     }
 

--- a/packages/workbox-cache-expiration/src/lib/cache-expiration-plugin.js
+++ b/packages/workbox-cache-expiration/src/lib/cache-expiration-plugin.js
@@ -51,11 +51,11 @@ class CacheExpirationPlugin extends CacheExpiration {
    * @param {Response} input.cachedResponse The `Response` object that's been
    *        read from a cache and whose freshness should be checked.
    * @param {Number} [input.now] A timestamp. Defaults to the current time.
-   * @return {Promise<Response|null>} Either the `cachedResponse`, if it's
+   * @return {Response} Either the `cachedResponse`, if it's
    *         fresh, or `null` if the `Response` is older than `maxAgeSeconds`.
    */
-  async cacheWillMatch({cacheName, cachedResponse, now} = {}) {
-    if (await this.isResponseFresh({cacheName, cachedResponse, now})) {
+  cacheWillMatch({cacheName, cachedResponse, now} = {}) {
+    if (this.isResponseFresh({cacheName, cachedResponse, now})) {
       return cachedResponse;
     }
 

--- a/packages/workbox-cache-expiration/src/lib/cache-expiration.js
+++ b/packages/workbox-cache-expiration/src/lib/cache-expiration.js
@@ -161,11 +161,17 @@ class CacheExpiration {
         }
 
         const parsedDate = new Date(dateHeader);
+        const headerTime = parsedDate.getTime();
         // If the Date header was invalid for some reason, parsedDate.getTime()
-        // will return NaN, and the comparison will always be false. We want
-        // invalid dates to be treated as fresh. In order to ensure this
-        // behavior, we need to return the negation of this comparison.
-        return !((parsedDate.getTime() + (this.maxAgeSeconds * 1000)) < now);
+        // will return NaN. We want to treat that as a fresh response, since we
+        // assume fresh unless proven otherwise.
+        if (isNaN(headerTime)) {
+          return true;
+        }
+
+        // If we have a valid headerTime, then our response is fresh iff the
+        // headerTime plus maxAgeSeconds is greater than the current time.
+        return (headerTime + (this.maxAgeSeconds * 1000)) > now;
       } else {
         // TODO (jeffposnick): Change this method interface to be async, and
         // check for the IDB for the specific URL in order to determine

--- a/packages/workbox-cache-expiration/src/lib/cache-expiration.js
+++ b/packages/workbox-cache-expiration/src/lib/cache-expiration.js
@@ -131,21 +131,22 @@ class CacheExpiration {
    * be used.
    *
    * @param {Object} input
+   * @param {string} input.cacheName Name of the cache the responses belong to.
    * @param {Response} input.cachedResponse The `Response` object that's been
    *        read from a cache and whose freshness should be checked.
    * @param {Number} [input.now] A timestamp.
    *
    * Defaults to the current time.
-   * @return {boolean} Either `true` if the response is fresh, or `false` if the
-   * `Response` is older than `maxAgeSeconds` and should no longer be
-   * used.
+   * @return {Promise<boolean>} Either `true` if the response is fresh, or
+   * `false` if the `Response` is older than `maxAgeSeconds` and should no
+   * longer be used.
    *
    * @example
    * expirationPlugin.isResponseFresh({
    *   cachedResponse: responseFromCache
    * });
    */
-  isResponseFresh({cachedResponse, now} = {}) {
+  async isResponseFresh({cacheName, cachedResponse, now} = {}) {
     // Only bother checking for freshness if we have a valid response and if
     // maxAgeSeconds is set. Otherwise, skip the check and always return true.
     if (cachedResponse && this.maxAgeSeconds) {
@@ -165,6 +166,8 @@ class CacheExpiration {
           // Only return false if all the conditions are met.
           return false;
         }
+      } else {
+        await this.expireEntries({cacheName, now});
       }
     }
 

--- a/packages/workbox-cache-expiration/src/lib/cache-expiration.js
+++ b/packages/workbox-cache-expiration/src/lib/cache-expiration.js
@@ -137,7 +137,7 @@ class CacheExpiration {
    * @param {Number} [input.now] A timestamp.
    *
    * Defaults to the current time.
-   * @return {Promise<boolean>} Either `true` if the response is fresh, or
+   * @return {boolean} Either `true` if the response is fresh, or
    * `false` if the `Response` is older than `maxAgeSeconds` and should no
    * longer be used.
    *
@@ -146,7 +146,7 @@ class CacheExpiration {
    *   cachedResponse: responseFromCache
    * });
    */
-  async isResponseFresh({cacheName, cachedResponse, now} = {}) {
+  isResponseFresh({cacheName, cachedResponse, now} = {}) {
     // Only bother checking for freshness if we have a valid response and if
     // maxAgeSeconds is set. Otherwise, skip the check and always return true.
     if (cachedResponse && this.maxAgeSeconds) {
@@ -167,7 +167,7 @@ class CacheExpiration {
           return false;
         }
       } else {
-        await this.expireEntries({cacheName, now});
+        this.expireEntries({cacheName, now});
       }
     }
 

--- a/packages/workbox-cache-expiration/test/browser/end-to-end.js
+++ b/packages/workbox-cache-expiration/test/browser/end-to-end.js
@@ -37,4 +37,34 @@ describe(`End to End Test of Cache Expiration`, function() {
 
     expect(keys).to.have.length(EXPECTED_CACHE_SIZE);
   });
+
+  it(`should work properly when a cache-first strategy + maxAgeSeconds is used, and responses lack a Date header`, async function() {
+    const iframe = await goog.swUtils.controlledBySW(
+      '/packages/workbox-cache-expiration/test/static/cache-first-max-age-seconds.js');
+
+    const currentUrl = new URL(location);
+    const nextPort = parseInt(currentUrl.port) + 1;
+    const corsOrigin = `${currentUrl.protocol}//${currentUrl.hostname}:${nextPort}`;
+    const testUrl = new URL('/__echo/cors-no-cache/test', corsOrigin);
+
+    const firstResponse = await iframe.contentWindow.fetch(testUrl);
+    const firstResponseBody = await firstResponse.text();
+
+    // The service worker should be using a maxAgeSeconds of 1, so skip ahead
+    // 1.1 seconds. We can't use sinon's fake clock here, since we need a
+    // consistent clock between the iframe's scope and the service worker scope.
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    const secondResponse = await iframe.contentWindow.fetch(testUrl);
+    const secondResponseBody = await secondResponse.text();
+    // Since we're using a cache-first policy, the expiration happens after the
+    // previous entry had already been read from cache. So the first and second
+    // responses should be the same.
+    expect(firstResponseBody).to.eql(secondResponseBody);
+
+    const thirdResponse = await iframe.contentWindow.fetch(testUrl);
+    const thirdResponseBody = await thirdResponse.text();
+    // By the time the third response is read, the cache expiration will have
+    // completed, so this one should be different.
+    expect(firstResponseBody).not.to.eql(thirdResponseBody);
+  });
 });

--- a/packages/workbox-cache-expiration/test/browser/end-to-end.js
+++ b/packages/workbox-cache-expiration/test/browser/end-to-end.js
@@ -45,6 +45,7 @@ describe(`End to End Test of Cache Expiration`, function() {
   it(`should work properly when a cache-first strategy + maxAgeSeconds is used, and responses lack a Date header`, async function() {
     // See the comment later about a source of potential flakiness.
     this.retries(2);
+    this.timeout(6 * 1000);
 
     const iframe = await goog.swUtils.controlledBySW(
       '/packages/workbox-cache-expiration/test/static/cache-first-max-age-seconds.js');

--- a/packages/workbox-cache-expiration/test/browser/end-to-end.js
+++ b/packages/workbox-cache-expiration/test/browser/end-to-end.js
@@ -6,6 +6,10 @@ describe(`End to End Test of Cache Expiration`, function() {
 
   beforeEach(() => goog.swUtils.cleanState());
 
+  async function asyncDelay(seconds) {
+    await new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+  }
+
   it(`should work properly when there are many simultaneous requests`, async function() {
     const iframe = await goog.swUtils.controlledBySW(
       '/packages/workbox-cache-expiration/test/static/cache-expiration.js');
@@ -39,6 +43,9 @@ describe(`End to End Test of Cache Expiration`, function() {
   });
 
   it(`should work properly when a cache-first strategy + maxAgeSeconds is used, and responses lack a Date header`, async function() {
+    // See the comment later about a source of potential flakiness.
+    this.retries(2);
+
     const iframe = await goog.swUtils.controlledBySW(
       '/packages/workbox-cache-expiration/test/static/cache-first-max-age-seconds.js');
 
@@ -51,9 +58,9 @@ describe(`End to End Test of Cache Expiration`, function() {
     const firstResponseBody = await firstResponse.text();
 
     // The service worker should be using a maxAgeSeconds of 1, so skip ahead
-    // 1.1 seconds. We can't use sinon's fake clock here, since we need a
+    // 1.5 seconds. We can't use sinon's fake clock here, since we need a
     // consistent clock between the iframe's scope and the service worker scope.
-    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await asyncDelay(1.5);
     const secondResponse = await iframe.contentWindow.fetch(testUrl);
     const secondResponseBody = await secondResponse.text();
     // Since we're using a cache-first policy, the expiration happens after the
@@ -61,6 +68,9 @@ describe(`End to End Test of Cache Expiration`, function() {
     // responses should be the same.
     expect(firstResponseBody).to.eql(secondResponseBody);
 
+    // POTENTIALLY FLAKY: Wait another 2 seconds, after which point the cache
+    // expiration logic will have hopefully completed.
+    await asyncDelay(2);
     const thirdResponse = await iframe.contentWindow.fetch(testUrl);
     const thirdResponseBody = await thirdResponse.text();
     // By the time the third response is read, the cache expiration will have

--- a/packages/workbox-cache-expiration/test/static/cache-first-max-age-seconds.js
+++ b/packages/workbox-cache-expiration/test/static/cache-first-max-age-seconds.js
@@ -1,0 +1,23 @@
+importScripts('/__test/bundle/workbox-runtime-caching');
+importScripts('/__test/bundle/workbox-cache-expiration');
+
+self.addEventListener('install', (event) => event.waitUntil(self.skipWaiting()));
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));
+
+const cacheExpirationPlugin= new workbox.cacheExpiration.CacheExpirationPlugin({
+  maxAgeSeconds: 1,
+});
+const requestWrapper = new workbox.runtimeCaching.RequestWrapper({
+  cacheName: 'cache-first-max-age-seconds',
+  plugins: [cacheExpirationPlugin],
+});
+const handler = new workbox.runtimeCaching.CacheFirst({
+  requestWrapper,
+  waitOnCache: true,
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.url.includes('/__echo/cors-no-cache')) {
+    event.respondWith(handler.handle({event}));
+  }
+});

--- a/packages/workbox-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/workbox-runtime-caching/src/lib/request-wrapper.js
@@ -175,7 +175,7 @@ class RequestWrapper {
 
     if (this.plugins.has('cacheWillMatch')) {
       const plugin = this.plugins.get('cacheWillMatch')[0];
-      cachedResponse = await plugin.cacheWillMatch({
+      cachedResponse = plugin.cacheWillMatch({
         request, cache, cachedResponse,
         matchOptions: this.matchOptions, cacheName: this.cacheName,
       });

--- a/packages/workbox-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/workbox-runtime-caching/src/lib/request-wrapper.js
@@ -175,8 +175,10 @@ class RequestWrapper {
 
     if (this.plugins.has('cacheWillMatch')) {
       const plugin = this.plugins.get('cacheWillMatch')[0];
-      cachedResponse = plugin.cacheWillMatch({request, cache, cachedResponse,
-        matchOptions: this.matchOptions});
+      cachedResponse = await plugin.cacheWillMatch({
+        request, cache, cachedResponse,
+        matchOptions: this.matchOptions, cacheName: this.cacheName,
+      });
     }
 
     return cachedResponse;

--- a/utils/server-instance.js
+++ b/utils/server-instance.js
@@ -54,6 +54,14 @@ class ServerInstance {
       res.send(`${req.params.file}-${Date.now()}`);
     });
 
+    this._app.all('/__echo/cors-no-cache/:file', function(req, res) {
+      res.setHeader('Access-Control-Allow-Methods',
+        'POST, GET, PUT, DELETE, OPTIONS');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.send(`${req.params.file}-${Date.now()}`);
+    });
+
     this._app.all('/__echo/date-with-cors/:file', function(req, res) {
       res.setHeader('Access-Control-Allow-Methods',
         'POST, GET, PUT, DELETE, OPTIONS');


### PR DESCRIPTION
R: @addyosmani @gauntface
CC: @pbakaus

Fixes #691

This fixes a bug that would prevent a response used in a cache-first handler from properly triggering `maxAgeSeconds`-based expiration iff that response lacked a `Date:` header. A CORS-response without the `Date:` header specifically whitelisted via [`Access-Control-Expose-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Expose-Headers) could trigger this scenario, as @pbakaus encountered.

This also changes the method signature of the `cacheWillMatch` lifecycle callback to be `async` (i.e. return a `Promise`), since we now want to wait for it to complete before returning a cached response to the client (to ensure that any expiration that's necessary gets performed). That should (arguably) be considered a breaking change, since `cacheWillMatch` is part of the public interface.