### PR TITLE
fixed: bug that causes passed in manifestTransforms not to run

### DIFF
--- a/packages/workbox-build/src/lib/utils/filter-files.js
+++ b/packages/workbox-build/src/lib/utils/filter-files.js
@@ -76,7 +76,7 @@ module.exports = (fileDetails, options) => {
     };
   });
 
-  const manifestTransforms = [];
+  let manifestTransforms = [];
 
   if (options.modifyUrlPrefix) {
     manifestTransforms.push(modifyUrlPrefixTranform(options.modifyUrlPrefix));
@@ -89,7 +89,9 @@ module.exports = (fileDetails, options) => {
 
   if (options.manifestTransforms) {
     if (Array.isArray(options.manifestTransforms)) {
-      manifestTransforms.concat(options.manifestTransforms);
+      manifestTransforms = manifestTransforms.concat(
+        options.manifestTransforms
+      );
     } else {
       throw new Error(errors['bad-manifest-transforms']);
     }


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

Fixes issue of custom `manifestTransforms` never being ran as described here: https://github.com/GoogleChrome/workbox/pull/712/files#r131218250

If you'd rather fix it as part of the other PR feel free to close this one, just figured I'd throw it out there if you folks wanted to fix this in a hurry. 