### PR TITLE
Give a precache-specific Router precedence

### DIFF
--- a/packages/workbox-sw/src/lib/workbox-sw.js
+++ b/packages/workbox-sw/src/lib/workbox-sw.js
@@ -128,11 +128,20 @@ class WorkboxSW {
       cacheId,
     });
 
+    // Create a Router instance that's used by the `Route` for precached assets.
+    // See https://github.com/GoogleChrome/workbox/issues/839
+    this._precacheRouter = new Router(
+      this._revisionedCacheManager.getCacheName(),
+    );
+
     this._router = new Router(
       this._revisionedCacheManager.getCacheName(),
     );
 
     if (handleFetch) {
+      // Give precedence to the _precacheRouter by registering its `fetch`
+      // handler first.
+      this._precacheRouter.addFetchListener();
       this._router.addFetchListener();
     }
 
@@ -339,7 +348,7 @@ class WorkboxSW {
       return false;
     };
 
-    this.router.registerRoute(capture, cacheFirstHandler);
+    this._precacheRouter.registerRoute(capture, cacheFirstHandler);
   }
 
   /**

--- a/packages/workbox-sw/test/sw/cache-id.js
+++ b/packages/workbox-sw/test/sw/cache-id.js
@@ -68,7 +68,7 @@ describe(`Cache ID`, function() {
     // about; it's not possible to spy on the method calls and check parameters,
     // since they're called during the WorkboxSW constructor and are called on
     // object instances that don't exist prior to the constructor.
-    const precacheRoute = workboxSW.router._routes.get('GET')[0];
+    const precacheRoute = workboxSW._precacheRouter._routes.get('GET')[0];
     const actualCacheName = precacheRoute.handler.requestWrapper.cacheName;
 
     expect(actualCacheName.startsWith(expectedCachePrefix)).to.be.true;


### PR DESCRIPTION
R: @philipwalton @addyosmani @gauntface

Fixes #839

This change should lead to the cache-first route for precached assets always having precedence over runtime caching routes.

I think this sort of change is safe to roll out as part of a minor release, since while we are changing existing behavior, we're changing it in a way that fixes a previously introduced bug and brings us in line with our documented behavior.