### PR TITLE
V3 sw proxy

### DIFF
--- a/packages/workbox-sw/index.mjs
+++ b/packages/workbox-sw/index.mjs
@@ -49,22 +49,36 @@ class WorkboxSW {
     if (!this._options.disableModuleImports) {
       this.loadModule('workbox-core');
     }
+
+    this._setupProxy();
   }
 
   /**
-   * Get workbox-core.
+   * This method adds a proxy to the WorkboxSW object.
+   *
+   * @private
    */
-  get core() {
-    return workbox.core.default;
-  }
+  _setupProxy() {
+    const moduleNameMapping = {
+      'expiration': 'cache-expiration',
+      'strategies': 'runtime-caching',
+    };
 
-  /**
-   * Get workbox-precaching.
-   */
-  get precaching() {
-    this.loadModule('workbox-precaching');
+    const handler = {
+      get(target, key) {
+        let moduleName = `workbox-${key}`;
+        if (moduleNameMapping[key]) {
+           moduleName = moduleNameMapping[key];
+        }
+        console.info(`importing: '${moduleName}'`);
 
-    return workbox.precaching.default;
+        this.loadModule(moduleName);
+
+        return workbox[key].default;
+      },
+    };
+
+    new Proxy(this, handler);
   }
 
   /**

--- a/packages/workbox-sw/index.mjs
+++ b/packages/workbox-sw/index.mjs
@@ -24,14 +24,18 @@ import './_version.mjs';
  */
 
 const CDN_PATH = `WORKBOX_CDN_ROOT_URL`;
-const MODULE_KEY_TO_NAME_MAPPING = {
-  'expiration': 'workbox-cache-expiration',
-  'strategies': 'workbox-runtime-caching',
-};
+
+// TODO Make this list be generated during build time using the package.json's.
+// workbox namespace value.
 const MODULE_NAME_TO_KEY_MAPPING = {
   'workbox-cache-expiration': 'expiration',
   'workbox-runtime-caching': 'strategies',
 };
+const MODULE_KEY_TO_NAME_MAPPING = {};
+for (const moduleName of Object.keys(MODULE_NAME_TO_KEY_MAPPING)) {
+  const namespace = MODULE_NAME_TO_KEY_MAPPING[moduleName];
+  MODULE_KEY_TO_NAME_MAPPING[namespace] = moduleName;
+}
 
 /**
  * This class can be used to make it easy to use the various parts of
@@ -102,6 +106,8 @@ class WorkboxSW {
       try {
         importScripts(modulePath);
       } catch (err) {
+        // TODO Add context of this error if using the CDN vs the local file.
+
         // We can't rely on workbox-core being loaded so using console
         console.error(
           `Unable to import module '${moduleName}' from '${modulePath}'.`);

--- a/packages/workbox-sw/index.mjs
+++ b/packages/workbox-sw/index.mjs
@@ -71,7 +71,14 @@ class WorkboxSW {
         target.loadModule(moduleName);
         // Add the key to the target (i.e. instance of WorkboxSW)
         // so the next access doesn't attempt to load the module again.
-        target[key] = workbox[key].default;
+        if (workbox[key].default) {
+          // Most cases developers will only want the default export
+          target[key] = workbox[key].default;
+        } else {
+          // For modules with no default export, make all classes hang off
+          // of WorkboxSW.
+          target[key] = workbox[key];
+        }
         return target[key];
       },
     });

--- a/test/workbox-sw/node/test-WorkboxSW.mjs
+++ b/test/workbox-sw/node/test-WorkboxSW.mjs
@@ -12,6 +12,15 @@ describe(`[workbox-sw] WorkboxSW`, function() {
   beforeEach(function() {
     sandbox.restore();
     delete global.workbox;
+
+    sandbox.stub(global, 'importScripts').callsFake((url) => {
+      if (url.includes('workbox-')) {
+        global.workbox = global.workbox || {};
+        if (url.includes('workbox-core')) {
+          global.workbox.core = global.workbox.core || {};
+        }
+      }
+    });
   });
 
   after(function() {
@@ -56,7 +65,6 @@ describe(`[workbox-sw] WorkboxSW`, function() {
     });
 
     it(`should load workbox-core on construction`, function() {
-      sandbox.stub(global, 'importScripts');
       sandbox.spy(WorkboxSW.prototype, 'loadModule');
 
       // TODO Switch to contstants.BUILD_TYPES.prod
@@ -80,7 +88,6 @@ describe(`[workbox-sw] WorkboxSW`, function() {
     });
 
     it(`should use module cb to load workbox-core if a function is provided`, function() {
-      sandbox.stub(global, 'importScripts');
       const callbackSpy = sandbox.spy((moduleName, debug) => {
         return `/custom-path/${moduleName}/${debug}`;
       });
@@ -123,8 +130,6 @@ describe(`[workbox-sw] WorkboxSW`, function() {
       },
     ];
     generateTestVariants(`should import using modulePathPrefix`, modulePathVariations, async function(variant) {
-      sandbox.stub(global, 'importScripts');
-
       new WorkboxSW({
         debug: true,
         modulePathPrefix: variant.prefix,
@@ -182,6 +187,7 @@ describe(`[workbox-sw] WorkboxSW`, function() {
 
     it(`should print error message when importScripts fails`, function() {
       const errorMessage = 'Injected error.';
+      global.importScripts.restore();
       sandbox.stub(global, 'importScripts').callsFake(() => {
         throw new Error(errorMessage);
       });

--- a/test/workbox-sw/node/test-WorkboxSW.mjs
+++ b/test/workbox-sw/node/test-WorkboxSW.mjs
@@ -6,6 +6,27 @@ import constants from '../../../gulp-tasks/utils/constants';
 
 import WorkboxSW from '../../../packages/workbox-sw/index.mjs';
 
+const fakeWorkbox = {
+  core: {
+    default: {
+      msg: 'workbox-core',
+    },
+  },
+  precaching: {
+    default: {
+      msg: 'workbox-precaching',
+    },
+  },
+  strategies: {
+    example1: {
+      msg: 'workbox-strategies-1',
+    },
+    example2: {
+      msg: 'workbox-strategies-2',
+    },
+  },
+};
+
 describe(`[workbox-sw] WorkboxSW`, function() {
   let sandbox = sinon.sandbox.create();
 
@@ -17,7 +38,13 @@ describe(`[workbox-sw] WorkboxSW`, function() {
       if (url.includes('workbox-')) {
         global.workbox = global.workbox || {};
         if (url.includes('workbox-core')) {
-          global.workbox.core = global.workbox.core || {};
+          global.workbox.core = global.workbox.core || fakeWorkbox.core;
+        }
+        if (url.includes('workbox-precaching')) {
+          global.workbox.precaching = global.workbox.precaching || fakeWorkbox.precaching;
+        }
+        if (url.includes('workbox-runtime-caching')) {
+          global.workbox.strategies = global.workbox.strategies || fakeWorkbox.strategies;
         }
       }
     });
@@ -77,14 +104,15 @@ describe(`[workbox-sw] WorkboxSW`, function() {
       expect(global.importScripts.args[0]).to.deep.equal([`WORKBOX_CDN_ROOT_URL/workbox-core.${process.env.NODE_ENV.slice(0, 4)}.js`]);
     });
 
-    it(`should not load workbox-core if disableModulesImports is true`, function() {
-      sandbox.stub(WorkboxSW.prototype, 'loadModule');
+    it(`should not call importScripts if disableModulesImports is true`, function() {
+      global.workbox = fakeWorkbox;
 
       const wb = new WorkboxSW({
         disableModuleImports: true,
       });
 
-      expect(wb.loadModule.callCount).to.equal(0);
+      expect(global.importScripts.callCount).to.equal(0);
+      expect(wb.core).to.equal(fakeWorkbox.core.default);
     });
 
     it(`should use module cb to load workbox-core if a function is provided`, function() {
@@ -177,12 +205,15 @@ describe(`[workbox-sw] WorkboxSW`, function() {
 
   describe(`loadModule()`, function() {
     it(`should throw when loading module while disableModuleImports is true`, function() {
+      global.workbox = fakeWorkbox;
+
       const wb = new WorkboxSW({
         disableModuleImports: true,
       });
       expect(() => {
         wb.loadModule('should-throw');
-      }).to.throw(`disableModuleImports`);
+      }).to.throw(`The namespace 'workbox.should-throw' isn't defined.`);
+      expect(global.importScripts.callCount).to.equal(0);
     });
 
     it(`should print error message when importScripts fails`, function() {
@@ -209,15 +240,6 @@ describe(`[workbox-sw] WorkboxSW`, function() {
 
   describe(`get core`, function() {
     it(`should return core.default`, function() {
-      const fakeWorkbox = {
-        core: {
-          default: {},
-        },
-      };
-      sandbox.stub(WorkboxSW.prototype, 'loadModule').callsFake(() => {
-        global.workbox = fakeWorkbox;
-      });
-
       const wb = new WorkboxSW();
       expect(wb.core).to.equal(fakeWorkbox.core.default);
     });
@@ -225,19 +247,15 @@ describe(`[workbox-sw] WorkboxSW`, function() {
 
   describe(`get precaching`, function() {
     it(`should return precaching.default`, function() {
-      const fakeWorkbox = {
-        precaching: {
-          default: {},
-        },
-      };
-      sandbox.stub(WorkboxSW.prototype, 'loadModule').callsFake((moduleName) => {
-        if (moduleName === 'workbox-precaching') {
-          global.workbox = fakeWorkbox;
-        }
-      });
-
       const wb = new WorkboxSW();
       expect(wb.precaching).to.equal(fakeWorkbox.precaching.default);
+    });
+  });
+
+  describe(`get strategies`, function() {
+    it(`should return all of strategies`, function() {
+      const wb = new WorkboxSW();
+      expect(wb.strategies).to.equal(fakeWorkbox.strategies);
     });
   });
 });

--- a/test/workbox-sw/static/sw.js
+++ b/test/workbox-sw/static/sw.js
@@ -7,7 +7,10 @@ const wb = new self.WorkboxSW({
   },
 });
 
-wb.core.setLogLevel(self.workbox.core.LOG_LEVELS.log);
+wb.skipWaiting();
+wb.clientsClaim();
+
+wb.core.setLogLevel(self.workbox.core.LOG_LEVELS.debug);
 
 wb.precaching.precache([
   'example.css',


### PR DESCRIPTION
R: @jeffposnick @addyosmani @philipwalton 

This uses the proxy stuff to make it possible to dynamically pull in workbox modules via importScripts and via the need to know about the `workbox` namespace and 'default' export name.

See what you think. I am slightly concerned that the list of modules is manually curated and not tested, so I will likely change the list to come from a auto-generated build step that will look for modules that have namespaces different to their module name and add only those to the mapping.

I also am concerned that any value will result in an attempted network request - this will likely just lead to some super unnecessary hits on storage that could be prevented. BUT for now I'll leave as is.