### PR TITLE
For the temporary github and CDN stuff, remove the generated files

### DIFF
--- a/gulp-tasks/publish-cdn.js
+++ b/gulp-tasks/publish-cdn.js
@@ -6,11 +6,16 @@ const cdnUploadHelper = require('./utils/cdn-helper');
 const publishHelpers = require('./utils/publish-helpers');
 const githubHelper = require('./utils/github-helper');
 const logHelper = require('../infra/utils/log-helper');
+const constants = require('./utils/constants');
 
 const findMissingCDNTags = async (tagsData) => {
   const missingTags = [];
   for (let tagData of tagsData) {
     let exists = await cdnUploadHelper.tagExists(tagData.name);
+
+    if (tagData.name.indexOf('3.0.0-alpha') !== -1) {
+      exists = false;
+    }
 
     if (!exists) {
       missingTags.push(tagData);
@@ -54,6 +59,11 @@ gulp.task('publish-cdn:generate-from-tags', async () => {
 });
 
 gulp.task('publish-cdn:temp-v3', async () => {
+  // Let's force this to always be fresh - in case we run it outside of
+  // gulp publish
+  fs.removeSync(
+    path.join(__dirname, '..', constants.GENERATED_RELEASE_FILES_DIRNAME));
+
   const lernaPkg = fs.readJSONSync(
     path.join(__dirname, '..', 'lerna.json'),
   );

--- a/gulp-tasks/publish-cdn.js
+++ b/gulp-tasks/publish-cdn.js
@@ -13,7 +13,7 @@ const findMissingCDNTags = async (tagsData) => {
   for (let tagData of tagsData) {
     let exists = await cdnUploadHelper.tagExists(tagData.name);
 
-    if (tagData.name.indexOf('3.0.0-alpha') !== -1) {
+    if (tagData.name.includes('3.0.0-alpha')) {
       exists = false;
     }
 
@@ -61,10 +61,10 @@ gulp.task('publish-cdn:generate-from-tags', async () => {
 gulp.task('publish-cdn:temp-v3', async () => {
   // Let's force this to always be fresh - in case we run it outside of
   // gulp publish
-  fs.removeSync(
+  await fs.remove(
     path.join(__dirname, '..', constants.GENERATED_RELEASE_FILES_DIRNAME));
 
-  const lernaPkg = fs.readJSONSync(
+  const lernaPkg = await fs.readJSON(
     path.join(__dirname, '..', 'lerna.json'),
   );
   const tagName = lernaPkg.version;

--- a/gulp-tasks/publish-github.js
+++ b/gulp-tasks/publish-github.js
@@ -1,9 +1,11 @@
 const gulp = require('gulp');
 const path = require('path');
+const fs = require('fs-extra');
 
 const publishHelpers = require('./utils/publish-helpers');
 const githubHelper = require('./utils/github-helper');
 const logHelper = require('../infra/utils/log-helper');
+const constants = require('./utils/constants');
 
 const publishReleaseOnGithub =
   async (tagName, releaseInfo, tarPath, zipPath) => {
@@ -71,6 +73,11 @@ gulp.task('publish-github:generate-from-tags', async () => {
 // TODO: Delete this task when v3 is about to launch.
 // This is just to publish v3 branch as v3.0.0-alpha
 gulp.task('publish-github:temp-v3', async () => {
+  // Let's force this to always be fresh - in case we run it outside of
+  // gulp publish
+  fs.removeSync(
+    path.join(__dirname, '..', constants.GENERATED_RELEASE_FILES_DIRNAME));
+
   const tagName = 'v3.0.0-alpha';
   const gitBranch = 'v3';
 

--- a/gulp-tasks/publish-github.js
+++ b/gulp-tasks/publish-github.js
@@ -75,7 +75,7 @@ gulp.task('publish-github:generate-from-tags', async () => {
 gulp.task('publish-github:temp-v3', async () => {
   // Let's force this to always be fresh - in case we run it outside of
   // gulp publish
-  fs.removeSync(
+  await fs.remove(
     path.join(__dirname, '..', constants.GENERATED_RELEASE_FILES_DIRNAME));
 
   const tagName = 'v3.0.0-alpha';


### PR DESCRIPTION
R: @jeffposnick 

This is only useful for us testing stuff out between full publishes, but I just hit it with one of the demos so would be good to land.