### PR TITLE
use strict to support Node 4

### DIFF
--- a/packages/workbox-build/src/lib/utils/get-file-details.js
+++ b/packages/workbox-build/src/lib/utils/get-file-details.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const glob = require('glob');
 const path = require('path');
 

--- a/packages/workbox-build/src/lib/utils/no-revision-for-urls-matching-transform.js
+++ b/packages/workbox-build/src/lib/utils/no-revision-for-urls-matching-transform.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const errors = require('../errors');
 
 module.exports = (regexp) => {


### PR DESCRIPTION
> /home/travis/build/twbs/bootstrap/node_modules/workbox-build/build/lib/utils/get-file-details.js:9
  let globbedFiles;
  ^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode

build failed on node 4, due to "let".
this should fix it!