### PR TITLE
Tweaking tests to not use the iife

### DIFF
--- a/test/workbox-routing/node/normalizeHandler.mjs
+++ b/test/workbox-routing/node/normalizeHandler.mjs
@@ -1,83 +1,99 @@
+import clearRequire from 'clear-require';
 import makeServiceWorkerEnv from 'service-worker-mock';
 import {expect} from 'chai';
 
 import expectError from '../../../infra/utils/expectError.js';
 
-(async () => {
-  Object.assign(global, makeServiceWorkerEnv());
+Object.assign(global, makeServiceWorkerEnv());
 
-  const normalizeHandler = (await import('../../../packages/workbox-routing/lib/normalizeHandler.mjs')).default;
+const handler = {
+  handle: () => {},
+};
+const functionHandler = () => {};
 
-  const handler = {
-    handle: () => {},
-  };
-  const functionHandler = () => {};
+const invalidHandlerObject = {};
+const invalidHandlerString = 'INVALID';
 
-  const invalidHandlerObject = {};
-  const invalidHandlerString = 'INVALID';
+describe(`workbox-routing: _normalizeHandler`, function() {
+  const initialNodeEnv = process.env.NODE_ENV;
 
-  describe(`workbox-routing: _normalizeHandler`, function() {
-    const initialNodeEnv = process.env.NODE_ENV;
-    after(function() {
-      process.env.NODE_ENV = initialNodeEnv;
+  after(function() {
+    process.env.NODE_ENV = initialNodeEnv;
+  });
+
+  describe(`(NODE_ENV = development)`, function() {
+    let normalizeHandler;
+
+    before(async function() {
+      process.env.NODE_ENV = 'development';
+
+      clearRequire.all();
+
+      // We need to import after setting the NODE_ENV so workbox-core also
+      // gets the correct NODE_ENV
+      const normalizeModule = await import('../../../packages/workbox-routing/lib/normalizeHandler.mjs');
+      normalizeHandler = normalizeModule.default;
     });
 
-    describe(`(NODE_ENV = development)`, function() {
-      before(function() {
-        process.env.NODE_ENV = 'development';
-      });
-
-      it(`should properly normalize an object that exposes a handle method`, async function() {
-        const normalizedHandler = normalizeHandler(handler);
-        expect(normalizedHandler).to.have.property('handle');
-      });
-
-      it(`should properly normalize a function`, async function() {
-        const normalizedHandler = normalizeHandler(functionHandler);
-        expect(normalizedHandler).to.have.property('handle');
-      });
-
-      it(`should throw when called with an object that doesn't expose a handle method`, async function() {
-        await expectError(
-          () => normalizeHandler(invalidHandlerObject),
-          'missing-a-method',
-          (error) => {
-            expect(error.details).to.have.property('moduleName').that.equals('workbox-routing');
-            expect(error.details).to.have.property('className').that.equals('Route');
-            expect(error.details).to.have.property('funcName').that.equals('constructor');
-            expect(error.details).to.have.property('paramName').that.equals('handler');
-          }
-        );
-      });
-
-      it(`should throw when called with something other than a function or an object`, async function() {
-        await expectError(
-          () => normalizeHandler(invalidHandlerString),
-          'incorrect-type',
-          (error) => {
-            expect(error.details).to.have.property('moduleName').that.equals('workbox-routing');
-            expect(error.details).to.have.property('className').that.equals('Route');
-            expect(error.details).to.have.property('funcName').that.equals('constructor');
-            expect(error.details).to.have.property('paramName').that.equals('handler');
-          }
-        );
-      });
+    it(`should properly normalize an object that exposes a handle method`, function() {
+      const normalizedHandler = normalizeHandler(handler);
+      expect(normalizedHandler).to.have.property('handle');
     });
 
-    describe(`(NODE_ENV = production)`, function() {
-      before(function() {
-        process.env.NODE_ENV = 'production';
-      });
+    it(`should properly normalize a function`, async function() {
+      const normalizedHandler = normalizeHandler(functionHandler);
+      expect(normalizedHandler).to.have.property('handle');
+    });
 
-      it(`should properly normalize an object that exposes a handle method`, async function() {
-        const normalizedHandler = normalizeHandler(handler);
-        expect(normalizedHandler).to.have.property('handle');
-      });
+    it(`should throw when called with an object that doesn't expose a handle method`, function() {
+      return expectError(
+        () => normalizeHandler(invalidHandlerObject),
+        'missing-a-method',
+        (error) => {
+          expect(error.details).to.have.property('moduleName').that.equals('workbox-routing');
+          expect(error.details).to.have.property('className').that.equals('Route');
+          expect(error.details).to.have.property('funcName').that.equals('constructor');
+          expect(error.details).to.have.property('paramName').that.equals('handler');
+        }
+      );
+    });
 
-      it(`should properly normalize a function`, async function() {
-        const normalizedHandler = normalizeHandler(functionHandler);
-        expect(normalizedHandler).to.have.property('handle');
-      });
+    it(`should throw when called with something other than a function or an object`, function() {
+      return expectError(
+        () => normalizeHandler(invalidHandlerString),
+        'incorrect-type',
+        (error) => {
+          expect(error.details).to.have.property('moduleName').that.equals('workbox-routing');
+          expect(error.details).to.have.property('className').that.equals('Route');
+          expect(error.details).to.have.property('funcName').that.equals('constructor');
+          expect(error.details).to.have.property('paramName').that.equals('handler');
+        }
+      );
     });
   });
-})();
+
+  describe(`(NODE_ENV = production)`, function() {
+    let normalizeHandler;
+
+    before(async function() {
+      process.env.NODE_ENV = 'production';
+
+      clearRequire.all();
+
+      // We need to import after setting the NODE_ENV so workbox-core also
+      // gets the correct NODE_ENV
+      const normalizeModule = await import('../../../packages/workbox-routing/lib/normalizeHandler.mjs');
+      normalizeHandler = normalizeModule.default;
+    });
+
+    it(`should properly normalize an object that exposes a handle method`, function() {
+      const normalizedHandler = normalizeHandler(handler);
+      expect(normalizedHandler).to.have.property('handle');
+    });
+
+    it(`should properly normalize a function`, function() {
+      const normalizedHandler = normalizeHandler(functionHandler);
+      expect(normalizedHandler).to.have.property('handle');
+    });
+  });
+});

--- a/test/workbox-routing/node/route.mjs
+++ b/test/workbox-routing/node/route.mjs
@@ -1,131 +1,143 @@
+import clearRequire from 'clear-require';
 import makeServiceWorkerEnv from 'service-worker-mock';
 import {expect} from 'chai';
 
 import expectError from '../../../infra/utils/expectError.js';
 
-(async () => {
-  Object.assign(global, makeServiceWorkerEnv());
-  const Route = (await import('../../../packages/workbox-routing/lib/Route.mjs')).default;
+Object.assign(global, makeServiceWorkerEnv());
 
-  const match = () => {};
-  const handler = {
-    handle: () => {},
-  };
-  const functionHandler = () => {};
-  const method = 'POST';
+const match = () => {};
+const handler = {
+  handle: () => {},
+};
+const functionHandler = () => {};
+const method = 'POST';
 
-  const invalidHandlerObject = {};
-  const invalidMethod = 'INVALID';
+const invalidHandlerObject = {};
+const invalidMethod = 'INVALID';
 
-  describe(`workbox-routing: Route`, function() {
-    const initialNodeEnv = process.env.NODE_ENV;
-    after(function() {
-      process.env.NODE_ENV = initialNodeEnv;
+describe(`workbox-routing: Route`, function() {
+  const initialNodeEnv = process.env.NODE_ENV;
+  after(function() {
+    process.env.NODE_ENV = initialNodeEnv;
+  });
+
+  describe(`(NODE_ENV = development)`, function() {
+    let Route;
+
+    before(async function() {
+      process.env.NODE_ENV = 'development';
+
+      clearRequire.all();
+
+      const RouteModule = await import('../../../packages/workbox-routing/lib/Route.mjs');
+      Route = RouteModule.default;
     });
 
-    describe(`(NODE_ENV = development)`, function() {
-      before(function() {
-        process.env.NODE_ENV = 'development';
-      });
-
-      it(`should throw when called without any parameters`, async function() {
-        await expectError(
-          () => new Route(),
-          'incorrect-type',
-          (error) => {
-            expect(error.details).to.have.property('moduleName').that.equals('workbox-routing');
-            expect(error.details).to.have.property('className').that.equals('Route');
-            expect(error.details).to.have.property('funcName').that.equals('constructor');
-          }
-        );
-      });
-
-      it(`should throw when called without a valid handler parameter`, async function() {
-        await expectError(
-          () => new Route(match),
-          'incorrect-type',
-          (error) => {
-            expect(error.details).to.have.property('moduleName').that.equals('workbox-routing');
-            expect(error.details).to.have.property('className').that.equals('Route');
-            expect(error.details).to.have.property('funcName').that.equals('constructor');
-            expect(error.details).to.have.property('paramName').that.equals('handler');
-          }
-        );
-
-        await expectError(
-          () => new Route(match, invalidHandlerObject),
-          'missing-a-method',
-          (error) => {
-            expect(error.details).to.have.property('moduleName').that.equals('workbox-routing');
-            expect(error.details).to.have.property('className').that.equals('Route');
-            expect(error.details).to.have.property('funcName').that.equals('constructor');
-            expect(error.details).to.have.property('paramName').that.equals('handler');
-          }
-        );
-      });
-
-      it(`should throw when called without a valid match parameter`, async function() {
-        await expectError(
-          () => new Route(null, handler),
-          'incorrect-type',
-          (error) => {
-            expect(error.details).to.have.property('moduleName').that.equals('workbox-routing');
-            expect(error.details).to.have.property('className').that.equals('Route');
-            expect(error.details).to.have.property('funcName').that.equals('constructor');
-            expect(error.details).to.have.property('paramName').that.equals('match');
-          }
-        );
-      });
-
-      it(`should not throw when called with valid handler.handle and match parameters`, function() {
-        expect(() => new Route(match, handler)).not.to.throw();
-      });
-
-      it(`should not throw when called with a valid function handler and match parameters`, function() {
-        expect(() => new Route(match, functionHandler)).not.to.throw();
-      });
-
-      it(`should throw when called with an invalid method`, async function() {
-        await expectError(
-          () => new Route(match, handler, invalidMethod),
-          'invalid-value',
-          (error) => expect(error.details).to.have.property('paramName').that.equals('method')
-        );
-      });
-
-      it(`should use the method provided when called with a valid method`, function() {
-        const route = new Route(match, handler, method);
-        expect(route._method).to.equal(method);
-      });
-
-      it(`should use a default of GET when called without a method`, function() {
-        const route = new Route(match, handler);
-        expect(route._method).to.equal('GET');
-      });
+    it(`should throw when called without any parameters`, async function() {
+      await expectError(
+        () => new Route(),
+        'incorrect-type',
+        (error) => {
+          expect(error.details).to.have.property('moduleName').that.equals('workbox-routing');
+          expect(error.details).to.have.property('className').that.equals('Route');
+          expect(error.details).to.have.property('funcName').that.equals('constructor');
+        }
+      );
     });
 
-    describe(`(NODE_ENV = production)`, function() {
-      before(function() {
-        process.env.NODE_ENV = 'production';
-      });
+    it(`should throw when called without a valid handler parameter`, async function() {
+      await expectError(
+        () => new Route(match),
+        'incorrect-type',
+        (error) => {
+          expect(error.details).to.have.property('moduleName').that.equals('workbox-routing');
+          expect(error.details).to.have.property('className').that.equals('Route');
+          expect(error.details).to.have.property('funcName').that.equals('constructor');
+          expect(error.details).to.have.property('paramName').that.equals('handler');
+        }
+      );
 
-      it(`should not throw when called with valid handler.handle and match parameters`, function() {
-        expect(() => new Route(match, handler)).not.to.throw();
-      });
+      await expectError(
+        () => new Route(match, invalidHandlerObject),
+        'missing-a-method',
+        (error) => {
+          expect(error.details).to.have.property('moduleName').that.equals('workbox-routing');
+          expect(error.details).to.have.property('className').that.equals('Route');
+          expect(error.details).to.have.property('funcName').that.equals('constructor');
+          expect(error.details).to.have.property('paramName').that.equals('handler');
+        }
+      );
+    });
 
-      it(`should not throw when called with a valid function handler and match parameters`, function() {
-        expect(() => new Route(match, functionHandler)).not.to.throw();
-      });
+    it(`should throw when called without a valid match parameter`, async function() {
+      await expectError(
+        () => new Route(null, handler),
+        'incorrect-type',
+        (error) => {
+          expect(error.details).to.have.property('moduleName').that.equals('workbox-routing');
+          expect(error.details).to.have.property('className').that.equals('Route');
+          expect(error.details).to.have.property('funcName').that.equals('constructor');
+          expect(error.details).to.have.property('paramName').that.equals('match');
+        }
+      );
+    });
 
-      it(`should use the method provided when called with a valid method`, function() {
-        const route = new Route(match, handler, method);
-        expect(route._method).to.equal(method);
-      });
+    it(`should not throw when called with valid handler.handle and match parameters`, function() {
+      expect(() => new Route(match, handler)).not.to.throw();
+    });
 
-      it(`should use a default of GET when called without a method`, function() {
-        const route = new Route(match, handler);
-        expect(route._method).to.equal('GET');
-      });
+    it(`should not throw when called with a valid function handler and match parameters`, function() {
+      expect(() => new Route(match, functionHandler)).not.to.throw();
+    });
+
+    it(`should throw when called with an invalid method`, async function() {
+      await expectError(
+        () => new Route(match, handler, invalidMethod),
+        'invalid-value',
+        (error) => expect(error.details).to.have.property('paramName').that.equals('method')
+      );
+    });
+
+    it(`should use the method provided when called with a valid method`, function() {
+      const route = new Route(match, handler, method);
+      expect(route._method).to.equal(method);
+    });
+
+    it(`should use a default of GET when called without a method`, function() {
+      const route = new Route(match, handler);
+      expect(route._method).to.equal('GET');
     });
   });
-})();
+
+  describe(`(NODE_ENV = production)`, function() {
+    let Route;
+
+    before(async function() {
+      process.env.NODE_ENV = 'production';
+
+      clearRequire.all();
+
+      const RouteModule = await import('../../../packages/workbox-routing/lib/Route.mjs');
+      Route = RouteModule.default;
+    });
+
+    it(`should not throw when called with valid handler.handle and match parameters`, function() {
+      expect(() => new Route(match, handler)).not.to.throw();
+    });
+
+    it(`should not throw when called with a valid function handler and match parameters`, function() {
+      expect(() => new Route(match, functionHandler)).not.to.throw();
+    });
+
+    it(`should use the method provided when called with a valid method`, function() {
+      const route = new Route(match, handler, method);
+      expect(route._method).to.equal(method);
+    });
+
+    it(`should use a default of GET when called without a method`, function() {
+      const route = new Route(match, handler);
+      expect(route._method).to.equal('GET');
+    });
+  });
+});


### PR DESCRIPTION
Solves point 3 of #814

I know this PR looks like a complete change but thats because I've removed the iffe and indented each line.

Changes are:
- Removed iife
- Moved imports to before where the ENV is changed - this ensures that the import is using the correct NODE_ENV
- Cleared the require cache (workbox-core doesn't expose the assert library in prod and if you require it once with prod, it'll never expose assert).
- Changed the await wrapping to import module and then reference default.

This will likely changed based on discussion in #814 but I really don't want this pattern to be continued, hence this PR.