### PR TITLE
V3 sw mock update

### DIFF
--- a/infra/testing/sw-env-mocks/FetchEvent.js
+++ b/infra/testing/sw-env-mocks/FetchEvent.js
@@ -13,9 +13,6 @@
  limitations under the License.
 */
 
-
-const ExtendableEvent = require('./ExtendableEvent');
-
 // FetchEvent
 // https://www.w3.org/TR/service-workers-1/#fetch-event-section
 class FetchEvent extends ExtendableEvent {

--- a/infra/testing/sw-env-mocks/SyncEvent.js
+++ b/infra/testing/sw-env-mocks/SyncEvent.js
@@ -13,7 +13,6 @@
  limitations under the License.
 */
 
-
 const ExtendableEvent = require('./ExtendableEvent');
 
 // SyncEvent

--- a/infra/testing/sw-env.js
+++ b/infra/testing/sw-env.js
@@ -44,5 +44,6 @@ global.SyncEvent = SyncEvent;
 
 // Because we override Request, we can use the serivce-worker-mock because it
 // checks for type of Request, that will no longer match in our tests.
+// We need to use Request until https://github.com/pinterest/service-workers/issues/65
 global.Request = Request;
 global.FetchEvent = FetchEvent;

--- a/infra/testing/sw-env.js
+++ b/infra/testing/sw-env.js
@@ -12,37 +12,37 @@
  */
 
 const serviceWorkerMock = require('service-worker-mock');
+
+// Assign first so other classes can inherit the globals
+// Assign all properties of `self` to `global`;
+Object.assign(global, serviceWorkerMock());
+// Ensure `self` and `global` are the same object so stubbing works on either.
+global.self = global;
+
 const {IDBFactory, IDBKeyRange} = require('shelving-mock-indexeddb');
 const Blob = require('./sw-env-mocks/Blob');
 const Event = require('./sw-env-mocks/Event');
 const {addEventListener, dispatchEvent} = require('./sw-env-mocks/event-listeners');
-const ExtendableEvent = require('./sw-env-mocks/ExtendableEvent');
 const fetch = require('./sw-env-mocks/fetch');
 const FetchEvent = require('./sw-env-mocks/FetchEvent');
-const Headers = require('./sw-env-mocks/Headers');
 const Request = require('./sw-env-mocks/Request');
 const SyncEvent = require('./sw-env-mocks/SyncEvent');
 const SyncManager = require('./sw-env-mocks/SyncManager');
-
-// Assign all properties of `self` to `global`;
-Object.assign(global, serviceWorkerMock());
-
-// Ensure `self` and `global` are the same object so stubbing works on either.
-global.self = global;
 
 // Add/fix globals not in 'service-worker-mock'.
 global.addEventListener = addEventListener;
 global.Blob = Blob;
 global.dispatchEvent = dispatchEvent;
 global.Event = Event;
-global.ExtendableEvent = ExtendableEvent;
 global.fetch = fetch;
-global.FetchEvent = FetchEvent;
-global.Headers = Headers;
 global.indexedDB = new IDBFactory();
 global.IDBKeyRange = IDBKeyRange;
 global.importScripts = () => {};
 global.location = 'https://example.com';
 global.registration.sync = new SyncManager();
-global.Request = Request;
 global.SyncEvent = SyncEvent;
+
+// Because we override Request, we can use the serivce-worker-mock because it
+// checks for type of Request, that will no longer match in our tests.
+global.Request = Request;
+global.FetchEvent = FetchEvent;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3996,6 +3996,15 @@
         "isarray": "1.0.0"
       }
     },
+    "dom-urls": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
+      "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
+      "dev": true,
+      "requires": {
+        "urijs": "1.19.0"
+      }
+    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -14299,10 +14308,13 @@
       "dev": true
     },
     "service-worker-mock": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-1.5.0.tgz",
-      "integrity": "sha1-VqO1744N+ugInhQ42jCeEsgpdh8=",
-      "dev": true
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-1.7.0.tgz",
+      "integrity": "sha1-03TWH41MH7ps/KhK/MzKgLjDXLM=",
+      "dev": true,
+      "requires": {
+        "dom-urls": "1.1.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -15801,6 +15813,12 @@
           }
         }
       }
+    },
+    "urijs": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.0.tgz",
+      "integrity": "sha512-Qs2odXn0hST5VSPVjpi73CMqtbAoanahaqWBujGU+IyMrMqpWcIhDewxQRhCkmqYxuyvICDcSuLdv2O7ncWBGw==",
+      "dev": true
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "semver": "^5.4.1",
     "serve-index": "^1.9.1",
     "serve-static": "^1.13.1",
-    "service-worker-mock": "^1.5.0",
+    "service-worker-mock": "^1.7.0",
     "shelving-mock-indexeddb": "philipwalton/shelving-mock-indexeddb#clone-fix",
     "sinon": "^3.2.1",
     "tempy": "^0.2.1",


### PR DESCRIPTION
R: @jeffposnick @addyosmani @philipwalton 

Updates service worker mock.

There are a few issues that crop up when we switch everything over that can be switched over.

The most worrying thing is the headers and background sync - The mock just inherits Map, I don't know if this is correct or not, but when passing this into background sync indexed DB started to complain about needing JSON friendly objects.

Routing also had some issues that appears with the FetchEvent, but that was because the mock checks if the request input is of type 'Request' which we override so it doesn't actually work :(
