### PR TITLE
V3 CacheFirst

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11688,9 +11688,9 @@
       "dev": true
     },
     "service-worker-mock": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-1.3.0.tgz",
-      "integrity": "sha1-JGBWejIIRnmFc1z4xa5upXtd1S8=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-1.5.0.tgz",
+      "integrity": "sha1-VqO1744N+ugInhQ42jCeEsgpdh8=",
       "dev": true
     },
     "set-blocking": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "semver": "^5.4.1",
     "serve-index": "^1.9.1",
     "serve-static": "^1.13.1",
-    "service-worker-mock": "^1.2.2",
+    "service-worker-mock": "^1.5.0",
     "shelving-mock-indexeddb": "^1.0.4",
     "sinon": "^3.2.1",
     "tempy": "^0.2.1",

--- a/packages/workbox-core/utils/cacheWrapper.mjs
+++ b/packages/workbox-core/utils/cacheWrapper.mjs
@@ -106,4 +106,5 @@ const _isResponseSafeToCache = async (request, response, plugins) => {
 
 export default {
   put: putWrapper,
+  match: matchWrapper,
 };

--- a/packages/workbox-runtime-caching/CacheFirst.mjs
+++ b/packages/workbox-runtime-caching/CacheFirst.mjs
@@ -32,6 +32,8 @@ class CacheFirst {
    * @param {Object} options
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by `workbox-core`.
+   * @param {string} options.plugins Workbox plugins you may want to use in
+   * conjunction with this caching strategy.
    */
   constructor(options = {}) {
     this._cacheName =

--- a/packages/workbox-runtime-caching/CacheFirst.mjs
+++ b/packages/workbox-runtime-caching/CacheFirst.mjs
@@ -1,0 +1,83 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import {_private} from 'workbox-core';
+
+/**
+ * An implementation of a [cache-first](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#cache-falling-back-to-network)
+ * request strategy.
+ *
+ * A cache first strategy is useful for assets that are revisioned since it
+ * assets can be cached for long periods of time, saving the users data.
+ *
+ * @param {FetchEvent} event The request to handle.
+ * @return {Promise<Response>}
+ *
+ * @memberof module:workbox-runtime-caching
+ */
+class CacheFirst {
+  /**
+   * @param {Object} options
+   * @param {string} options.cacheName Cache name to store and retrieve
+   * requests. Defaults to cache names provided by `workbox-core`.
+   */
+  constructor({cacheName, plugins} = {}) {
+    this._cacheName =
+      _private.cacheNames.getRuntimeName(cacheName);
+      this._plugins = plugins;
+  }
+
+  /**
+   * Handle the provided fetch event.
+   *
+   * @param {FetchEvent} event
+   * @return {Promise<Response>}
+   */
+  async handle(event) {
+    if (process.env.NODE_ENV !== 'production') {
+      // TODO: Switch to core.assert
+      // core.assert.isInstance({event}, FetchEvent);
+    }
+
+    const cachedResponse = await _private.cacheWrapper.match(
+      this._cacheName,
+      event.request,
+      this._plugins
+    );
+
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+
+    const response = await _private.fetchWrapper.fetch(
+      event.request,
+      this._plugins
+    );
+
+    // Keep the service worker while we put the request to the cache
+    event.waitUntil(
+      _private.cacheWrapper.put(
+        this._cacheName,
+        event.request,
+        response.clone(),
+        this._plugins
+      )
+    );
+
+    return response;
+  }
+}
+
+export default CacheFirst;

--- a/packages/workbox-runtime-caching/CacheFirst.mjs
+++ b/packages/workbox-runtime-caching/CacheFirst.mjs
@@ -33,10 +33,10 @@ class CacheFirst {
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by `workbox-core`.
    */
-  constructor({cacheName, plugins} = {}) {
+  constructor(options = {}) {
     this._cacheName =
-      _private.cacheNames.getRuntimeName(cacheName);
-      this._plugins = plugins;
+      _private.cacheNames.getRuntimeName(options.cacheName);
+      this._plugins = options.plugins || [];
   }
 
   /**
@@ -67,11 +67,12 @@ class CacheFirst {
     );
 
     // Keep the service worker while we put the request to the cache
+    const responseClone = response.clone();
     event.waitUntil(
       _private.cacheWrapper.put(
         this._cacheName,
         event.request,
-        response.clone(),
+        responseClone,
         this._plugins
       )
     );

--- a/packages/workbox-runtime-caching/index.mjs
+++ b/packages/workbox-runtime-caching/index.mjs
@@ -1,0 +1,3 @@
+import CacheFirst from './CacheFirst.mjs';
+
+export {CacheFirst};

--- a/packages/workbox-runtime-caching/package.json
+++ b/packages/workbox-runtime-caching/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "workbox-runtime-caching",
+  "version": "3.0.0",
+  "license": "Apache-2.0",
+  "author": "Google's Web DevRel Team",
+  "description": "A service worker helper library implementing common caching strategies.",
+  "repository": "googlechrome/workbox",
+  "bugs": "https://github.com/googlechrome/workbox/issues",
+  "homepage": "https://github.com/GoogleChrome/workbox",
+  "keywords": [
+    "workbox",
+    "workboxjs",
+    "service worker",
+    "sw",
+    "router",
+    "routing"
+  ],
+  "scripts": {
+    "prepublish": "gulp build-packages --package workbox-runtime-caching"
+  },
+  "workbox": {
+    "browserNamespace": "strategies",
+    "packageType": "browser"
+  },
+  "main": "index.mjs",
+  "module": "index.mjs",
+  "browser": "build/browser/workbox-runtime-caching.prod.js",
+  "dependencies": {
+    "workbox-core": "3.0.0"
+  }
+}

--- a/test/workbox-runtime-caching/node/test-CacheFirst.mjs
+++ b/test/workbox-runtime-caching/node/test-CacheFirst.mjs
@@ -1,0 +1,169 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+import sinon from 'sinon';
+import {expect} from 'chai';
+
+import {_private} from '../../../packages/workbox-core/index.mjs';
+import {compareResponses} from '../utils/response-comparisons.mjs';
+
+import CacheFirst from '../../../packages/workbox-runtime-caching/CacheFirst.mjs';
+
+describe(`[workbox-runtime-caching] CacheFirst`, function() {
+  let sandbox = sinon.sandbox.create();
+
+  beforeEach(async function() {
+    let usedCacheNames = await caches.keys();
+    await Promise.all(usedCacheNames.map((cacheName) => {
+      return caches.delete(cacheName);
+    }));
+
+    sandbox.restore();
+  });
+
+  after(async function() {
+    let usedCacheNames = await caches.keys();
+    await Promise.all(usedCacheNames.map((cacheName) => {
+      return caches.delete(cacheName);
+    }));
+
+    sandbox.restore();
+  });
+
+  it(`should be able to fetch and cache a request to default cache`, async function() {
+    const request = new Request('http://example.io/test/');
+    // Doesn't follow spec: https://github.com/pinterest/service-workers/issues/52
+    const event = new FetchEvent(request);
+
+    sandbox.stub(global, 'fetch').callsFake((req) => {
+      expect(req).to.equal(request);
+      return Promise.resolve(new Response('Hello Test.'));
+    });
+    let cachePromise;
+    sandbox.stub(event, 'waitUntil').callsFake((promise) => {
+      cachePromise = promise;
+    });
+
+    const cacheFirst = new CacheFirst();
+    const firstHandleResponse = await cacheFirst.handle(event);
+
+    // Wait until cache.put is finished.
+    await cachePromise;
+    const cache = await caches.open(_private.cacheNames.getRuntimeName());
+    const firstCachedResponse = await cache.match(request);
+
+    await compareResponses(firstHandleResponse, firstCachedResponse, true);
+
+    const secondHandleResponse = await cacheFirst.handle(event);
+
+    // Reset spy state so we can check fetch wasn't called.
+    global.fetch.reset();
+
+    const secondCachedResponse = await cache.match(request);
+    await compareResponses(firstCachedResponse, secondHandleResponse, true);
+    await compareResponses(firstCachedResponse, secondCachedResponse, true);
+    expect(fetch.callCount).to.equal(0);
+  });
+
+  it(`should be able to cache a non-existant request to custom cache`, async function() {
+    const cacheName = 'test-cache-name';
+    const request = new Request('http://example.io/test/');
+    // Doesn't follow spec: https://github.com/pinterest/service-workers/issues/52
+    const event = new FetchEvent(request);
+
+    sandbox.stub(global, 'fetch').callsFake((req) => {
+      expect(req).to.equal(request);
+      return Promise.resolve(new Response('Hello Test.'));
+    });
+    let cachePromise;
+    sandbox.stub(event, 'waitUntil').callsFake((promise) => {
+      cachePromise = promise;
+    });
+
+    const cacheFirst = new CacheFirst({
+      cacheName,
+    });
+    const firstHandleResponse = await cacheFirst.handle(event);
+
+    // Wait until cache.put is finished.
+    await cachePromise;
+    const cache = await caches.open(cacheName);
+    const firstCachedResponse = await cache.match(request);
+
+    await compareResponses(firstHandleResponse, firstCachedResponse, true);
+  });
+
+  it(`should not cache an opaque response by default`, async function() {
+    const request = new Request('http://example.io/test/');
+    // Doesn't follow spec: https://github.com/pinterest/service-workers/issues/52
+    const event = new FetchEvent(request);
+
+    sandbox.stub(global, 'fetch').callsFake((req) => {
+      expect(req).to.equal(request);
+      return Promise.resolve(new Response('Hello Test.', {
+        status: 0,
+      }));
+    });
+    let cachePromise;
+    sandbox.stub(event, 'waitUntil').callsFake((promise) => {
+      cachePromise = promise;
+    });
+
+    const cacheFirst = new CacheFirst();
+    const firstHandleResponse = await cacheFirst.handle(event);
+
+    // Wait until cache.put is finished.
+    await cachePromise;
+    const cache = await caches.open(_private.cacheNames.getRuntimeName());
+    const firstCachedResponse = await cache.match(request);
+
+    expect(firstCachedResponse).to.equal(null);
+    expect(firstHandleResponse).to.exist;
+  });
+
+  it(`should cache an opaque response when a cacheWillUpdate plugin returns true`, async function() {
+    const request = new Request('http://example.io/test/');
+    // Doesn't follow spec: https://github.com/pinterest/service-workers/issues/52
+    const event = new FetchEvent(request);
+
+    sandbox.stub(global, 'fetch').callsFake((req) => {
+      expect(req).to.equal(request);
+      return Promise.resolve(new Response('Hello Test.', {
+        status: 0,
+      }));
+    });
+    let cachePromise;
+    sandbox.stub(event, 'waitUntil').callsFake((promise) => {
+      cachePromise = promise;
+    });
+
+    const cacheFirst = new CacheFirst({
+      plugins: [
+        {
+          cacheWillUpdate: ({request, response}) => {
+            return response;
+          },
+        },
+      ],
+    });
+    const firstHandleResponse = await cacheFirst.handle(event);
+
+    // Wait until cache.put is finished.
+    await cachePromise;
+    const cache = await caches.open(_private.cacheNames.getRuntimeName());
+    const firstCachedResponse = await cache.match(request);
+
+    await compareResponses(firstHandleResponse, firstCachedResponse, true);
+  });
+});

--- a/test/workbox-runtime-caching/utils/response-comparisons.mjs
+++ b/test/workbox-runtime-caching/utils/response-comparisons.mjs
@@ -1,0 +1,15 @@
+import {expect} from 'chai';
+
+function compareResponses(first, second, shouldBeSame) {
+  const firstClone = first.clone();
+  const secondClone = second.clone();
+
+  return Promise.all([firstClone.text(), secondClone.text()])
+  .then(([firstBody, secondBody]) => {
+    return expect(firstBody === secondBody).to.eql(shouldBeSame);
+  });
+}
+
+export {
+  compareResponses,
+};


### PR DESCRIPTION
R: @jeffposnick @addyosmani @philipwalton 

Adds CacheFirst Strategy.

- Uses the default runtime cache name
- Can be override with options.cacheName in constructor
- plugins can be added to override caching logic etc
- Removed waitOnCache in favor of using event.waitUntil and fixing tests to support this.