### PR TITLE
Precaching coverage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,9 +41,6 @@ module.exports = {
       'infra/testing/cli-test-helper.js',
       'infra/utils/log-helper.js',
       'packages/workbox-cli/src/lib/logger.js',
-      'test/workbox-precaching/node/controllers/test-PrecacheController.mjs',
-      'test/workbox-precaching/node/utils/test-showWarningsIfNeeded.mjs',
-      'test/workbox-precaching/node/utils/test-printCleanupDetails.mjs',
     ],
     rules: {
       'no-console': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,7 @@ module.exports = {
       'packages/workbox-cli/src/lib/logger.js',
       'test/workbox-precaching/node/controllers/test-PrecacheController.mjs',
       'test/workbox-precaching/node/utils/test-showWarningsIfNeeded.mjs',
+      'test/workbox-precaching/node/utils/test-printCleanupDetails.mjs',
     ],
     rules: {
       'no-console': 0,

--- a/gulp-tasks/test-node.js
+++ b/gulp-tasks/test-node.js
@@ -56,7 +56,15 @@ gulp.task('test-node:clean', () => {
 });
 
 gulp.task('test-node:coverage', () => {
-  return spawn(getNpmCmd(), ['run', 'coverage-report']);
+  const runOptions = ['run', 'coverage-report'];
+  if (global.packageOrStar !== '*') {
+    runOptions.push('--');
+    runOptions.push('--include');
+    runOptions.push(
+      path.posix.join('packages', global.packageOrStar, '**', '*')
+    );
+  }
+  return spawn(getNpmCmd(), runOptions);
 });
 
 gulp.task('test-node', gulp.series(

--- a/infra/testing/auto-stub-logger.mjs
+++ b/infra/testing/auto-stub-logger.mjs
@@ -1,0 +1,21 @@
+import sinon from 'sinon';
+import logger from '../../packages/workbox-core/utils/logger.mjs';
+
+const sandbox = sinon.sandbox.create();
+
+// This is part of the "root" mocha suite - meaning it'll reset all the logger
+// values before every test.
+beforeEach(function() {
+  sandbox.restore();
+
+  sandbox.stub(logger, 'debug');
+  sandbox.stub(logger, 'log');
+  sandbox.stub(logger, 'warn');
+  sandbox.stub(logger, 'error');
+  sandbox.stub(logger, 'groupCollapsed');
+  sandbox.stub(logger, 'groupEnd');
+});
+
+after(function() {
+  sandbox.restore();
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "local-jsdoc": "jsdoc",
     "local-lerna": "lerna",
-    "test": "nyc --clean false --require @std/esm --require ./infra/testing/sw-env --silent mocha",
+    "test": "nyc --clean false --require @std/esm --require ./infra/testing/sw-env --silent mocha ./infra/testing/auto-stub-logger.mjs",
     "coverage-report": "nyc report --reporter lcov --reporter text",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "eslint \"**/*.{js,mjs}\" --ignore-path .gitignore",

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -40,9 +40,6 @@ class PrecacheController {
     this._cacheName = _private.cacheNames.getPrecacheName(cacheName);
     this._entriesToCacheMap = new Map();
     this._precacheDetailsModel = new PrecachedDetailsModel(this._cacheName);
-    if (process.env.NODE_ENV !== 'production') {
-      this._checkEntryRevisioning = true;
-    }
   }
 
   /**
@@ -144,9 +141,7 @@ class PrecacheController {
    */
   async install() {
     if (process.env.NODE_ENV !== 'production') {
-      if (this._checkEntryRevisioning === true) {
-        showWarningsIfNeeded(this._entriesToCacheMap);
-      }
+      showWarningsIfNeeded(this._entriesToCacheMap);
     }
 
     const updatedEntries = [];
@@ -307,7 +302,7 @@ class PrecacheController {
    *
    * @return {Array<string>} An array of URLs.
    */
-  async getCachedUrls() {
+  getCachedUrls() {
     return Array.from(this._entriesToCacheMap.keys())
     .map((url) => new URL(url, location).href);
   }

--- a/packages/workbox-precaching/default.mjs
+++ b/packages/workbox-precaching/default.mjs
@@ -24,32 +24,33 @@ let fetchListenersAdded = false;
 const cacheName = _private.cacheNames.getPrecacheName();
 const precacheController = new PrecacheController(cacheName);
 
-/**
- * This method will add items to the precache list, removing duplicates
- * and ensuring the information is valid.
- *
- * @param {Array<Object|string>} entries Array of entries to precache.
- *
- * @alias module:workbox-precaching.precache
- */
-const precache = (entries) => {
-  precacheController.addToCacheList(entries);
+const _removeIgnoreUrlParams = (origUrlObject, ignoreUrlParametersMatching) => {
+  // Exclude initial '?'
+  const searchString = origUrlObject.search.slice(1);
 
-  if (installActivateListenersAdded || entries.length <= 0) {
-    return;
-  }
-
-  installActivateListenersAdded = true;
-  self.addEventListener('install', (event) => {
-    event.waitUntil(precacheController.install());
+  // Split into an array of 'key=value' strings
+  const keyValueStrings = searchString.split('&');
+  const keyValuePairs = keyValueStrings.map((keyValueString) => {
+    // Split each 'key=value' string into a [key, value] array
+    return keyValueString.split('=');
   });
-  self.addEventListener('activate', (event) => {
-    event.waitUntil(precacheController.cleanup());
+  const filteredKeyValuesPairs = keyValuePairs.filter((keyValuePair) => {
+    return ignoreUrlParametersMatching
+      .every((ignoredRegex) => {
+        // Return true iff the key doesn't match any of the regexes.
+        return !ignoredRegex.test(keyValuePair[0]);
+      });
   });
-};
+  const filteredStrings = filteredKeyValuesPairs.map((keyValuePair) => {
+    // Join each [key, value] array into a 'key=value' string
+    return keyValuePair.join('=');
+  });
 
-const removeIgnoreUrlParams = (url, ignoreUrlParametersMatching) => {
-
+  // Join the array of 'key=value' strings into a string with '&' in
+  // between each
+  const urlClone = new URL(origUrlObject);
+  urlClone.search = filteredStrings.join('&');
+  return urlClone;
 };
 
 /**
@@ -63,7 +64,10 @@ const removeIgnoreUrlParams = (url, ignoreUrlParametersMatching) => {
  *
  * @private
  */
-const _getPrecachedUrl = (url, options) => {
+const _getPrecachedUrl = (url, {
+  ignoreUrlParametersMatching = [/^utm_/],
+  directoryIndex = 'index.html',
+} = {}) => {
   const urlObject = new URL(url, location);
 
   // If we precache '/some-url' but the URL referenced from the browser
@@ -78,21 +82,47 @@ const _getPrecachedUrl = (url, options) => {
     return urlObject.href;
   }
 
-  let strippedUrl = removeIgnoreUrlParams(
-    urlObject.href, options.ignoreUrlParametersMatching
+  let strippedUrl = _removeIgnoreUrlParams(
+    urlObject, ignoreUrlParametersMatching
   );
   if (cachedUrls.indexOf(strippedUrl.href) !== -1) {
     return strippedUrl.href;
   }
 
-  if (options.directoryIndex && strippedUrl.pathname.endsWith('/')) {
-    strippedUrl.pathname += options.directoryIndex;
+  if (directoryIndex && strippedUrl.pathname.endsWith('/')) {
+    strippedUrl.pathname += directoryIndex;
     if (cachedUrls.indexOf(strippedUrl.href) !== -1) {
       return strippedUrl.href;
     }
   }
 
   return null;
+};
+
+const moduleExports = {};
+
+/**
+ * This method will add items to the precache list, removing duplicates
+ * and ensuring the information is valid.
+ *
+ * @param {Array<Object|string>} entries Array of entries to precache.
+ *
+ * @alias module:workbox-precaching.precache
+ */
+moduleExports.precache = (entries) => {
+  precacheController.addToCacheList(entries);
+
+  if (installActivateListenersAdded || entries.length <= 0) {
+    return;
+  }
+
+  installActivateListenersAdded = true;
+  self.addEventListener('install', (event) => {
+    event.waitUntil(precacheController.install());
+  });
+  self.addEventListener('activate', (event) => {
+    event.waitUntil(precacheController.cleanup());
+  });
 };
 
 /**
@@ -111,7 +141,7 @@ const _getPrecachedUrl = (url, options) => {
  *
  * @alias module:workbox-precaching.addRoute
  */
-const addRoute = (options) => {
+moduleExports.addRoute = (options) => {
   if (fetchListenersAdded) {
     // TODO Throw error here.
     return;
@@ -143,13 +173,9 @@ const addRoute = (options) => {
  *
  * @alias module:workbox-precaching.precacheAndRoute
  */
-const precacheAndRoute = (entries, options) => {
-  precache(entries);
-  addRoute(options);
+moduleExports.precacheAndRoute = (entries, options) => {
+  moduleExports.precache(entries);
+  moduleExports.addRoute(options);
 };
 
-export default {
-  precache,
-  addRoute,
-  precacheAndRoute,
-};
+export default moduleExports;

--- a/packages/workbox-precaching/default.mjs
+++ b/packages/workbox-precaching/default.mjs
@@ -64,20 +64,22 @@ const removeIgnoreUrlParams = (url, ignoreUrlParametersMatching) => {
  * @private
  */
 const _getPrecachedUrl = (url, options) => {
+  const urlObject = new URL(url, location);
+
   // If we precache '/some-url' but the URL referenced from the browser
   // is '/some-url#1234', the comparison won't work unless we normalise
   // the URLS.
   // See https://github.com/GoogleChrome/workbox/issues/488.
-  url.hash = '';
+  urlObject.hash = '';
 
   const cachedUrls = precacheController.getCachedUrls();
-  if (cachedUrls.indexOf(url.href) !== -1) {
+  if (cachedUrls.indexOf(urlObject.href) !== -1) {
     // It's a perfect match
-    return url.href;
+    return urlObject.href;
   }
 
   let strippedUrl = removeIgnoreUrlParams(
-    url.href, options.ignoreUrlParametersMatching
+    urlObject.href, options.ignoreUrlParametersMatching
   );
   if (cachedUrls.indexOf(strippedUrl.href) !== -1) {
     return strippedUrl.href;

--- a/packages/workbox-precaching/index.mjs
+++ b/packages/workbox-precaching/index.mjs
@@ -16,7 +16,7 @@
 
 import core from 'workbox-core';
 import PrecacheController from './controllers/PrecacheController.mjs';
-import defaultPrecachingExport from './default-precaching-export.mjs';
+import defaultPrecachingExport from './default.mjs';
 import './_version.mjs';
 /**
  * @module workbox-precaching

--- a/packages/workbox-precaching/utils/printCleanupDetails.mjs
+++ b/packages/workbox-precaching/utils/printCleanupDetails.mjs
@@ -34,7 +34,7 @@ const logGroup = (groupTitle, urls) => {
  * @private
  * @memberof module:workbox-precachig
  */
-export default async (deletedCacheRequests, deletedRevisionDetails) => {
+export default (deletedCacheRequests, deletedRevisionDetails) => {
   if (deletedCacheRequests.length === 0 &&
     deletedRevisionDetails.length === 0) {
     return;
@@ -51,8 +51,8 @@ export default async (deletedCacheRequests, deletedRevisionDetails) => {
     `${revisionDeleteCount === 1 ? 'entry' : 'entries'} ` +
     `${revisionDeleteCount === 1 ? 'was' : 'were'} deleted from IndexedDB.`;
 
-    _private.logger.groupCollapsed(
-     `During precaching cleanup, ${cacheDeleteText} and ${revisionDeleteText}`);
+  _private.logger.groupCollapsed(
+    `During precaching cleanup, ${cacheDeleteText} and ${revisionDeleteText}`);
 
   logGroup('Deleted Cache Requests', deletedCacheRequests);
   logGroup('Revision Details Deleted from DB', deletedRevisionDetails);

--- a/packages/workbox-precaching/utils/printInstallDetails.mjs
+++ b/packages/workbox-precaching/utils/printInstallDetails.mjs
@@ -40,7 +40,7 @@ const logGroup = (groupTitle, entries) => {
  * @private
  * @memberof module:workbox-precachig
  */
-export default async (updatedEntries, notUpdatedEntries) => {
+export default (updatedEntries, notUpdatedEntries) => {
   // Goal is to print the message:
   //    Precached X files.
   // Or:

--- a/test/workbox-core/node/utils/test-logger.mjs
+++ b/test/workbox-core/node/utils/test-logger.mjs
@@ -6,15 +6,18 @@ import logger from '../../../../packages/workbox-core/utils/logger.mjs';
 
 
 describe(`workbox-core logger`, function() {
-  let sandbox;
-
-  before(async function() {
-    sandbox = sinon.sandbox.create();
-  });
+  const sandbox = sinon.sandbox.create();
 
   beforeEach(function() {
     // Reset between runs
     core.setLogLevel(LOG_LEVELS.debug);
+
+    // Undo the logger stubs setup in infra/testing/auto-stub-logger.mjs
+    Object.keys(logger).forEach((key) => {
+      if (logger[key].restore) {
+        logger[key].restore();
+      }
+    });
   });
 
   afterEach(function() {

--- a/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
@@ -27,12 +27,6 @@ describe(`[workbox-precaching] PrecacheController`, function() {
     // a mocha bug where `afterEach` hooks aren't run for skipped tests.
     // https://github.com/mochajs/mocha/issues/2546
     sandbox.restore();
-
-    sandbox.stub(logger, 'log');
-    sandbox.stub(logger, 'debug');
-    sandbox.stub(logger, 'warn');
-    sandbox.stub(logger, 'groupCollapsed');
-    sandbox.stub(logger, 'groupEnd');
   });
 
   after(function() {

--- a/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
@@ -7,6 +7,7 @@ import generateTestVariants from '../../../../infra/testing/generate-variant-tes
 import {prodOnly, devOnly} from '../../../../infra/testing/env-it';
 
 import {_private} from '../../../../packages/workbox-core/index.mjs';
+import logger from '../../../../packages/workbox-core/utils/logger.mjs';
 import PrecacheController from '../../../../packages/workbox-precaching/controllers/PrecacheController.mjs';
 
 const {cacheNames} = _private;
@@ -27,11 +28,11 @@ describe(`[workbox-precaching] PrecacheController`, function() {
     // https://github.com/mochajs/mocha/issues/2546
     sandbox.restore();
 
-    sandbox.stub(console, 'log');
-    sandbox.stub(console, 'debug');
-    sandbox.stub(console, 'warn');
-    sandbox.stub(console, 'groupCollapsed');
-    sandbox.stub(console, 'groupEnd');
+    sandbox.stub(logger, 'log');
+    sandbox.stub(logger, 'debug');
+    sandbox.stub(logger, 'warn');
+    sandbox.stub(logger, 'groupCollapsed');
+    sandbox.stub(logger, 'groupEnd');
   });
 
   after(function() {
@@ -221,7 +222,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       precacheController.addToCacheList(cacheList);
 
       // Reset as addToCacheList will log.
-      console.log.reset();
+      logger.log.reset();
 
       const updateInfo = await precacheController.install();
       expect(updateInfo.updatedEntries.length).to.equal(cacheList.length);
@@ -240,7 +241,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
 
       if (process.env.NODE_ENV != 'production') {
         // Make sure we print some debug info.
-        expect(console.log.callCount).to.be.gt(0);
+        expect(logger.log.callCount).to.be.gt(0);
       }
     });
 
@@ -254,7 +255,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
 
       await precacheController.install();
 
-      expect(console.log.callCount).to.equal(0);
+      expect(logger.log.callCount).to.equal(0);
     });
 
     it(`should clean redirected precache entries`, async function() {
@@ -312,7 +313,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       precacheControllerOne.addToCacheList(cacheListOne);
 
       // Reset as addToCacheList will log.
-      console.log.reset();
+      logger.log.reset();
 
       const updateInfo = await precacheControllerOne.install();
       expect(updateInfo.updatedEntries.length).to.equal(cacheListOne.length);
@@ -329,7 +330,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
 
       if (process.env.NODE_ENV != 'production') {
         // Make sure we print some debug info.
-        expect(console.log.callCount).to.be.gt(0);
+        expect(logger.log.callCount).to.be.gt(0);
       }
 
       /*
@@ -345,7 +346,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       precacheControllerTwo.addToCacheList(cacheListTwo);
 
       // Reset as addToCacheList will log.
-      console.log.reset();
+      logger.log.reset();
 
       const updateInfoTwo = await precacheControllerTwo.install();
       expect(updateInfoTwo.updatedEntries.length).to.equal(2);
@@ -367,7 +368,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
 
       if (process.env.NODE_ENV != 'production') {
         // Make sure we print some debug info.
-        expect(console.log.callCount).to.be.gt(0);
+        expect(logger.log.callCount).to.be.gt(0);
       }
     });
   });
@@ -393,14 +394,14 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       await precacheControllerOne.install();
 
       // Reset as addToCacheList and install will log.
-      console.log.reset();
+      logger.log.reset();
 
       const cleanupDetailsOne = await precacheControllerOne.cleanup();
       expect(cleanupDetailsOne.deletedCacheRequests.length).to.equal(0);
       expect(cleanupDetailsOne.deletedRevisionDetails.length).to.equal(0);
 
       // Make sure we print some debug info.
-      expect(console.log.callCount).to.equal(0);
+      expect(logger.log.callCount).to.equal(0);
 
       /*
       THEN precache the same URLs but two with different revisions
@@ -416,7 +417,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       await precacheControllerTwo.install();
 
       // Reset as addToCacheList and install will log.
-      console.log.reset();
+      logger.log.reset();
 
       const cleanupDetailsTwo = await precacheControllerTwo.cleanup();
       expect(cleanupDetailsTwo.deletedCacheRequests.length).to.equal(1);
@@ -439,7 +440,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       }));
 
       // Make sure we print some debug info.
-      expect(console.log.callCount).to.be.gt(0);
+      expect(logger.log.callCount).to.be.gt(0);
     });
 
     it(`shouldn't open / create a cache when performing cleanup`, async function() {
@@ -473,12 +474,12 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       await precacheControllerTwo.install();
 
       // Reset as addToCacheList and install will log.
-      console.log.reset();
+      logger.log.reset();
 
       await precacheControllerTwo.cleanup();
 
       // Make sure we didn't print any debug info.
-      expect(console.log.callCount).to.equal(0);
+      expect(logger.log.callCount).to.equal(0);
     });
   });
 

--- a/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
@@ -481,4 +481,25 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       expect(console.log.callCount).to.equal(0);
     });
   });
+
+  describe(`getCachedUrls()`, function() {
+    it(`should return the cached URLs`, function() {
+      const precacheController = new PrecacheController();
+      const cacheList = [
+        '/index.1234.html',
+        {url: '/example.1234.css'},
+        {url: '/scripts/index.js', revision: '1234'},
+        {url: '/scripts/stress.js?test=search&foo=bar', revision: '1234'},
+      ];
+      precacheController.addToCacheList(cacheList);
+
+      const urls = precacheController.getCachedUrls();
+      expect(urls).to.deep.equal([
+        new URL('/index.1234.html', location).toString(),
+        new URL('/example.1234.css', location).toString(),
+        new URL('/scripts/index.js', location).toString(),
+        new URL('/scripts/stress.js?test=search&foo=bar', location).toString(),
+      ]);
+    });
+  });
 });

--- a/test/workbox-precaching/node/controllers/test-default.mjs
+++ b/test/workbox-precaching/node/controllers/test-default.mjs
@@ -2,7 +2,8 @@ import sinon from 'sinon';
 import {expect} from 'chai';
 import clearRequire from 'clear-require';
 
-import {PrecacheController} from '../../../../packages/workbox-precaching/index.mjs';
+import core from '../../../../packages/workbox-core/index.mjs';
+import PrecacheController from '../../../../packages/workbox-precaching/controllers/PrecacheController.mjs';
 
 describe(`[workbox-precaching] default export`, function() {
   const sandbox = sinon.sandbox.create();
@@ -12,9 +13,9 @@ describe(`[workbox-precaching] default export`, function() {
     sandbox.restore();
 
     // console.log('CLEARNING <-----------------------------');
-    clearRequire('../../../../packages/workbox-precaching/index.mjs');
+    clearRequire('../../../../packages/workbox-precaching/default.mjs');
 
-    const module = await import('../../../../packages/workbox-precaching/index.mjs');
+    const module = await import('../../../../packages/workbox-precaching/default.mjs');
     precaching = module.default;
   });
 
@@ -24,7 +25,7 @@ describe(`[workbox-precaching] default export`, function() {
 
   describe(`precache()`, function() {
     it(`should only install and activate listeners once`, function() {
-      sandbox.spy(self, 'addEventListener');
+      sandbox.stub(self, 'addEventListener');
 
       precaching.precache(['/']);
       precaching.precache(['/2']);
@@ -37,6 +38,8 @@ describe(`[workbox-precaching] default export`, function() {
     it(`should call install and cleanup on install and activate`, async function() {
       sandbox.spy(PrecacheController.prototype, 'install');
       sandbox.spy(PrecacheController.prototype, 'cleanup');
+
+      expect(PrecacheController.prototype.install.callCount).to.equal(0);
 
       precaching.precache(['/']);
 
@@ -76,10 +79,50 @@ describe(`[workbox-precaching] default export`, function() {
       sandbox.stub(self, 'addEventListener');
 
       precaching.addRoute();
-      // precaching.addRoute();
+      precaching.addRoute();
 
       expect(self.addEventListener.callCount).to.equal(1);
       expect(self.addEventListener.args[0][0]).to.equal('fetch');
+    });
+
+    it(`should add a fetch listener that only matches precached urls`, async function() {
+      let fetchCb;
+      sandbox.stub(self, 'addEventListener').callsFake((eventName, cb) => {
+        if (eventName === 'fetch') {
+          fetchCb = cb;
+        }
+      });
+
+      precaching.addRoute();
+      precaching.precache(['/']);
+
+      const cachedResponse = new Response('Injected Response');
+      const cache = await caches.open(core.cacheNames.precache);
+      cache.put(new URL('/', location).href, cachedResponse);
+
+      const fetchEvent = new FetchEvent('fetch', {
+        request: new Request('/'),
+      });
+      let fetchPromise;
+      fetchEvent.respondWith = (promise) => {
+        fetchPromise = promise;
+      };
+      fetchCb(fetchEvent);
+
+      const response = await fetchPromise;
+      expect(response).to.exist;
+      expect(response).to.equal(cachedResponse);
+
+      const unprecachedFetchEvent = new FetchEvent('fetch', {
+        request: new Request('/url-isnt-precached'),
+      });
+
+      unprecachedFetchEvent.respondWith = () => {
+        throw new Error('respondWith() must not be called for non-precached URLs');
+      };
+
+      const result = fetchCb(unprecachedFetchEvent);
+      expect(typeof result).to.equal('undefined');
     });
   });
 });

--- a/test/workbox-precaching/node/controllers/test-default.mjs
+++ b/test/workbox-precaching/node/controllers/test-default.mjs
@@ -12,7 +12,6 @@ describe(`[workbox-precaching] default export`, function() {
   beforeEach(async function() {
     sandbox.restore();
 
-    // console.log('CLEARNING <-----------------------------');
     clearRequire('../../../../packages/workbox-precaching/default.mjs');
 
     const module = await import('../../../../packages/workbox-precaching/default.mjs');

--- a/test/workbox-precaching/node/controllers/test-default.mjs
+++ b/test/workbox-precaching/node/controllers/test-default.mjs
@@ -1,0 +1,85 @@
+import sinon from 'sinon';
+import {expect} from 'chai';
+import clearRequire from 'clear-require';
+
+import {PrecacheController} from '../../../../packages/workbox-precaching/index.mjs';
+
+describe(`[workbox-precaching] default export`, function() {
+  const sandbox = sinon.sandbox.create();
+  let precaching;
+
+  beforeEach(async function() {
+    sandbox.restore();
+
+    // console.log('CLEARNING <-----------------------------');
+    clearRequire('../../../../packages/workbox-precaching/index.mjs');
+
+    const module = await import('../../../../packages/workbox-precaching/index.mjs');
+    precaching = module.default;
+  });
+
+  after(function() {
+    sandbox.restore();
+  });
+
+  describe(`precache()`, function() {
+    it(`should only install and activate listeners once`, function() {
+      sandbox.spy(self, 'addEventListener');
+
+      precaching.precache(['/']);
+      precaching.precache(['/2']);
+
+      expect(self.addEventListener.callCount).to.equal(2);
+      expect(self.addEventListener.args[0][0]).to.equal('install');
+      expect(self.addEventListener.args[1][0]).to.equal('activate');
+    });
+
+    it(`should call install and cleanup on install and activate`, async function() {
+      sandbox.spy(PrecacheController.prototype, 'install');
+      sandbox.spy(PrecacheController.prototype, 'cleanup');
+
+      precaching.precache(['/']);
+
+      const installEvent = new ExtendableEvent('install');
+      let controllerInstallPromise;
+      installEvent.waitUntil = (promise) => {
+        controllerInstallPromise = promise;
+      };
+      self.dispatchEvent(installEvent);
+
+      await controllerInstallPromise;
+      expect(PrecacheController.prototype.install.callCount).to.equal(1);
+
+      const activateEvent = new ExtendableEvent('activate');
+      let controllerActivatePromise;
+      activateEvent.waitUntil = (promise) => {
+        controllerActivatePromise = promise;
+      };
+      self.dispatchEvent(activateEvent);
+
+      await controllerActivatePromise;
+      expect(PrecacheController.prototype.cleanup.callCount).to.equal(1);
+    });
+  });
+
+  describe(`addRoute()`, function() {
+    it(`should add a fetch listener when called`, function() {
+      sandbox.stub(self, 'addEventListener');
+
+      precaching.addRoute();
+
+      expect(self.addEventListener.callCount).to.equal(1);
+      expect(self.addEventListener.args[0][0]).to.equal('fetch');
+    });
+
+    it(`should not allow adding route twice`, function() {
+      sandbox.stub(self, 'addEventListener');
+
+      precaching.addRoute();
+      // precaching.addRoute();
+
+      expect(self.addEventListener.callCount).to.equal(1);
+      expect(self.addEventListener.args[0][0]).to.equal('fetch');
+    });
+  });
+});

--- a/test/workbox-precaching/node/utils/test-cleanRedirect.mjs
+++ b/test/workbox-precaching/node/utils/test-cleanRedirect.mjs
@@ -1,0 +1,31 @@
+import sinon from 'sinon';
+import {expect} from 'chai';
+
+import cleanRedirect from '../../../../packages/workbox-precaching/utils/cleanRedirect.mjs';
+
+describe(`[workbox-precaching] cleanRedirect()`, function() {
+  const sandbox = sinon.sandbox.create();
+
+  beforeEach(function() {
+    sandbox.restore();
+  });
+
+  after(function() {
+    sandbox.restore();
+  });
+
+  it(`should use blob where there is no body in the reponse`, async function() {
+    const response = new Response('Original Response');
+    sandbox.stub(response, 'clone').callsFake(() => {
+      const newResponse = new Response('Repeated Response');
+      delete newResponse.body;
+      newResponse.blob = () => {
+        return Promise.resolve('Blob Body');
+      };
+      return newResponse;
+    });
+
+    const cleanedResponse = await cleanRedirect(response);
+    expect(cleanedResponse.body).to.equal('Blob Body');
+  });
+});

--- a/test/workbox-precaching/node/utils/test-printCleanupDetails.mjs
+++ b/test/workbox-precaching/node/utils/test-printCleanupDetails.mjs
@@ -10,12 +10,6 @@ describe(`[workbox-precaching] printCleanupDetails`, function() {
 
   beforeEach(function() {
     sandbox.restore();
-
-    sandbox.stub(logger, 'log');
-    sandbox.stub(logger, 'debug');
-    sandbox.stub(logger, 'warn');
-    sandbox.stub(logger, 'groupCollapsed');
-    sandbox.stub(logger, 'groupEnd');
   });
 
   after(function() {

--- a/test/workbox-precaching/node/utils/test-printCleanupDetails.mjs
+++ b/test/workbox-precaching/node/utils/test-printCleanupDetails.mjs
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 import {expect} from 'chai';
 
 import {devOnly} from '../../../../infra/testing/env-it';
+import logger from '../../../../packages/workbox-core/utils/logger.mjs';
 import printCleanupDetails from '../../../../packages/workbox-precaching/utils/printCleanupDetails.mjs';
 
 describe(`[workbox-precaching] printCleanupDetails`, function() {
@@ -10,11 +11,11 @@ describe(`[workbox-precaching] printCleanupDetails`, function() {
   beforeEach(function() {
     sandbox.restore();
 
-    sandbox.spy(console, 'log');
-    sandbox.stub(console, 'debug');
-    sandbox.stub(console, 'warn');
-    sandbox.stub(console, 'groupCollapsed');
-    sandbox.stub(console, 'groupEnd');
+    sandbox.stub(logger, 'log');
+    sandbox.stub(logger, 'debug');
+    sandbox.stub(logger, 'warn');
+    sandbox.stub(logger, 'groupCollapsed');
+    sandbox.stub(logger, 'groupEnd');
   });
 
   after(function() {
@@ -24,18 +25,18 @@ describe(`[workbox-precaching] printCleanupDetails`, function() {
   it(`shouldn't print if nothing was deleted`, function() {
     printCleanupDetails([], []);
 
-    expect(console.log.callCount).to.equal(0);
+    expect(logger.log.callCount).to.equal(0);
   });
 
   devOnly.it(`should print at least one entry was delete`, function() {
     printCleanupDetails(['/'], ['/']);
 
-    expect(console.log.callCount).to.be.gt(0);
+    expect(logger.log.callCount).to.be.gt(0);
   });
 
   devOnly.it(`should print strings with multiple entries`, function() {
     printCleanupDetails(['/', '/2'], ['/', '/2']);
 
-    expect(console.log.callCount).to.be.gt(0);
+    expect(logger.log.callCount).to.be.gt(0);
   });
 });

--- a/test/workbox-precaching/node/utils/test-printCleanupDetails.mjs
+++ b/test/workbox-precaching/node/utils/test-printCleanupDetails.mjs
@@ -1,0 +1,41 @@
+import sinon from 'sinon';
+import {expect} from 'chai';
+
+import {devOnly} from '../../../../infra/testing/env-it';
+import printCleanupDetails from '../../../../packages/workbox-precaching/utils/printCleanupDetails.mjs';
+
+describe(`[workbox-precaching] printCleanupDetails`, function() {
+  let sandbox = sinon.sandbox.create();
+
+  beforeEach(function() {
+    sandbox.restore();
+
+    sandbox.spy(console, 'log');
+    sandbox.stub(console, 'debug');
+    sandbox.stub(console, 'warn');
+    sandbox.stub(console, 'groupCollapsed');
+    sandbox.stub(console, 'groupEnd');
+  });
+
+  after(function() {
+    sandbox.restore();
+  });
+
+  it(`shouldn't print if nothing was deleted`, function() {
+    printCleanupDetails([], []);
+
+    expect(console.log.callCount).to.equal(0);
+  });
+
+  devOnly.it(`should print at least one entry was delete`, function() {
+    printCleanupDetails(['/'], ['/']);
+
+    expect(console.log.callCount).to.be.gt(0);
+  });
+
+  devOnly.it(`should print strings with multiple entries`, function() {
+    printCleanupDetails(['/', '/2'], ['/', '/2']);
+
+    expect(console.log.callCount).to.be.gt(0);
+  });
+});

--- a/test/workbox-precaching/node/utils/test-printInstallDetails.mjs
+++ b/test/workbox-precaching/node/utils/test-printInstallDetails.mjs
@@ -1,0 +1,31 @@
+import sinon from 'sinon';
+import {expect} from 'chai';
+
+import {devOnly} from '../../../../infra/testing/env-it';
+import printInstallDetails from '../../../../packages/workbox-precaching/utils/printInstallDetails.mjs';
+import PrecacheEntry from '../../../../packages/workbox-precaching/models/PrecacheEntry.mjs';
+
+describe(`[workbox-precaching] printInstallDetails`, function() {
+  let sandbox = sinon.sandbox.create();
+
+  beforeEach(function() {
+    sandbox.restore();
+
+    sandbox.spy(console, 'log');
+    sandbox.stub(console, 'debug');
+    sandbox.stub(console, 'warn');
+    sandbox.stub(console, 'groupCollapsed');
+    sandbox.stub(console, 'groupEnd');
+  });
+
+  after(function() {
+    sandbox.restore();
+  });
+
+  devOnly.it(`should print with single update`, function() {
+    const precacheEntry = new PrecacheEntry({url: '/'}, '/', '/', false);
+    printInstallDetails([], [precacheEntry]);
+
+    expect(console.log.callCount).to.equal(1);
+  });
+});

--- a/test/workbox-precaching/node/utils/test-printInstallDetails.mjs
+++ b/test/workbox-precaching/node/utils/test-printInstallDetails.mjs
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 import {expect} from 'chai';
 
 import {devOnly} from '../../../../infra/testing/env-it';
+import logger from '../../../../packages/workbox-core/utils/logger.mjs';
 import printInstallDetails from '../../../../packages/workbox-precaching/utils/printInstallDetails.mjs';
 import PrecacheEntry from '../../../../packages/workbox-precaching/models/PrecacheEntry.mjs';
 
@@ -11,11 +12,11 @@ describe(`[workbox-precaching] printInstallDetails`, function() {
   beforeEach(function() {
     sandbox.restore();
 
-    sandbox.spy(console, 'log');
-    sandbox.stub(console, 'debug');
-    sandbox.stub(console, 'warn');
-    sandbox.stub(console, 'groupCollapsed');
-    sandbox.stub(console, 'groupEnd');
+    sandbox.stub(logger, 'log');
+    sandbox.stub(logger, 'debug');
+    sandbox.stub(logger, 'warn');
+    sandbox.stub(logger, 'groupCollapsed');
+    sandbox.stub(logger, 'groupEnd');
   });
 
   after(function() {
@@ -26,6 +27,6 @@ describe(`[workbox-precaching] printInstallDetails`, function() {
     const precacheEntry = new PrecacheEntry({url: '/'}, '/', '/', false);
     printInstallDetails([], [precacheEntry]);
 
-    expect(console.log.callCount).to.equal(1);
+    expect(logger.log.callCount).to.equal(1);
   });
 });

--- a/test/workbox-precaching/node/utils/test-printInstallDetails.mjs
+++ b/test/workbox-precaching/node/utils/test-printInstallDetails.mjs
@@ -11,12 +11,6 @@ describe(`[workbox-precaching] printInstallDetails`, function() {
 
   beforeEach(function() {
     sandbox.restore();
-
-    sandbox.stub(logger, 'log');
-    sandbox.stub(logger, 'debug');
-    sandbox.stub(logger, 'warn');
-    sandbox.stub(logger, 'groupCollapsed');
-    sandbox.stub(logger, 'groupEnd');
   });
 
   after(function() {

--- a/test/workbox-precaching/node/utils/test-showWarningsIfNeeded.mjs
+++ b/test/workbox-precaching/node/utils/test-showWarningsIfNeeded.mjs
@@ -10,12 +10,6 @@ describe(`[workbox-precaching] showWarningsIfNeeded`, function() {
 
   beforeEach(function() {
     sandbox.restore();
-
-    sandbox.stub(logger, 'log');
-    sandbox.stub(logger, 'debug');
-    sandbox.stub(logger, 'warn');
-    sandbox.stub(logger, 'groupCollapsed');
-    sandbox.stub(logger, 'groupEnd');
   });
 
   after(function() {

--- a/test/workbox-precaching/node/utils/test-showWarningsIfNeeded.mjs
+++ b/test/workbox-precaching/node/utils/test-showWarningsIfNeeded.mjs
@@ -1,9 +1,9 @@
 import sinon from 'sinon';
 import {expect} from 'chai';
 
-import constants from '../../../../gulp-tasks/utils/constants';
 import PrecacheEntry from '../../../../packages/workbox-precaching/models/PrecacheEntry.mjs';
 import showWarningsIfNeeded from '../../../../packages/workbox-precaching/utils/showWarningsIfNeeded.mjs';
+import logger from '../../../../packages/workbox-core/utils/logger.mjs';
 
 describe(`[workbox-precaching] showWarningsIfNeeded`, function() {
   let sandbox = sinon.sandbox.create();
@@ -11,11 +11,11 @@ describe(`[workbox-precaching] showWarningsIfNeeded`, function() {
   beforeEach(function() {
     sandbox.restore();
 
-    sandbox.stub(console, 'log');
-    sandbox.stub(console, 'debug');
-    sandbox.stub(console, 'warn');
-    sandbox.stub(console, 'groupCollapsed');
-    sandbox.stub(console, 'groupEnd');
+    sandbox.stub(logger, 'log');
+    sandbox.stub(logger, 'debug');
+    sandbox.stub(logger, 'warn');
+    sandbox.stub(logger, 'groupCollapsed');
+    sandbox.stub(logger, 'groupEnd');
   });
 
   after(function() {
@@ -30,7 +30,7 @@ describe(`[workbox-precaching] showWarningsIfNeeded`, function() {
 
     showWarningsIfNeeded(entriesMap);
 
-    expect(console.log.callCount).to.equal(0);
+    expect(logger.log.callCount).to.equal(0);
   });
 
   it(`should print as the entry has no revision`, function() {
@@ -41,10 +41,6 @@ describe(`[workbox-precaching] showWarningsIfNeeded`, function() {
 
     showWarningsIfNeeded(entriesMap);
 
-    if (process.env.NODE_ENV === constants.BUILD_TYPES.prod) {
-      expect(console.log.callCount).to.equal(0);
-    } else {
-      expect(console.log.callCount).to.be.gt(0);
-    }
+    expect(logger.log.callCount).to.be.gt(0);
   });
 });

--- a/test/workbox-routing/node/test-Router.mjs
+++ b/test/workbox-routing/node/test-Router.mjs
@@ -5,7 +5,6 @@ import Route from '../../../packages/workbox-routing/Route.mjs';
 import Router from '../../../packages/workbox-routing/Router.mjs';
 import expectError from '../../../infra/testing/expectError';
 import generateTestVariants from '../../../infra/testing/generate-variant-tests';
-import {_private} from '../../../packages/workbox-core/index.mjs';
 
 describe(`[workbox-routing] Router`, function() {
   const sandbox = sinon.sandbox.create();

--- a/test/workbox-routing/node/test-Router.mjs
+++ b/test/workbox-routing/node/test-Router.mjs
@@ -9,7 +9,6 @@ import {_private} from '../../../packages/workbox-core/index.mjs';
 
 describe(`[workbox-routing] Router`, function() {
   const sandbox = sinon.sandbox.create();
-  const {logger} = _private;
   const MATCH = () => {};
   const HANDLER = {handle: () => {}};
   const METHOD = 'POST';
@@ -20,8 +19,6 @@ describe(`[workbox-routing] Router`, function() {
     // a mocha bug where `afterEach` hooks aren't run for skipped tests.
     // https://github.com/mochajs/mocha/issues/2546
     sandbox.restore();
-    // Prevent logs in the mocha output.
-    sandbox.stub(logger);
   });
 
   after(function() {


### PR DESCRIPTION
R: @jeffposnick @addyosmani @philipwalton 

- Adds tests for the default export logic
- Fixes a few bugs
- Adds an auto-logger stub that basically silences a big chunk of the output from the library (I need to find a solution for the workbox-core welcome message that is clogging up tests)