### PR TITLE
Adding fixes to the range requests

### DIFF
--- a/packages/workbox-range-requests/src/index.js
+++ b/packages/workbox-range-requests/src/index.js
@@ -14,7 +14,6 @@
 */
 
 /**
- * @module workbox-range-requests
  * # workbox-range-requests
  *
  * A helper library that instructs a service worker respond to HTTP requests
@@ -36,6 +35,8 @@
  *
  * - https://github.com/jakearchibald/range-request-test/blob/master/static/sw.js
  * - https://github.com/GoogleChrome/sample-media-pwa/blob/master/src/client/scripts/ranged-response.js
+ *
+ * @module workbox-range-requests
  */
 
 import handleRangeRequest from './lib/handle-range-request.js';

--- a/packages/workbox-range-requests/src/lib/cached-range-response-plugin.js
+++ b/packages/workbox-range-requests/src/lib/cached-range-response-plugin.js
@@ -16,8 +16,6 @@
 import handleRangeRequest from './handle-range-request.js';
 
 /**
- * @memberof module:workbox-range-requests
- *
  * This class is meant to be automatically invoked as a plugin to a
  * {@link module:workbox-runtime-caching.RequestWrapper|RequestWrapper}, which
  * is used by the `workbox-sw` and `workbox-runtime-caching` modules. If you
@@ -26,6 +24,8 @@ import handleRangeRequest from './handle-range-request.js';
  *
  * Under the hood, this will call `handleRangeRequest()`, passing
  * in the appropriate request and response objects.
+ *
+
  *
  * @example
  * const workboxSW = new WorkboxSW();

--- a/packages/workbox-range-requests/src/lib/handle-range-request.js
+++ b/packages/workbox-range-requests/src/lib/handle-range-request.js
@@ -18,8 +18,6 @@ import logHelper from '../../../../lib/log-helper.js';
 import {isType, isInstance} from '../../../../lib/assert.js';
 
 /**
- * @memberof module:workbox-range-requests
- *
  * The public function `handleRangeRequest()` takes a `Request` and `Response`
  * object as input, and returns one of two things:
  *
@@ -50,6 +48,8 @@ import {isType, isInstance} from '../../../../lib/assert.js';
  *     );
  *   }
  * });
+ *
+ * @memberof module:workbox-range-requests
  */
 
 /**


### PR DESCRIPTION

R: @jeffposnick @addyosmani @philipwalton 

Current docs for range-request plugin are making jsdocs cranky :( 

Just needed to move the `@module` definition to below the comment.