### PR TITLE
V3 sw load mod

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
   },
   rules: {
     "jsdoc/check-types": 2,
+    "jsdoc/newline-after-description": 2,
   },
   plugins: [
       'jsdoc',
@@ -78,6 +79,14 @@ module.exports = {
     ],
     rules: {
       'max-len': 0,
+    },
+  }
+  , {
+    files: [
+      'packages/workbox-sw/**/*',
+    ],
+    globals: {
+      'workbox': false,
     },
   }],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
   }, {
     files: [
       'packages/workbox-core/utils/logger.mjs',
+      'packages/workbox-sw/index.mjs',
       'test/workbox-core/bundle/node/utils/test-LogHelper.js',
       'infra/testing/cli-test-helper.js',
       'infra/utils/log-helper.js',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,7 @@ module.exports = {
     ],
     globals: {
       'workbox': false,
+    },
   }, {
     files: [
       'infra/testing/env-it.js',

--- a/gulp-tasks/publish-cdn.js
+++ b/gulp-tasks/publish-cdn.js
@@ -9,7 +9,13 @@ const logHelper = require('../infra/utils/log-helper');
 const findMissingCDNTags = async (tagsData) => {
   const missingTags = [];
   for (let tagData of tagsData) {
-    const exists = await cdnUploadHelper.tagExists(tagData.name);
+    let exists = await cdnUploadHelper.tagExists(tagData.name);
+    // TODO: Remove this override for the v3.0.0-alpha
+    if (tagData.name === 'v3.0.0-alpha') {
+      logHelper.warn(`Forcing update to CDN for v3.0.0-alpha`);
+      exists = false;
+    }
+
     if (!exists) {
       missingTags.push(tagData);
     }
@@ -36,10 +42,6 @@ const handleCDNUpload = async (tagName, gitBranch) => {
 };
 
 gulp.task('publish-cdn:generate-from-tags', async () => {
-  // This gives the google-cloud/storage module a change to complain
-  // before any of the publish bundle work kicks in.
-  await cdnUploadHelper.init();
-
   // Get all of the tags in the repo.
   const tags = await githubHelper.getTags();
   const missingTags = await findMissingCDNTags(tags);
@@ -56,10 +58,6 @@ gulp.task('publish-cdn:generate-from-tags', async () => {
 });
 
 gulp.task('publish-cdn:temp-v3', async () => {
-  // This gives the google-cloud/storage module a change to complain
-  // before any of the publish bundle work kicks in.
-  await cdnUploadHelper.init();
-
   const tagName = 'v3.0.0-alpha';
   const gitBranch = 'v3';
 

--- a/gulp-tasks/test-integration.js
+++ b/gulp-tasks/test-integration.js
@@ -97,6 +97,12 @@ gulp.task('test-integration', async () => {
     return;
   }
 
+  const packagesToTest =
+    glob.sync(`test/${global.packageOrStar}/integration`);
+  if (packagesToTest.length === 0) {
+    return;
+  }
+
   await testServer.start();
 
   try {

--- a/gulp-tasks/utils/build-browser-package.js
+++ b/gulp-tasks/utils/build-browser-package.js
@@ -81,8 +81,14 @@ module.exports = (packagePath, buildType) => {
     return Promise.reject(ERROR_NO_NAMSPACE + ' ' + packageName);
   }
 
+  let prefix = `${constants.NAMESPACE_PREFIX}.`;
+  if (pkgJson.workbox.disableNamespacePrefix) {
+    prefix = '';
+  }
+
+  const exports = pkgJson.workbox.disabledNamedExports ? 'default' : 'named';
   const namespace =
-    `${constants.NAMESPACE_PREFIX}.${pkgJson.workbox.browserNamespace}`;
+    `${prefix}${pkgJson.workbox.browserNamespace}`;
   const outputFilename = `${packageName}.${buildType.slice(0, 4)}.js`;
   const outputDirectory = path.join(packagePath,
     constants.PACKAGE_BUILD_DIRNAME, constants.BROWSER_BUILD_DIRNAME);
@@ -91,6 +97,7 @@ module.exports = (packagePath, buildType) => {
     Building Browser Bundle for
     ${logHelper.highlight(packageName)}.
   `);
+  logHelper.log(`    Exports: ${logHelper.highlight(exports)}`);
   logHelper.log(`    Namespace: ${logHelper.highlight(namespace)}`);
   logHelper.log(`    Filename: ${logHelper.highlight(outputFilename)}`);
 
@@ -98,7 +105,7 @@ module.exports = (packagePath, buildType) => {
     input: moduleIndexPath,
     rollup,
     format: 'iife',
-    exports: 'named',
+    exports,
     name: namespace,
     sourcemap: true,
     globals,

--- a/gulp-tasks/utils/rollup-helper.js
+++ b/gulp-tasks/utils/rollup-helper.js
@@ -1,6 +1,7 @@
 const uglifyPlugin = require('rollup-plugin-uglify');
 const minify = require('uglify-es').minify;
 const replace = require('rollup-plugin-replace');
+const lernaPkg = require('../../lerna.json');
 
 module.exports = {
   // Every use of rollup should have minification and the replace
@@ -35,12 +36,16 @@ module.exports = {
       );
     }
 
+    const replaceOptions = {
+      'WORKBOX_VERSION_TAG': lernaPkg.version,
+    };
+
     if (buildType) {
-      // Replace allows us to input NODE_ENV and strip code accordingly
-      plugins.push(replace({
-        'process.env.NODE_ENV': JSON.stringify(buildType),
-      }));
+      replaceOptions['process.env.NODE_ENV'] = JSON.stringify(buildType);
     }
+
+    // Replace allows us to input NODE_ENV and strip code accordingly
+    plugins.push(replace(replaceOptions));
 
     return plugins;
   },

--- a/infra/testing/sw-env.js
+++ b/infra/testing/sw-env.js
@@ -18,6 +18,7 @@ const makeServiceWorkerEnv = require('service-worker-mock');
 global.fetch = mockFetch;
 global.indexedDB = new IDBFactory();
 global.IDBKeyRange = IDBKeyRange;
+global.importScripts = () => {};
 
 const swEnv = makeServiceWorkerEnv();
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.2.0"
+  "version": "3.0.0-alpha"
 }

--- a/packages/workbox-build/src/entry-points/options/base-options.js
+++ b/packages/workbox-build/src/entry-points/options/base-options.js
@@ -30,6 +30,7 @@ class BaseOptions {
 
   /**
    * Performs validation and assigns default values for all the options.
+   *
    * @param {Object} [options] The options to initialize this class with;
    * will be validated based on the set of supported options.
    * @param {Object} [schema] The schema to use when validating options.

--- a/packages/workbox-core/utils/cacheWrapper.mjs
+++ b/packages/workbox-core/utils/cacheWrapper.mjs
@@ -2,6 +2,7 @@
  * Wrapper around cache.put().
  *
  * Will call `cacheDidUpdate` on plugins if the cache was updated.
+ *
  * @param {string} cacheName
  * @param {Request} request
  * @param {Response} response
@@ -76,6 +77,7 @@ const matchWrapper = async (cacheName, request, matchOptions, plugins = []) => {
 /**
  * This method will call cacheWillUpdate on the available plugins (or use
  * response.ok) to determine if the Response is safe and valid to cache.
+ *
  * @param {Request} request
  * @param {Response} response
  * @param {Array<Object>} plugins

--- a/packages/workbox-core/utils/indexedDBHelper.mjs
+++ b/packages/workbox-core/utils/indexedDBHelper.mjs
@@ -7,6 +7,7 @@
 class DBWrapper {
   /**
    * Wraps a provided Database.
+   *
    * @param {IDBDatabase} idb
    * @param {string} storename
    */
@@ -17,6 +18,7 @@ class DBWrapper {
 
   /**
    * Get a value for a given ID.
+   *
    * @param {Object} key
    * @return {Promise<string>}
    */
@@ -66,6 +68,7 @@ class DBWrapper {
 
   /**
    * Put a value in the database for a given id.
+   *
    * @param {Object} key
    * @param {Object} value
    * @return {Promise}
@@ -86,6 +89,7 @@ class DBWrapper {
 
   /**
    * Delete a value in the database with a given id.
+   *
    * @param {Object} key
    * @return {Promise}
    */
@@ -121,6 +125,7 @@ class IndexedDBHelper {
 
   /**
    * Get an opened IndexedDB.
+   *
    * @param {string} name
    * @param {string} storename
    * @param {Object} objectStoreOptions

--- a/packages/workbox-precaching/models/PrecacheEntry.mjs
+++ b/packages/workbox-precaching/models/PrecacheEntry.mjs
@@ -8,6 +8,7 @@ export default class PrecacheEntry {
 /**
  * This class ensures all cache list entries are consistent and
  * adds cache busting if required.
+ *
  * @param {*} originalInput
  * @param {string} url
  * @param {string} revision
@@ -29,7 +30,7 @@ export default class PrecacheEntry {
    *
    * @param {Request} request The request to cache bust
    * @return {Request} A cachebusted Request
-   * 
+   *
    * @private
    */
   _cacheBustRequest(request) {

--- a/packages/workbox-routing/lib/Route.mjs
+++ b/packages/workbox-routing/lib/Route.mjs
@@ -78,6 +78,7 @@ import normalizeHandler from './normalizeHandler.mjs';
 class Route {
   /**
    * Constructor for Route class.
+   *
    * @param {module:workbox-routing.Route~matchCallback} match
    * A callback function that determines whether the route matches a given
    * `fetch` event.

--- a/packages/workbox-sw/index.mjs
+++ b/packages/workbox-sw/index.mjs
@@ -80,7 +80,14 @@ class WorkboxSW {
       );
     }
 
-    importScripts(this._getImportPath(moduleName));
+    let modulePath = this._getImportPath(moduleName);
+    try {
+      importScripts(modulePath);
+    } catch (err) {
+      console.error(
+        `Unable to import module '${moduleName}' with path '${modulePath}'.`);
+      throw err;
+    }
   }
 
   /**

--- a/packages/workbox-sw/index.mjs
+++ b/packages/workbox-sw/index.mjs
@@ -75,7 +75,7 @@ class WorkboxSW {
       // This can't be a WorkboxError as we can't rely on workbox-core being
       // loaded.
       throw new Error(
-        `Attempted to load module while disableModuleImports is true.`
+        `Attempted to load '${moduleName}' while disableModuleImports is true.`
       );
     }
 

--- a/packages/workbox-sw/index.mjs
+++ b/packages/workbox-sw/index.mjs
@@ -5,6 +5,8 @@
  * @module workbox-sw
  */
 
+const CDN_PATH = `https://storage.googleapis.com/workbox-cdn/releases`;
+
 /**
  * This class can be used to make it easy to use the various parts of
  * Workbox.
@@ -20,8 +22,31 @@ class WorkboxSW {
   constructor(options) {
     this._options = Object.assign({
       debug: self.location.hostname === 'localhost',
-      pathPrefix: null,
+      modulePathPrefix: null,
+      modulePathCb: null,
+      disableModuleImports: false,
     }, options);
+    this._env = this._options.debug ? 'dev' : 'prod';
+
+    if (!this._options.disableModuleImports) {
+      this.loadModule('workbox-core');
+    }
+  }
+
+  /**
+   * Get workbox-core.
+   */
+  get core() {
+    return workbox.core.default;
+  }
+
+  /**
+   * Get workbox-precaching.
+   */
+  get precaching() {
+    this.loadModule('workbox-precaching');
+
+    return workbox.precaching.default;
   }
 
   /**
@@ -39,6 +64,54 @@ class WorkboxSW {
   clientsClaim() {
     self.addEventListener('activate', () => self.clients.claim());
   }
+
+  /**
+   * Load a Workbox module by passing in the appropriate module name.
+   *
+   * @param {string} moduleName
+   */
+  loadModule(moduleName) {
+    if (this._options.disableModuleImports) {
+      // This can't be a WorkboxError as we can't rely on workbox-core being
+      // loaded.
+      throw new Error(
+        `Attempted to load module while disableModuleImports is true.`
+      );
+    }
+
+    importScripts(this._getImportPath(moduleName));
+  }
+
+  /**
+   * This method will get the path / CDN URL to be used for importScript calls.
+   *
+   * @param {string} moduleName
+   * @return {string} URL to the desired module.
+   *
+   * @private
+   */
+  _getImportPath(moduleName) {
+    if (this._options.modulePathCb) {
+      return this._options.modulePathCb(moduleName, this._options.debug);
+    }
+
+    let pathParts = [CDN_PATH];
+
+    // TODO: This needs to be dynamic some how.
+    const version = 'v3.0.0-alpha';
+    const fileName = `${moduleName}.${this._env}.js`;
+
+    const pathPrefix = this._options.modulePathPrefix;
+    if (pathPrefix) {
+      // Split to avoid issues with developers ending / not ending with slash
+      pathParts = pathPrefix.split('/');
+    }
+
+    pathParts.push(version);
+    pathParts.push(fileName);
+
+    return pathParts.join('/');
+  }
 }
 
-export {WorkboxSW};
+export default WorkboxSW;

--- a/packages/workbox-sw/index.mjs
+++ b/packages/workbox-sw/index.mjs
@@ -95,19 +95,23 @@ class WorkboxSW {
       return this._options.modulePathCb(moduleName, this._options.debug);
     }
 
-    let pathParts = [CDN_PATH];
-
     // TODO: This needs to be dynamic some how.
-    const version = 'v3.0.0-alpha';
+    let pathParts = [CDN_PATH, 'v3.0.0-alpha'];
+
     const fileName = `${moduleName}.${this._env}.js`;
 
     const pathPrefix = this._options.modulePathPrefix;
     if (pathPrefix) {
       // Split to avoid issues with developers ending / not ending with slash
       pathParts = pathPrefix.split('/');
+
+      // We don't need a slash at the end as we will be adding
+      // a filename regardless
+      if (pathParts[pathParts.length - 1] === '') {
+        pathParts.splice(pathParts.length - 1, 1);
+      }
     }
 
-    pathParts.push(version);
     pathParts.push(fileName);
 
     return pathParts.join('/');

--- a/packages/workbox-sw/index.mjs
+++ b/packages/workbox-sw/index.mjs
@@ -6,6 +6,7 @@
  */
 
 const CDN_PATH = `https://storage.googleapis.com/workbox-cdn/releases`;
+const VERSION = `WORKBOX_VERSION_TAG`;
 
 /**
  * This class can be used to make it easy to use the various parts of
@@ -96,7 +97,7 @@ class WorkboxSW {
     }
 
     // TODO: This needs to be dynamic some how.
-    let pathParts = [CDN_PATH, 'v3.0.0-alpha'];
+    let pathParts = [CDN_PATH, VERSION];
 
     const fileName = `${moduleName}.${this._env}.js`;
 

--- a/packages/workbox-sw/package.json
+++ b/packages/workbox-sw/package.json
@@ -17,7 +17,9 @@
     "prepublish": "gulp build-packages --package workbox-sw"
   },
   "workbox": {
-    "browserNamespace": "sw",
+    "browserNamespace": "WorkboxSW",
+    "disableNamespacePrefix": "true",
+    "disabledNamedExports": "true",
     "packageType": "browser"
   },
   "main": "build/browser-bundles/workbox-sw.prod.js",

--- a/packages/workbox-sw/package.json
+++ b/packages/workbox-sw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-sw",
-  "version": "3.0.0",
+  "version": "3.0.0-alpha",
   "license": "Apache-2.0",
   "author": "Google's Web DevRel Team",
   "description": "This module makes it easy to get started with the Workbox service worker libraries.",
@@ -23,8 +23,5 @@
     "packageType": "browser"
   },
   "main": "build/browser-bundles/workbox-sw.prod.js",
-  "module": "index.mjs",
-  "dependencies": {
-    "workbox-core": "3.0.0"
-  }
+  "module": "index.mjs"
 }

--- a/test/workbox-sw/node/test-WorkboxSW.mjs
+++ b/test/workbox-sw/node/test-WorkboxSW.mjs
@@ -1,12 +1,16 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 
-import {WorkboxSW} from '../../../packages/workbox-sw/index.mjs';
+import WorkboxSW from '../../../packages/workbox-sw/index.mjs';
 
 describe(`[workbox-sw] WorkboxSW`, function() {
   let sandbox = sinon.sandbox.create();
 
-  afterEach(function() {
+  beforeEach(function() {
+    sandbox.restore();
+  });
+
+  after(function() {
     sandbox.restore();
   });
 
@@ -15,7 +19,9 @@ describe(`[workbox-sw] WorkboxSW`, function() {
       const wb = new WorkboxSW();
       expect(wb._options).to.deep.equal({
         debug: false,
-        pathPrefix: null,
+        modulePathPrefix: null,
+        modulePathCb: null,
+        disableModuleImports: false,
       });
     });
 
@@ -27,18 +33,25 @@ describe(`[workbox-sw] WorkboxSW`, function() {
       const wb = new WorkboxSW();
       expect(wb._options).to.deep.equal({
         debug: true,
-        pathPrefix: null,
+        modulePathPrefix: null,
+        modulePathCb: null,
+        disableModuleImports: false,
       });
     });
 
-    it(`should use provided options when provided`, function() {
+    it(`should use provided options`, function() {
+      const cb = () => {};
       const wb = new WorkboxSW({
         debug: true,
-        pathPrefix: 'http://custom-cdn.example.com/workbox-modules/v1.0.0/',
+        modulePathPrefix: 'http://custom-cdn.example.com/workbox-modules/v1.0.0/',
+        modulePathCb: cb,
+        disableModuleImports: true,
       });
       expect(wb._options).to.deep.equal({
         debug: true,
-        pathPrefix: 'http://custom-cdn.example.com/workbox-modules/v1.0.0/',
+        modulePathPrefix: 'http://custom-cdn.example.com/workbox-modules/v1.0.0/',
+        modulePathCb: cb,
+        disableModuleImports: true,
       });
     });
   });

--- a/test/workbox-sw/node/test-WorkboxSW.mjs
+++ b/test/workbox-sw/node/test-WorkboxSW.mjs
@@ -178,6 +178,26 @@ describe(`[workbox-sw] WorkboxSW`, function() {
         wb.loadModule('should-throw');
       }).to.throw(`disableModuleImports`);
     });
+
+    it(`should print error message when importScripts fails`, function() {
+      const errorMessage = 'Injected error.';
+      sandbox.stub(global, 'importScripts').callsFake(() => {
+        throw new Error(errorMessage);
+      });
+      sandbox.stub(console, 'error').callsFake((errMsg) => {
+        expect(errMsg.indexOf('workbox-core')).to.not.equal(-1);
+        expect(errMsg.indexOf(
+          'https://storage.googleapis.com/workbox-cdn/releases/WORKBOX_VERSION_TAG/workbox-core.prod.js'
+        )).to.not.equal(-1);
+      });
+
+      try {
+        new WorkboxSW();
+        throw new Error('No error thrown.');
+      } catch (err) {
+        expect(err.message).to.equal(errorMessage);
+      }
+    });
   });
 
   describe(`get core`, function() {

--- a/test/workbox-sw/node/test-WorkboxSW.mjs
+++ b/test/workbox-sw/node/test-WorkboxSW.mjs
@@ -55,12 +55,17 @@ describe(`[workbox-sw] WorkboxSW`, function() {
     });
 
     it(`should load workbox-core on construction`, function() {
-      sandbox.stub(WorkboxSW.prototype, 'loadModule');
+      sandbox.stub(global, 'importScripts');
+      sandbox.spy(WorkboxSW.prototype, 'loadModule');
 
-      const wb = new WorkboxSW();
+      // TODO Switch to contstants.BUILD_TYPES.prod
+      const wb = new WorkboxSW({
+        debug: process.env.NODE_ENV !== 'production',
+      });
 
       expect(wb.loadModule.callCount).to.equal(1);
-      expect(wb.loadModule.args[0]).to.deep.equal(['workbox-core']);
+      expect(global.importScripts.callCount).to.equal(1);
+      expect(global.importScripts.args[0]).to.deep.equal([`https://storage.googleapis.com/workbox-cdn/releases/WORKBOX_VERSION_TAG/workbox-core.${process.env.NODE_ENV.slice(0, 4)}.js`]);
     });
 
     it(`should not load workbox-core if disableModulesImports is true`, function() {

--- a/test/workbox-sw/node/test-WorkboxSW.mjs
+++ b/test/workbox-sw/node/test-WorkboxSW.mjs
@@ -31,12 +31,7 @@ describe(`[workbox-sw] WorkboxSW`, function() {
       });
 
       const wb = new WorkboxSW();
-      expect(wb._options).to.deep.equal({
-        debug: true,
-        modulePathPrefix: null,
-        modulePathCb: null,
-        disableModuleImports: false,
-      });
+      expect(wb._options.debug).to.deep.equal(true);
     });
 
     it(`should use provided options`, function() {
@@ -53,6 +48,25 @@ describe(`[workbox-sw] WorkboxSW`, function() {
         modulePathCb: cb,
         disableModuleImports: true,
       });
+    });
+
+    it(`should load workbox-core on construction`, function() {
+      sandbox.stub(WorkboxSW.prototype, 'loadModule');
+
+      const wb = new WorkboxSW();
+
+      expect(wb.loadModule.callCount).to.equal(1);
+      expect(wb.loadModule.args[0]).to.deep.equal(['workbox-core']);
+    });
+
+    it(`should not load workbox-core if disableModulesImports is true`, function() {
+      sandbox.stub(WorkboxSW.prototype, 'loadModule');
+
+      const wb = new WorkboxSW({
+        disableModuleImports: true,
+      });
+
+      expect(wb.loadModule.callCount).to.equal(0);
     });
   });
 

--- a/test/workbox-sw/static/example.css
+++ b/test/workbox-sw/static/example.css
@@ -1,0 +1,3 @@
+body {
+  background-color: 'green';
+}

--- a/test/workbox-sw/static/example.js
+++ b/test/workbox-sw/static/example.js
@@ -1,0 +1,1 @@
+window.example = 1 + 1;

--- a/test/workbox-sw/static/index.html
+++ b/test/workbox-sw/static/index.html
@@ -1,0 +1,27 @@
+<!-- This is a static file -->
+<!-- served from your routes in server.js -->
+
+<!-- You might want to try something fancier: -->
+<!-- html/nunjucks docs: https://mozilla.github.io/nunjucks/ -->
+<!-- pug: https://pugjs.org/ -->
+<!-- haml: http://haml.info/ -->
+<!-- hbs(handlebars): http://handlebarsjs.com/ -->
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <h1>
+      Testing Loading of Workbox via CDN
+    </h1>
+    <p>
+      This page will register a service worker that uses the Workbox CDN.
+    </p>
+    <script>
+      navigator.serviceWorker.register('sw.js');
+    </script>
+  </body>
+</html>

--- a/test/workbox-sw/static/sw.js
+++ b/test/workbox-sw/static/sw.js
@@ -1,0 +1,15 @@
+importScripts('../../../packages/workbox-sw/build/browser/workbox-sw.prod.js');
+
+const wb = new self.WorkboxSW({
+  modulePathCb: (moduleName, debug) => {
+    const build = debug ? 'dev' : 'prod';
+    return `../../../packages/${moduleName}/build/browser/${moduleName}.${build}.js`;
+  },
+});
+
+wb.core.logLevel = self.workbox.core.LOG_LEVELS.verbose;
+
+wb.precaching.precache([
+  'example.css',
+  'example.js',
+]);


### PR DESCRIPTION
R: @jeffposnick @addyosmani @philipwalton 

- Adds ability to load modules in workbox-sw
    - Three options around this:
        1. `modulePathPrefix` allows you to customise the path workbox-sw uses to import modules.
        2. `modulePathCb` allows a developers to completely control where a module is looked up.
        3. `disableModuleImports` force the library to only use globals and throw an error otherwise.
- Adds new line after description lint rule
- Allows deploying the v3 branch to the CDN regardless of whether it's already deployed or not (Will be helpful for testing)

Biggest question I have with this PR is around how we manage versions on CDN vs NPM.

At the moment we version modules separately so we avoid needless update churn. The CDN updates whenever a new git tag is released.

In this PR, I'm assuming the version in the `lerna.json` file is a safe way to get the latest tag being pushed to the CDN and using that inject the version to use into workbox-sw. (See VERSION = `WORKBOX_VERSION_TAG`). I'm not sure if this will be enough when publishing with lerna (i.e. will it bump this version before cutting the release or is it done after).