### PR TITLE
Allowing registerNavigationRoute to accept a match function.

### DIFF
--- a/packages/workbox-routing/test/sw/navigation-route.js
+++ b/packages/workbox-routing/test/sw/navigation-route.js
@@ -7,11 +7,13 @@ describe('Test of the NavigationRoute class', function() {
   const blacklist = [new RegExp(path)];
   const handler = {handle: () => {}};
   const event = {request: {mode: 'navigate'}};
+  const match = (path) => path.startsWith('/test');
 
   const invalidHandler = {};
   const invalidBlacklist = 'invalid';
   const invalidWhitelist = 'invalid';
   const invalidEvent = {request: {mode: 'cors'}};
+
 
   it(`should throw when NavigationRoute() is called without any parameters`, function() {
     let thrownError = null;
@@ -101,5 +103,17 @@ describe('Test of the NavigationRoute class', function() {
     const url = new URL(path, location);
     const route = new workbox.routing.NavigationRoute({handler, whitelist});
     expect(route.match({event: invalidEvent, url})).to.not.be.ok;
+  });
+
+  it(`should match navigation requests for URLs who match the function`, function() {
+    const url = new URL(path, location);
+    const route = new workbox.routing.NavigationRoute({handler, match});
+    expect(route.match({event, url})).to.be.ok;
+  });
+
+  it(`should not match navigation requests for URLs that do not match the function`, function() {
+    const url = new URL('/does/not/match', location);
+    const route = new workbox.routing.NavigationRoute({handler, match});
+    expect(route.match({event, url})).to.not.be.ok;
   });
 });

--- a/packages/workbox-sw/src/lib/router.js
+++ b/packages/workbox-sw/src/lib/router.js
@@ -132,6 +132,10 @@ class Router extends SWRoutingRouter {
    * @param {Array<RegExp>} [options.blacklist] Defaults to an empty blacklist.
    * @param {Array<RegExp>} [options.whitelist] Defaults to `[/./]`, which will
    *        match all request URLs.
+   * @param {function} [options.match] A function which is used to determine
+   *        if the current path is matched. This can be used with the whitelist
+   *        param. If you are using an external router, you can use this option
+   *        to hook into the routers matcher.
    * @param {String} [options.cacheName] The name of the cache which contains
    *        the cached response for `url`. Defaults to the name of the cache
    *        used by precache().
@@ -151,6 +155,7 @@ class Router extends SWRoutingRouter {
       handler: () => caches.match(url, {cacheName}),
       whitelist: options.whitelist || [/./],
       blacklist: options.blacklist || [],
+      match: options.match || ((path) => true),
     })});
   }
 }


### PR DESCRIPTION
This feature allows registerNavigationRoute to accept a function to
determine whether the navigation event should be rendered from the
shell. This is particularly useful if you are using some sort of isomorphic
routing tool (such as react-routes or clojurescript/bidi), and want to
reuse the matching library provided.

R: @jeffposnick @addyosmani @gauntface