### PR TITLE
Linting rule for license header + adds missing headers.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
     "jsdoc/newline-after-description": 2,
   },
   plugins: [
-      'jsdoc',
+    'jsdoc',
   ],
   parser: 'babel-eslint',
   overrides: [{
@@ -96,5 +96,15 @@ module.exports = {
     rules: {
       'no-invalid-this': 0,
     },
+  }, {
+    files: [
+      'packages/**/*.{mjs,js}',
+    ],
+    plugins: [
+      'header',
+    ],
+    rules: {
+      'header/header': [2, 'block', {pattern: 'Copyright \\d{4} Google Inc.'}]
+    }
   }],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3576,6 +3576,12 @@
       "integrity": "sha512-5A83D+lH0PA81QMESKbLJd/a3ic8tPZtwUmqNrxMRo54nfFaUvtt89q/+icQ+fd66c2xQHn0KyFkzJDoAUfpZA==",
       "dev": true
     },
+    "eslint-plugin-header": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-1.2.0.tgz",
+      "integrity": "sha1-9wR3nG+8fGaPGA2DXeH0YrBGfDc=",
+      "dev": true
+    },
     "eslint-plugin-jsdoc": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "depcheck": "^0.6.7",
     "eslint": "^4.6.1",
     "eslint-config-google": "^0.9.1",
+    "eslint-plugin-header": "^1.2.0",
     "eslint-plugin-jsdoc": "^3.1.3",
     "event-stream": "^3.3.4",
     "express": "^4.16.1",

--- a/packages/workbox-build/src/entry-points/generate-sw-string.js
+++ b/packages/workbox-build/src/entry-points/generate-sw-string.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const GenerateSWStringOptions = require('./options/generate-sw-no-fs-options');
 const getFileManifestEntries = require('../lib/get-file-manifest-entries');
 const populateSWTemplate = require('../lib/populate-sw-template');

--- a/packages/workbox-build/src/entry-points/generate-sw.js
+++ b/packages/workbox-build/src/entry-points/generate-sw.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const path = require('path');
 
 const GenerateSWOptions = require('./options/generate-sw-options');

--- a/packages/workbox-build/src/entry-points/get-manifest.js
+++ b/packages/workbox-build/src/entry-points/get-manifest.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const GetManifestOptions = require('./options/get-manifest-options');
 const getFileManifestEntries = require('../lib/get-file-manifest-entries');
 

--- a/packages/workbox-build/src/entry-points/inject-manifest.js
+++ b/packages/workbox-build/src/entry-points/inject-manifest.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const assert = require('assert');
 const fse = require('fs-extra');
 const path = require('path');

