### PR TITLE
Fix for multiple cacheId prefixes in the precache handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,18 @@
   "name": "workbox",
   "version": "0.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "accepts": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
@@ -1729,8 +1740,8 @@
       "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.1",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.1.1",
@@ -2535,7 +2546,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extendable": "0.1.1"
+      }
     },
     "external-editor": {
       "version": "2.0.4",
@@ -3721,15 +3735,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3739,6 +3744,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4619,7 +4633,10 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
       "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "has-gulplog": {
       "version": "0.1.0",
@@ -5289,16 +5306,6 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "jsprim": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
@@ -5908,12 +5915,26 @@
       "resolved": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
       "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
       "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "async-array-reduce": "0.2.1",
+        "extend-shallow": "2.0.1",
+        "fs-exists-sync": "0.1.0",
+        "glob": "7.1.2",
+        "has-glob": "0.1.1",
+        "is-valid-glob": "0.3.0",
+        "lazy-cache": "2.0.2",
+        "resolve-dir": "0.1.1"
+      },
       "dependencies": {
         "lazy-cache": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "set-getter": "0.1.0"
+          }
         }
       }
     },
@@ -7370,7 +7391,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-multi-entry/-/rollup-plugin-multi-entry-2.0.1.tgz",
       "integrity": "sha1-Szrqjdxa/Jt/n/v7FEHATvOQcbQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "matched": "0.4.4"
+      }
     },
     "rollup-plugin-node-resolve": {
       "version": "3.0.0",
@@ -7698,7 +7722,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "to-object-path": "0.3.0"
+      }
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -7985,15 +8012,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
@@ -8001,6 +8019,15 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -8316,7 +8343,10 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "tough-cookie": {
       "version": "2.3.2",

--- a/packages/workbox-sw/src/lib/strategies.js
+++ b/packages/workbox-sw/src/lib/strategies.js
@@ -187,6 +187,9 @@ class Strategies {
    * @private
    * @param {Class} HandlerClass The class to be configured and instantiated.
    * @param {Object} [options] Options to configure the handler.
+   * @param {boolean} [options.excludeCacheId] If true, we assume that
+   * options.cacheName already includes the cacheId, and it does not need to
+   * be specified twice.
    * @return {Handler} A handler instance configured with the appropriate
    * behaviours
    */
@@ -199,8 +202,11 @@ class Strategies {
 
     const wrapperOptions = {
       plugins: [],
-      cacheId: this._cacheId,
     };
+
+    if (!options.excludeCacheId) {
+      wrapperOptions.cacheId = this._cacheId;
+    }
 
     if (options['cacheName']) {
       wrapperOptions['cacheName'] = options['cacheName'];

--- a/packages/workbox-sw/src/lib/workbox-sw.js
+++ b/packages/workbox-sw/src/lib/workbox-sw.js
@@ -300,6 +300,12 @@ class WorkboxSW {
     const cacheFirstHandler = this.strategies.cacheFirst({
       cacheName: this._revisionedCacheManager.getCacheName(),
       plugins,
+      // this._revisionedCacheManager.getCacheName() already includes a cacheId
+      // prefix if the developer set one. We want to tell the cacheFirst()
+      // factory method to exclude the cacheId to ensure that it doesn't prepend
+      // the cacheId twice when it determines its cache name.
+      // See https://github.com/GoogleChrome/workbox/issues/714
+      excludeCacheId: true,
     });
 
     const capture = ({url}) => {

--- a/packages/workbox-sw/test/sw/cache-id.js
+++ b/packages/workbox-sw/test/sw/cache-id.js
@@ -49,12 +49,28 @@ describe(`Cache ID`, function() {
     workboxSW.runtimeCacheName.indexOf(CACHE_ID).should.not.equal(-1);
   });
 
-  it(`should honor {excludeCacheId: true} when creating a strategy`, function() {
+  it(`should honor an explicit {excludeCacheId: true} when creating a strategy`, function() {
     const cacheId = 'CACHE_ID';
 
     const workboxSW = new WorkboxSW({cacheId});
 
     const strategy = workboxSW.strategies.cacheFirst({excludeCacheId: true});
     expect(strategy.requestWrapper.cacheName).not.to.have.string(cacheId);
+  });
+
+  // See https://github.com/GoogleChrome/workbox/issues/714
+  it(`should only prepend the cacheId once when creating the internal precaching route`, function() {
+    const cacheId = 'CACHE_ID';
+    const expectedCachePrefix = `${cacheId}-workbox-precaching-revisioned`;
+
+    const workboxSW = new WorkboxSW({cacheId});
+    // We need to poke around a bit at the internals to get the route we care
+    // about; it's not possible to spy on the method calls and check parameters,
+    // since they're called during the WorkboxSW constructor and are called on
+    // object instances that don't exist prior to the constructor.
+    const precacheRoute = workboxSW.router._routes.get('GET')[0];
+    const actualCacheName = precacheRoute.handler.requestWrapper.cacheName;
+
+    expect(actualCacheName.startsWith(expectedCachePrefix)).to.be.true;
   });
 });

--- a/packages/workbox-sw/test/sw/cache-id.js
+++ b/packages/workbox-sw/test/sw/cache-id.js
@@ -34,4 +34,13 @@ describe(`Cache ID`, function() {
     workboxSW._revisionedCacheManager.getCacheName().indexOf(CACHE_ID).should.not.equal(-1);
     workboxSW.runtimeCacheName.indexOf(CACHE_ID).should.not.equal(-1);
   });
+
+  it(`should honor {excludeCacheId: true} when creating a strategy`, function() {
+    const cacheId = 'CACHE_ID';
+
+    const workboxSW = new WorkboxSW({cacheId});
+
+    const strategy = workboxSW.strategies.cacheFirst({excludeCacheId: true});
+    expect(strategy.requestWrapper.cacheName).not.to.have.string(cacheId);
+  });
 });


### PR DESCRIPTION
R: @addyosmani @gauntface 
CC: @HenrikJoreteg @liuruoran88

This fixes #714 by explicitly changing the method call inside of `WorkboxSW` to indicate that for the internal `CacheOnly` handler use for precached requests, `cacheId` shouldn't be prepended when determining the corresponding cache name.

I decided to go with that approach rather than making a chance in the `RequestWrapper` constructor that checked to see if `cacheId` was already present in the `cacheName`, since you could theoretically imagine calling

```js
new RequestWrapper({
  cacheName: 'my-prefix',
  cacheId: 'my-prefix',
}});
```

In that situation, the user would expect the effective cache name to be `'my-prefix-my-prefix'`, and we'd want to still allow that.