### PR TITLE
Add all of workbox-sw's devDependencies to fix Lerna's versioning.

### DIFF
--- a/packages/workbox-sw/package.json
+++ b/packages/workbox-sw/package.json
@@ -22,5 +22,13 @@
   "bugs": "https://github.com/googlechrome/workbox/issues",
   "homepage": "https://github.com/GoogleChrome/workbox/tree/master/packages/workbox-sw",
   "main": "build/importScripts/workbox-sw.prod.v1.1.0.js",
-  "module": "build/modules/workbox-sw.prod.v1.1.0.mjs"
+  "module": "build/modules/workbox-sw.prod.v1.1.0.mjs",
+  "devDependencies": {
+    "workbox-broadcast-cache-update": "^1.1.0",
+    "workbox-cache-expiration": "^1.2.0",
+    "workbox-cacheable-response": "^1.1.0",
+    "workbox-precaching": "^1.2.0",
+    "workbox-routing": "^1.1.0",
+    "workbox-runtime-caching": "^1.2.0"
+  }
 }


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #703 

I *think* this is the right approach to ensure that Lerna properly bumps the `workbox-sw` version whenever any of the packages that it depends on also changes. We'll see if that's actually the case when I do a patch-level publish right after merging this.

Any feedback about whether I should be doing this different is appreciated.