--- a/packages/workbox-build/src/entry-points/options/base-options.js
+++ b/packages/workbox-build/src/entry-points/options/base-options.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const joi = require('joi');
 
 const SCHEMA = joi.object().keys({

--- a/packages/workbox-build/src/entry-points/options/generate-sw-no-fs-options.js
+++ b/packages/workbox-build/src/entry-points/options/generate-sw-no-fs-options.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const joi = require('joi');
 
 const BaseOptions = require('./base-options');

--- a/packages/workbox-build/src/entry-points/options/generate-sw-options.js
+++ b/packages/workbox-build/src/entry-points/options/generate-sw-options.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const joi = require('joi');
 
 const BaseOptions = require('./base-options');

--- a/packages/workbox-build/src/entry-points/options/get-manifest-options.js
+++ b/packages/workbox-build/src/entry-points/options/get-manifest-options.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const joi = require('joi');
 
 const BaseOptions = require('./base-options');

--- a/packages/workbox-build/src/entry-points/options/inject-manifest-options.js
+++ b/packages/workbox-build/src/entry-points/options/inject-manifest-options.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const joi = require('joi');
 
 const BaseOptions = require('./base-options');

--- a/packages/workbox-build/src/index.js
+++ b/packages/workbox-build/src/index.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const generateSW = require('./entry-points/generate-sw');
 const generateSWString = require('./entry-points/generate-sw-string');
 const getManifest = require('./entry-points/get-manifest');

--- a/packages/workbox-build/src/lib/copy-workbox-sw.js
+++ b/packages/workbox-build/src/lib/copy-workbox-sw.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const fse = require('fs-extra');
 const path = require('path');
 

--- a/packages/workbox-build/src/lib/errors.js
+++ b/packages/workbox-build/src/lib/errors.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const ol = require('common-tags').oneLine;
 
 module.exports = {

--- a/packages/workbox-build/src/lib/filter-files.js
+++ b/packages/workbox-build/src/lib/filter-files.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const maximumSizeTransform = require('./maximum-size-transform');
 const modifyUrlPrefixTranform = require('./modify-url-prefix-transform');
 const noRevisionForUrlsMatchingTransform =

--- a/packages/workbox-build/src/lib/get-composite-details.js
+++ b/packages/workbox-build/src/lib/get-composite-details.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const crypto = require('crypto');
 
 module.exports = (compositeUrl, dependencyDetails) => {

--- a/packages/workbox-build/src/lib/get-file-details.js
+++ b/packages/workbox-build/src/lib/get-file-details.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const glob = require('glob');
 const path = require('path');
 

--- a/packages/workbox-build/src/lib/get-file-hash.js
+++ b/packages/workbox-build/src/lib/get-file-hash.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const fs = require('fs');
 
 const getStringHash = require('./get-string-hash');

--- a/packages/workbox-build/src/lib/get-file-manifest-entries.js
+++ b/packages/workbox-build/src/lib/get-file-manifest-entries.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const assert = require('assert');
 const path = require('path');
 

--- a/packages/workbox-build/src/lib/get-file-size.js
+++ b/packages/workbox-build/src/lib/get-file-size.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const fs = require('fs');
 
 const errors = require('./errors');

--- a/packages/workbox-build/src/lib/get-string-details.js
+++ b/packages/workbox-build/src/lib/get-string-details.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const getStringHash = require('./get-string-hash');
 
 module.exports = (url, string) => {

--- a/packages/workbox-build/src/lib/get-string-hash.js
+++ b/packages/workbox-build/src/lib/get-string-hash.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const crypto = require('crypto');
 
 module.exports = (string) => {

--- a/packages/workbox-build/src/lib/maximum-size-transform.js
+++ b/packages/workbox-build/src/lib/maximum-size-transform.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 module.exports = (maximumFileSizeToCacheInBytes) => {
   return (manifest) => manifest.filter((entry) => {
     return entry.size <= maximumFileSizeToCacheInBytes;

--- a/packages/workbox-build/src/lib/modify-url-prefix-transform.js
+++ b/packages/workbox-build/src/lib/modify-url-prefix-transform.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const errors = require('./errors');
 
 /**

--- a/packages/workbox-build/src/lib/no-revision-for-urls-matching-transform.js
+++ b/packages/workbox-build/src/lib/no-revision-for-urls-matching-transform.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const errors = require('./errors');
 
 module.exports = (regexp) => {

--- a/packages/workbox-build/src/lib/populate-sw-template.js
+++ b/packages/workbox-build/src/lib/populate-sw-template.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const template = require('lodash.template');
 const swTemplate = require('../templates/sw-template');
 

--- a/packages/workbox-build/src/lib/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/runtime-caching-converter.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const errors = require('./errors');
 
 /**

--- a/packages/workbox-build/src/lib/use-build-type.js
+++ b/packages/workbox-build/src/lib/use-build-type.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 // TODO (jeffposnick): More flexibility in case naming conventions change.
 const DEFAULT_BUILD_TYPE = 'prod';
 

--- a/packages/workbox-build/src/lib/write-sw-using-default-template.js
+++ b/packages/workbox-build/src/lib/write-sw-using-default-template.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const fse = require('fs-extra');
 const path = require('path');
 

--- a/packages/workbox-build/src/templates/sw-template.js
+++ b/packages/workbox-build/src/templates/sw-template.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 module.exports = `<% if (importScripts) { %>
 importScripts(<%= importScripts.map(JSON.stringify).join(',') %>);
 <% } %>

--- a/packages/workbox-core/_private.mjs
+++ b/packages/workbox-core/_private.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import logger from './utils/logger.mjs';
 import WorkboxError from './models/WorkboxError.mjs';
 import fetchWrapper from './utils/fetchWrapper.mjs';

--- a/packages/workbox-core/index.mjs
+++ b/packages/workbox-core/index.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import assert from './utils/assert.mjs';
 import WorkboxError from './models/WorkboxError.mjs';
 import LOG_LEVELS from './models/LogLevels.mjs';

--- a/packages/workbox-core/models/LogLevels.mjs
+++ b/packages/workbox-core/models/LogLevels.mjs
@@ -1,7 +1,23 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 export default {
- verbose: 0,
- debug: 1,
- warn: 2,
- error: 3,
- silent: 4,
+  verbose: 0,
+  debug: 1,
+  warn: 2,
+  error: 3,
+  silent: 4,
 };

--- a/packages/workbox-core/models/WorkboxError.mjs
+++ b/packages/workbox-core/models/WorkboxError.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import messageGenerator from './messages/messageGenerator.mjs';
 
 /**

--- a/packages/workbox-core/models/cacheNames.mjs
+++ b/packages/workbox-core/models/cacheNames.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const _cacheNameDetails = {
   prefix: 'workbox',
   suffix: self.registration.scope,

--- a/packages/workbox-core/models/messages/messageGenerator.mjs
+++ b/packages/workbox-core/models/messages/messageGenerator.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import messages from './messages.mjs';
 
 const fallback = (code, ...args) => {

--- a/packages/workbox-core/models/messages/messages.mjs
+++ b/packages/workbox-core/models/messages/messages.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 export default {
   'invalid-type': ({paramName, expectedType, value}) => {
     if (!paramName || !expectedType) {

--- a/packages/workbox-core/utils/assert.mjs
+++ b/packages/workbox-core/utils/assert.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import WorkboxError from '../models/WorkboxError.mjs';
 
 /*

--- a/packages/workbox-core/utils/cacheWrapper.mjs
+++ b/packages/workbox-core/utils/cacheWrapper.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 /**
  * Wrapper around cache.put().
  *

--- a/packages/workbox-core/utils/fetchWrapper.mjs
+++ b/packages/workbox-core/utils/fetchWrapper.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import WorkboxError from '../models/WorkboxError.mjs';
 
 /**

--- a/packages/workbox-core/utils/indexedDBHelper.mjs
+++ b/packages/workbox-core/utils/indexedDBHelper.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 /**
  * This is a wrapper that makes it easier to use IDB.
  *

--- a/packages/workbox-core/utils/logger.mjs
+++ b/packages/workbox-core/utils/logger.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import core from '../index.mjs';
 import LOG_LEVELS from '../models/LogLevels.mjs';
 

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import {_private} from 'workbox-core';
 import core from 'workbox-core';
 

--- a/packages/workbox-precaching/default-precaching-export.mjs
+++ b/packages/workbox-precaching/default-precaching-export.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import PrecacheController from './controllers/PrecacheController.mjs';
 
 const precacheController = new PrecacheController();

--- a/packages/workbox-precaching/index.mjs
+++ b/packages/workbox-precaching/index.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import core from 'workbox-core';
 import PrecacheController from './controllers/PrecacheController.mjs';
 import defaultPrecachingExport from './default-precaching-export.mjs';

--- a/packages/workbox-precaching/models/PrecacheEntry.mjs
+++ b/packages/workbox-precaching/models/PrecacheEntry.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 /**
  * Used as a consistent way of referencing a URL to precache.
  *

--- a/packages/workbox-precaching/models/PrecachedDetailsModel.mjs
+++ b/packages/workbox-precaching/models/PrecachedDetailsModel.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import {_private} from 'workbox-core';
 
 // Allows minifier to mangle this name

--- a/packages/workbox-precaching/utils/cleanRedirect.mjs
+++ b/packages/workbox-precaching/utils/cleanRedirect.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 /**
  * @param {Response} response
  * @return {Response}

--- a/packages/workbox-precaching/utils/printCleanupDetails.mjs
+++ b/packages/workbox-precaching/utils/printCleanupDetails.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import {_private} from 'workbox-core';
 
 const logGroup = (groupTitle, urls) => {

--- a/packages/workbox-precaching/utils/printInstallDetails.mjs
+++ b/packages/workbox-precaching/utils/printInstallDetails.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import {_private} from 'workbox-core';
 
 /**

--- a/packages/workbox-precaching/utils/showWarningsIfNeeded.mjs
+++ b/packages/workbox-precaching/utils/showWarningsIfNeeded.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import {_private} from 'workbox-core';
 
 /**

--- a/packages/workbox-routing/default-export.mjs
+++ b/packages/workbox-routing/default-export.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import Router from './lib/Router.mjs';
 
 const router = new Router();

--- a/packages/workbox-routing/index.mjs
+++ b/packages/workbox-routing/index.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import core from 'workbox-core';
 import Route from './lib/Route.mjs';
 import Router from './lib/Router.mjs';

--- a/packages/workbox-runtime-caching/index.mjs
+++ b/packages/workbox-runtime-caching/index.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 import CacheFirst from './CacheFirst.mjs';
 
 export {CacheFirst};

--- a/packages/workbox-sw/index.mjs
+++ b/packages/workbox-sw/index.mjs
@@ -1,3 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 /**
  * This module is a single import that can be used to dynamically import
  * additional Workbox modules with no effort.


### PR DESCRIPTION
R: @philipwalton @addyosmani @gauntface

Fixes #867 

I'm just enforcing it for `packages/**/*.{mjs,js}` and I'm only checking for the Copyright portion (since we've used copyright headers that vary in formatting subtly), but that might be sufficient. Let me know if you think otherwise and I'll adjust the PR.