### PR TITLE
V3 Analyse Browser Bundles

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,22 +26,26 @@ module.exports = {
     },
   }, {
     files: [
-      'gulp-tasks/utils/log-helper.js',
       'packages/workbox-core/src/utils/LogHelper.js',
       'packages/workbox-core/test/bundle/node/utils/test-LogHelper.js',
+      'gulp-tasks/utils/log-helper.js',
+      'infra/tools/analyse-properties.js',
     ],
     rules: {
       'no-console': 0,
     },
   }, {
-    files: ['gulp-tasks/**/*.js'],
+    files: [
+      'gulp-tasks/**/*.js',
+      'infra/tools/analyse-properties.js'
+    ],
     rules: {
       'valid-jsdoc': 0,
       'require-jsdoc': 0,
     },
   }, {
     files: [
-      'infra/utils/generate-variant-tests.js'
+      'infra/utils/generate-variant-tests.js',
     ],
     env: {
       'mocha': true

--- a/gulp-tasks/analyze-properties.js
+++ b/gulp-tasks/analyze-properties.js
@@ -1,0 +1,14 @@
+const gulp = require('gulp');
+
+const AnalyseBuildForProperties = require('../infra/tools/analyse-properties');
+
+gulp.task('analyze-properties:run', async () => {
+  const analysisTool = new AnalyseBuildForProperties();
+  const results = await analysisTool.run();
+  results.forEach((entry) => {
+    analysisTool.printDetails(entry);
+  });
+});
+
+gulp.task('analyze-properties',
+  gulp.series(['build', 'analyze-properties:run']));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,6 @@
 const minimist = require('minimist');
 const fs = require('fs');
 const path = require('path');
-const glob = require('glob');
 
 const options = minimist(process.argv.slice(2));
 
@@ -35,8 +34,18 @@ global.port = options.port || 3000;
 global.packageOrStar = options.package || '*';
 global.cliOptions = options;
 
-const gulpTaskFiles = glob.sync('./gulp-tasks/*.js');
+// Forward referencing means the order of gulp-task
+// requires is important
+const gulpTaskFiles = [
+  'build-packages',
+  'build-test-bundles',
+  'build',
+  'lint',
+  'test',
+  'analyze-properties',
+];
+
 gulpTaskFiles.forEach((gulpTaskFile) => {
   // Requiring will be enough to register the tasks with gulp.
-  require(gulpTaskFile);
+  require(path.join(__dirname, 'gulp-tasks', gulpTaskFile));
 });

--- a/infra/tools/analyse-properties.js
+++ b/infra/tools/analyse-properties.js
@@ -1,0 +1,104 @@
+/**
+ * This file should be run as a node script to analyse the content of the
+ * browser bundles.
+ *
+ * It's an extremely naive approach to picking property names out and seeing
+ * how often they are used in the final browser bundles. This can be
+ * used to detect variable names that are long and used repeatedly meaning
+ * that a small refactor allowing `uglify-es` to mangle these properties,
+ * could lead to reasonable improvement in final bundle size.
+ *
+ * This is very rough and vague. It needs to be run manually and if it's not
+ * used can and should be removed from Workbox repo.
+ */
+const glob = require('glob');
+const path = require('path');
+const fs = require('fs-extra');
+
+const PROPERTY_REGEX = /\.(\w+)/g;
+
+class AnalyseBuildForProperties {
+  run() {
+    const filePaths = this.getBuildFiles();
+    return Promise.all(filePaths.map((filePath) => {
+      const rawAnalysis = this.analyzeFile(filePath);
+      const analysis = this.tidyData(rawAnalysis);
+
+      return {
+        filePath,
+        analysis,
+      };
+    }));
+  }
+
+  getBuildFiles() {
+    const buildGlob = path.join(__dirname, '..', '..', 'packages',
+      '*', 'build', 'browser-bundles', '*.js');
+    return glob.sync(buildGlob);
+  }
+
+  analyzeFile(filePath) {
+    const fileContents = fs.readFileSync(filePath).toString();
+
+    const matches = {};
+
+    let result;
+    while (result = PROPERTY_REGEX.exec(fileContents)) {
+      const resultKey = result[1];
+      if (!matches[resultKey]) {
+        matches[resultKey] = 0;
+      }
+      matches[resultKey]++;
+    }
+
+    return Object.keys(matches).map((matchKey) => {
+      return {
+        propertyName: matchKey,
+        propertyCount: matches[matchKey],
+      };
+    });
+  }
+
+  tidyData(analysisEntries) {
+    return analysisEntries.filter((entry) => {
+      // If there is only one entry or it's a single character it's
+      // either not important or it's already been minified.
+      return entry.propertyCount > 1 && entry.propertyName.length > 1;
+    })
+    .sort((a, b) => {
+      return b.propertyCount - a.propertyCount;
+    });
+  }
+
+  printDetails({filePath, analysis}) {
+    let longestPropertyName = 0;
+    analysis.forEach((entry) => {
+      if (entry.propertyName.length > longestPropertyName) {
+        longestPropertyName = entry.propertyName.length;
+      }
+    });
+
+    console.log();
+    console.log(`Results for '${path.relative(process.cwd(), filePath)}'`);
+    console.log();
+
+    analysis.forEach((entry) => {
+      const numberOfSpaces = longestPropertyName - entry.propertyName.length;
+      const extraSpace = ' '.repeat(numberOfSpaces);
+      console.log(`    ${entry.propertyName} ` +
+        `${extraSpace} ${entry.propertyCount}`);
+    });
+      console.log();
+  }
+}
+
+const analysisTool = new AnalyseBuildForProperties();
+analysisTool.run()
+.then((results) => {
+  results.forEach((entry) => {
+    analysisTool.printDetails(entry);
+  });
+})
+.catch((err) => {
+  console.error(err);
+});

--- a/infra/tools/analyse-properties.js
+++ b/infra/tools/analyse-properties.js
@@ -14,8 +14,7 @@
 const glob = require('glob');
 const path = require('path');
 const fs = require('fs-extra');
-
-const PROPERTY_REGEX = /\.(\w+)/g;
+const babylon = require('babylon');
 
 class AnalyseBuildForProperties {
   run() {
@@ -40,16 +39,21 @@ class AnalyseBuildForProperties {
   analyzeFile(filePath) {
     const fileContents = fs.readFileSync(filePath).toString();
 
+    const parsedCode = babylon.parse(fileContents);
+    const tokens = parsedCode.tokens;
+    const nameTokens = tokens.filter((token) => {
+      return token.type.label === 'name';
+    });
+
     const matches = {};
 
-    let result;
-    while (result = PROPERTY_REGEX.exec(fileContents)) {
-      const resultKey = result[1];
-      if (!matches[resultKey]) {
-        matches[resultKey] = 0;
+    nameTokens.forEach((token) => {
+      const variableName = token.value;
+      if (!matches[variableName]) {
+        matches[variableName] = 0;
       }
-      matches[resultKey]++;
-    }
+      matches[variableName]++;
+    });
 
     return Object.keys(matches).map((matchKey) => {
       return {

--- a/infra/tools/analyse-properties.js
+++ b/infra/tools/analyse-properties.js
@@ -15,10 +15,6 @@ const glob = require('glob');
 const path = require('path');
 const fs = require('fs-extra');
 const babylon = require('babylon');
-const gulp = require('gulp');
-
-// Load up the gulpfile.
-require(path.join(__dirname, '..', '..', 'gulpfile.js'));
 
 class AnalyseBuildForProperties {
   run() {
@@ -100,24 +96,4 @@ class AnalyseBuildForProperties {
   }
 }
 
-new Promise((resolve, reject) => {
-  gulp.task('build')((err, results) => {
-    if (err) {
-      return reject(err);
-    }
-
-    resolve();
-  });
-})
-.then(() => {
-  const analysisTool = new AnalyseBuildForProperties();
-  analysisTool.run()
-  .then((results) => {
-    results.forEach((entry) => {
-      analysisTool.printDetails(entry);
-    });
-  });
-})
-.catch((err) => {
-  console.error(err);
-});
+module.exports = AnalyseBuildForProperties;

--- a/infra/tools/analyse-properties.js
+++ b/infra/tools/analyse-properties.js
@@ -15,6 +15,10 @@ const glob = require('glob');
 const path = require('path');
 const fs = require('fs-extra');
 const babylon = require('babylon');
+const gulp = require('gulp');
+
+// Load up the gulpfile.
+require(path.join(__dirname, '..', '..', 'gulpfile.js'));
 
 class AnalyseBuildForProperties {
   run() {
@@ -96,11 +100,22 @@ class AnalyseBuildForProperties {
   }
 }
 
-const analysisTool = new AnalyseBuildForProperties();
-analysisTool.run()
-.then((results) => {
-  results.forEach((entry) => {
-    analysisTool.printDetails(entry);
+new Promise((resolve, reject) => {
+  gulp.task('build')((err, results) => {
+    if (err) {
+      return reject(err);
+    }
+
+    resolve();
+  });
+})
+.then(() => {
+  const analysisTool = new AnalyseBuildForProperties();
+  analysisTool.run()
+  .then((results) => {
+    results.forEach((entry) => {
+      analysisTool.printDetails(entry);
+    });
   });
 })
 .catch((err) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4409,9 +4409,9 @@
       "dev": true
     },
     "pr-bot": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/pr-bot/-/pr-bot-0.1.0.tgz",
-      "integrity": "sha512-Xtg6rh5H09suVoFYVd3Z+5LGsMuyUrbKAq6zOGVHOZe7/KLPYaLf/GNZl6AsReP9o6OhI12j4NHuh3zmc2YmvQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pr-bot/-/pr-bot-0.1.1.tgz",
+      "integrity": "sha512-fKn/r0+l57hR9/lNQKgbwhYg1hLqEnCJJQ1xk1fFeKFD88CKRvgtPY/GZYjO0m23Yyi56FPCcp2BXEpV40qERg==",
       "dev": true,
       "requires": {
         "chalk": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -412,6 +412,12 @@
         "regenerator-runtime": "0.10.5"
       }
     },
+    "babylon": {
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+      "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw==",
+      "dev": true
+    },
     "bach": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/GoogleChrome/workbox#readme",
   "devDependencies": {
+    "babylon": "^6.17.4",
     "chai": "^4.1.0",
     "chalk": "^2.0.1",
     "common-tags": "^1.4.0",


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

Here it comes . . . . . . I promise I'm not crazy :-/

![giphy 4](https://user-images.githubusercontent.com/139760/29193774-8cf9f244-7ddb-11e7-98f3-c9a9ea63a1f0.gif)

This is a tool that pulls out property names and function names. The idea being that if we have a tonne of variables being used that are public or not marked as private, the minifier is unable to rename it. This means the end file size will be larger than it needs to be.

I have no idea if this will be used going forward or not. But after manually going through some of the workbox-core code's and refactor slightly to shave off bundle size ~850 bytes to ~ 750 bytes. Moving forward with much larger code, I suspect that this **might** be useful.

I'd like to keep this in the infra directory just in case it does proof handy and I've added a comment to remove if it doesn't get used / isn't useful.

It filters out words which are only reference once in the source (i.e. public functions / properties) and will exclude single character variables names from the output. Currently we have all variables stripped apart from our namespace which occurs several times to initialize the namespace.

```shell
$ gulp build && node ./infra/tools/analyse-properties.js 
[14:57:41] Using gulpfile ~/Projects/Code/workbox/gulpfile.js
[14:57:41] Starting 'build'...
[14:57:41] Starting 'lerna-bootstrap'...
lerna info version 2.0.0
lerna info Bootstrapping 1 packages
lerna info lifecycle preinstall
lerna info Symlinking packages and binaries
lerna info lifecycle postinstall
lerna info lifecycle prepublish
lerna success Bootstrapped 1 packages
[14:57:43] Finished 'lerna-bootstrap' after 2.02 s
[14:57:43] Finished 'build' after 2.02 s

Results for 'packages/workbox-core/build/browser-bundles/workbox-core.dev.js'

    google   5
    workbox  3


Results for 'packages/workbox-core/build/browser-bundles/workbox-core.production.js'

    google   5
    workbox  3


```