### PR TITLE
Move towards using 'workbox' over 'workbox-cli'.

### DIFF
--- a/packages/workbox-cli/package.json
+++ b/packages/workbox-cli/package.json
@@ -12,7 +12,8 @@
     "cli"
   ],
   "bin": {
-    "workbox-cli": "build/bin.js"
+    "workbox-cli": "build/bin.js",
+    "workbox": "build/bin.js"
   },
   "files": [
     "build"

--- a/packages/workbox-cli/src/bin.js
+++ b/packages/workbox-cli/src/bin.js
@@ -21,6 +21,16 @@ const meow = require('meow');
 const cliHelpText = require('./cli-help');
 const CLI = require('./index.js');
 
+/* eslint-disable no-console */
+// argv[0] is the path to the node runtime.
+// argv[1] is the path to the script that node is running.
+if (process.argv[1].endsWith('workbox-cli')) {
+  console.warn(`Please run the command line tool as 'workbox' instead of ` +
+    `'workbox-cli'.\n'workbox-cli' will stop working in the next major ` +
+    `release.\n(See: https://github.com/GoogleChrome/workbox/issues/730)`);
+}
+/* eslint-enable no-console */
+
 const cliInstance = new CLI();
 const meowOutput = meow(cliHelpText);
 cliInstance.argv(meowOutput);

--- a/packages/workbox-cli/src/cli-help.js
+++ b/packages/workbox-cli/src/cli-help.js
@@ -1,5 +1,5 @@
 module.exports = `Usage:
-    workbox-cli [command] [options]
+    workbox [command] [options]
 
 Commands:
 
@@ -9,4 +9,4 @@ Commands:
 Options
 
     -h --help               Show this help text.
-    -v --version            Show current version of workbox-cli`;
+    -v --version            Show current version of workbox`;

--- a/packages/workbox-cli/test/static/example-cli-command/example-command.txt
+++ b/packages/workbox-cli/test/static/example-cli-command/example-command.txt
@@ -1,4 +1,4 @@
-workbox-cli --cacheId 'input-cache-id' --clientsClaim true --directoryIndex '/example-index.html' --handleFetch false --maximumFileSizeToCacheInBytes 2000 --navigateFallback /shell --skipWaiting true
+workbox --cacheId 'input-cache-id' --clientsClaim true --directoryIndex '/example-index.html' --handleFetch false --maximumFileSizeToCacheInBytes 2000 --navigateFallback /shell --skipWaiting true
 
 
   --dontCacheBustUrlsMatching /./

--- a/packages/workbox-sw/src/index.js
+++ b/packages/workbox-sw/src/index.js
@@ -30,7 +30,7 @@ import WorkboxSW from './lib/workbox-sw';
  * @example <caption>Caching assets and registering routes.</caption>
  *
  * // DO NOT CREATE THIS MANIFEST OR EDIT IT MANUALLY!!
- * // Use workbox-build or workbox-cli to generate the manifest for you.
+ * // Use workbox-build or the workbox CLI to generate the manifest for you.
  * const workboxSW = new WorkboxSW();
  * workboxSW.precache([
  *   {

--- a/packages/workbox-sw/src/lib/workbox-sw.js
+++ b/packages/workbox-sw/src/lib/workbox-sw.js
@@ -158,7 +158,7 @@ class WorkboxSW {
    *
    * // ...precache() can also take objects to cache
    * // non-revisioned URLs.
-   * // Please use workbox-build or workbox-cli to generate the manifest for
+   * // Please use workbox-build or the workbox CLI to generate the manifest for
    * // you.
    * workboxSW.precache([
    *     {


### PR DESCRIPTION
R: @addyosmani @gauntface

I've added `workbox` as an additional alias for the CLI. `workbox-cli` is still supported, but there's a console warning logged when it's used with additional context. I've also updated a few places where `workbox-cli` was referenced in comments.

This is the first part of #730, for inclusion in the upcoming `v2.0.0` release.