### PR TITLE
_private Fix and Precaching Integration Test

### DIFF
--- a/gulp-tasks/utils/rollup-helper.js
+++ b/gulp-tasks/utils/rollup-helper.js
@@ -19,6 +19,8 @@ module.exports = {
             reserved: [
               // Chai will break unless we reserve this private variable.
               '_obj',
+              // We need this to be exported correctly.
+              '_private',
             ],
             // mangle > properties > regex will allow uglify-es to minify
             // private variable and names that start with a single underscore

--- a/infra/testing/env-it.js
+++ b/infra/testing/env-it.js
@@ -19,7 +19,7 @@ module.exports = {
           return this.skip();
         }
 
-        cb();
+        return cb();
       });
     },
   },

--- a/infra/testing/test-server.js
+++ b/infra/testing/test-server.js
@@ -9,6 +9,10 @@ const logHelper = require('../utils/log-helper');
 const app = express();
 
 app.get(/\/__WORKBOX\/buildFile\/(workbox-[A-z]*)(\.(?:dev|prod)\.(.*))*/, (req, res) => {
+  res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
+  res.header('Expires', '-1');
+  res.header('Pragma', 'no-cache');
+
   const moduleName = req.params[0];
   const fileExtension = req.params[2];
 

--- a/test/workbox-precaching/integration/precache-and-update.js
+++ b/test/workbox-precaching/integration/precache-and-update.js
@@ -1,13 +1,69 @@
+const expect = require('chai').expect;
+const seleniumAssistant = require('selenium-assistant');
+
 describe(`[workbox-precaching] Precache and Update`, function() {
-  let webdriver = global.__workbox.webdriver;
+  let webdriver;
   let testServerAddress = global.__workbox.serverAddr;
 
-  it(`should load a page with service worker `, function() {
-    return webdriver.get(testServerAddress)
-    .then(() => {
-      return new Promise((resolve) => {
-        setTimeout(resolve, 3 * 1000);
+  beforeEach(async function() {
+    if (webdriver) {
+      await seleniumAssistant.killWebDriver(webdriver);
+      webdriver = null;
+    }
+
+    // Allow async functions 10s to complete
+    webdriver = await global.__workbox.seleniumBrowser.getSeleniumDriver();
+    webdriver.manage().timeouts().setScriptTimeout(10 * 1000);
+  });
+
+  after(async function() {
+    if (webdriver) {
+      await seleniumAssistant.killWebDriver(webdriver);
+    }
+  });
+
+  it(`should load a page with service worker `, async function() {
+    const testing = `${testServerAddress}/test/workbox-precaching/static/precache-and-update/`;
+    await webdriver.get(testing);
+    await webdriver.wait(() => {
+      return webdriver.executeAsyncScript((cb) => {
+        navigator.serviceWorker.getRegistration()
+        .then((registration) => {
+          if (!registration) {
+            return cb(false);
+          }
+
+          cb(registration.active !== null);
+        });
+      });
+    }, 3 * 1000);
+
+    const keys = await webdriver.executeAsyncScript((cb) => {
+      caches.keys()
+      .then((keys) => {
+        cb(keys);
       });
     });
+
+    expect(keys).to.deep.equal([
+      'workbox-precache-http://localhost:3004/test/workbox-precaching/static/precache-and-update/',
+    ]);
+
+    const cachedRequests = await webdriver.executeAsyncScript((cacheName, cb) => {
+      caches.open(cacheName)
+      .then((cache) => {
+        return cache.keys();
+      })
+      .then((keys) => {
+        cb(
+          keys.map((request) => request.url).sort()
+        );
+      });
+    }, keys[0]);
+
+    expect(cachedRequests).to.deep.equal([
+      'http://localhost:3004/test/workbox-precaching/static/precache-and-update/index.html',
+      'http://localhost:3004/test/workbox-precaching/static/precache-and-update/styles/index.css',
+    ]);
   });
 });


### PR DESCRIPTION
R: @jeffposnick @philipwalton 

Found a bug in precaching / core (The `_private` value was being mangled but needed to be reliable in all modules). This integration reproduced the bug and this PR contains the fix.

Also had to move to passing the seleniumAssistant browser (instead of the webdriver instance) so tests can close / reopen browsers - useful to start with clean profile / service worker state.