### PR TITLE
V3 globals

### DIFF
--- a/gulp-tasks/build-packages.js
+++ b/gulp-tasks/build-packages.js
@@ -32,11 +32,11 @@ const ERROR_NO_NAMSPACE = oneLine`
 const testObjectValueExists = (object, nestedPath) => {
   const pieces = nestedPath.split('.');
   let currentRoot = object;
-  for (let i = 0; i < pieces.length; i++) {
-    if (!currentRoot[pieces[i]]) {
+  for (const piece of pieces) {
+    if (!currentRoot[piece]) {
       return false;
     }
-    currentRoot = currentRoot[pieces[i]];
+    currentRoot = currentRoot[piece];
   }
   return true;
 };

--- a/gulp-tasks/build-packages.js
+++ b/gulp-tasks/build-packages.js
@@ -33,7 +33,7 @@ const testObjectValueExists = (object, nestedPath) => {
   const pieces = nestedPath.split('.');
   let currentRoot = object;
   for (let i = 0; i < pieces.length; i++) {
-    if (!currentRoot.piece) {
+    if (!currentRoot[pieces[i]]) {
       return false;
     }
     currentRoot = object[pieces[i]];

--- a/gulp-tasks/build-packages.js
+++ b/gulp-tasks/build-packages.js
@@ -88,7 +88,7 @@ const buildPackage = (packagePath, buildType) => {
   // scope and replace references with the core namespace
   const globals = (moduleId) => {
     // This regex matches for (workbox-*)(/any/path/here.mjs)
-    const workboxModuleIdRegex = /(workbox-\w*)([\/\w\.]*)*/g;
+    const workboxModuleIdRegex = /(workbox-\w*)([/\w.]*)*/g;
     const result = workboxModuleIdRegex.exec(moduleId);
     if (!result) {
       throw new Error(`Unknown global module ID: ${moduleId}`);

--- a/gulp-tasks/build-packages.js
+++ b/gulp-tasks/build-packages.js
@@ -181,7 +181,7 @@ const buildPackage = (packagePath, buildType) => {
     entry: browserEntryPath,
     format: 'iife',
     moduleName: namespace,
-    // sourceMap: true,
+    sourceMap: true,
     globals,
     external,
     plugins,

--- a/gulp-tasks/build-packages.js
+++ b/gulp-tasks/build-packages.js
@@ -32,12 +32,12 @@ const ERROR_NO_NAMSPACE = oneLine`
 const testObjectValueExists = (object, nestedPath) => {
   const pieces = nestedPath.split('.');
   let currentRoot = object;
-  pieces.forEach((piece) => {
+  for (let i = 0; i < pieces.length; i++) {
     if (!currentRoot.piece) {
       return false;
     }
-    currentRoot = object[piece];
-  });
+    currentRoot = object[pieces[i]];
+  }
   return true;
 };
 
@@ -103,8 +103,8 @@ const buildPackage = (packagePath, buildType) => {
       }
     }
 
-    // Get a packages browser namespace so we know where it will be
-    // ont he global scope (i.e. google.workbox.????)
+    // Get a package's browserNamespace so we know where it will be
+    // on the global scope (i.e. google.workbox.????)
     let browserNamespace = null;
     const packagePath = path.join(__dirname, '..', 'packages', packageName);
     try {
@@ -119,9 +119,9 @@ const buildPackage = (packagePath, buildType) => {
 
     let globalNamespace = `${constants.NAMESPACE_PREFIX}.${browserNamespace}`;
     let fileNamespace = '';
-    // If the module pulls in a specific files we'll need to add this
-    // to the namespace. i.e. workbox-core/internal/logHelper should
-    // become google.workbox.core.internal.logHelper.
+    // If a module pulls in a specific file the namespace will need to
+    // include this information. i.e. workbox-core/internal/logHelper should
+    // become google.workbox.core.internal.logHelper
     if (importFilePath) {
       // Glob for the file we want so that file extensions are automatically
       // searched for.

--- a/gulp-tasks/build-packages.js
+++ b/gulp-tasks/build-packages.js
@@ -36,7 +36,7 @@ const testObjectValueExists = (object, nestedPath) => {
     if (!currentRoot[pieces[i]]) {
       return false;
     }
-    currentRoot = object[pieces[i]];
+    currentRoot = currentRoot[pieces[i]];
   }
   return true;
 };

--- a/packages/workbox-core/index.mjs
+++ b/packages/workbox-core/index.mjs
@@ -10,6 +10,7 @@ class WorkboxCore {
   constructor() {
     this.INTERNAL = {
       logHelper: new LogHelper(),
+      precaching,
     };
   }
 }

--- a/packages/workbox-core/index.mjs
+++ b/packages/workbox-core/index.mjs
@@ -10,7 +10,6 @@ class WorkboxCore {
   constructor() {
     this.INTERNAL = {
       logHelper: new LogHelper(),
-      precaching,
     };
   }
 }

--- a/packages/workbox-core/package.json
+++ b/packages/workbox-core/package.json
@@ -16,7 +16,9 @@
   "scripts": {
     "prepublish": "gulp build-packages --package workbox-core"
   },
-  "workbox::browserNamespace": "core",
+  "workbox": {
+    "browserNamespace": "core"
+  },
   "main": "build/browser-bundles/workbox-core.prod.js",
   "module": "index.mjs"
 }

--- a/packages/workbox-core/package.json
+++ b/packages/workbox-core/package.json
@@ -6,7 +6,7 @@
   "description": "This module is used by a number of the other workboxjs.org modules to share common code.",
   "repository": "googlechrome/workbox",
   "bugs": "https://github.com/googlechrome/workbox/issues",
-  "homepage": "https://github.com/GoogleChrome/workbox/tree/master/packages/workbox-core",
+  "homepage": "https://github.com/GoogleChrome/workbox",
   "keywords": [
     "workbox",
     "workboxjs",


### PR DESCRIPTION
R: @jeffposnick @addyosmani @philipwalton 

My previous PR would generate the browser bundle. This PR changes rollup to dynamically mark modules and external modules and will dynamically replace the module import with a global namespace value.

This should be the last piece of infra to support the proposed build flow in: https://github.com/GoogleChrome/workbox/wiki/V3-:-ES2015-Modules-&-Browser-Bundles.

I'll look at CommonJS ASAP.
