### PR TITLE
Direct logs

### DIFF
--- a/infra/testing/auto-stub-logger.mjs
+++ b/infra/testing/auto-stub-logger.mjs
@@ -3,17 +3,21 @@ import logger from '../../packages/workbox-core/utils/logger.mjs';
 
 const sandbox = sinon.sandbox.create();
 
+const stubLogger = () => {
+  sandbox.stub(logger);
+  sandbox.stub(logger.unprefixed);
+};
+
+// Silence any early messages (Normally caused by logging from an import at
+// the top of a test)
+stubLogger();
+
 // This is part of the "root" mocha suite - meaning it'll reset all the logger
 // values before every test.
 beforeEach(function() {
   sandbox.restore();
 
-  sandbox.stub(logger, 'debug');
-  sandbox.stub(logger, 'log');
-  sandbox.stub(logger, 'warn');
-  sandbox.stub(logger, 'error');
-  sandbox.stub(logger, 'groupCollapsed');
-  sandbox.stub(logger, 'groupEnd');
+  stubLogger();
 });
 
 after(function() {

--- a/packages/workbox-core/utils/logger.mjs
+++ b/packages/workbox-core/utils/logger.mjs
@@ -31,8 +31,13 @@ const shouldPrint = (minLevel) => (logLevel <= minLevel);
 const setLoggerLevel = (newLogLevel) => logLevel = newLogLevel;
 const getLoggerLevel = () => logLevel;
 
-const _print = function(logFunction, logArgs, minLevel, levelColor) {
+const _print = function(logFunction, minLevel, logArgs, levelColor) {
   if (!shouldPrint(minLevel)) {
+    return;
+  }
+
+  if (!levelColor) {
+    logFunction(...logArgs);
     return;
   }
 
@@ -45,20 +50,57 @@ const _print = function(logFunction, logArgs, minLevel, levelColor) {
   logFunction(...logPrefix, ...logArgs);
 };
 
-const debug = (...args) => _print(console.debug, args, LOG_LEVELS.debug, GREY);
-const log = (...args) => _print(console.log, args, LOG_LEVELS.log, GREEN);
-const warn = (...args) => _print(console.warn, args, LOG_LEVELS.warn, YELLOW);
-const error = (...args) => _print(console.error, args, LOG_LEVELS.error, RED);
-
 // We always want groups to be logged unless logLevel is silent.
 const groupLevel = LOG_LEVELS.error;
-const groupCollapsed =
-  (...args) => _print(console.groupCollapsed, args, groupLevel, BLUE);
+
 const groupEnd = () => {
   if (shouldPrint(groupLevel)) {
     console.groupEnd();
   }
 };
+
+const defaultExport = {
+  groupEnd,
+  unprefixed: {
+    groupEnd,
+  },
+};
+const configs = {
+  debug: {
+    func: console.debug,
+    level: LOG_LEVELS.debug,
+    color: GREY,
+  },
+  log: {
+    func: console.log,
+    level: LOG_LEVELS.log,
+    color: GREEN,
+  },
+  warn: {
+    func: console.warn,
+    level: LOG_LEVELS.warn,
+    color: YELLOW,
+  },
+  error: {
+    func: console.error,
+    level: LOG_LEVELS.error,
+    color: RED,
+  },
+  groupCollapsed: {
+    func: console.groupCollapsed,
+    level: groupLevel,
+    color: BLUE,
+  },
+};
+Object.keys(configs).forEach((keyName) => {
+  const logConfig = configs[keyName];
+  defaultExport[keyName] =
+    (...args) => _print(logConfig.func, logConfig.level, args, logConfig.color);
+  defaultExport.unprefixed[keyName] =
+    (...args) => _print(logConfig.func, logConfig.level, args);
+});
+
 export {setLoggerLevel};
 export {getLoggerLevel};
-export default {log, debug, warn, error, groupCollapsed, groupEnd};
+
+export default defaultExport;

--- a/packages/workbox-core/workboxCore.mjs
+++ b/packages/workbox-core/workboxCore.mjs
@@ -53,20 +53,18 @@ class WorkboxCore {
     if (process.env.NODE_ENV !== 'production') {
       const padding = '   ';
       logger.groupCollapsed('Welcome to Workbox!');
-      /* eslint-disable no-console */
-      console.log(
+      logger.unprefixed.log(
         `📖 Read the guides and documentation\n` +
         `${padding}https://developers.google.com/web/tools/workbox/`
       );
-      console.log(
+      logger.unprefixed.log(
         `❓ Use the [workbox] tag on StackOverflow to ask questions\n` +
         `${padding}https://stackoverflow.com/questions/ask?tags=workbox`
       );
-      console.log(
+      logger.unprefixed.log(
         `🐛 Found a bug? Report it on GitHub\n` +
         `${padding}https://github.com/GoogleChrome/workbox/issues/new`
       );
-      /* eslint-enable no-console */
       logger.groupEnd();
     }
   }

--- a/packages/workbox-routing/Router.mjs
+++ b/packages/workbox-routing/Router.mjs
@@ -119,7 +119,7 @@ class Router {
           // hide it under a group in case developers wants to see it.
           _private.logger.groupCollapsed(
             `    View full request details here.`);
-          _private.logger.unprefixed.log(event.request); // eslint-disable-line no-console
+          _private.logger.unprefixed.log(event.request);
           _private.logger.groupEnd();
 
           debugMessages.forEach((msg) => {

--- a/packages/workbox-routing/Router.mjs
+++ b/packages/workbox-routing/Router.mjs
@@ -14,7 +14,7 @@
 */
 
 import core from 'workbox-core';
-import {_private, LOG_LEVELS} from 'workbox-core';
+import {_private} from 'workbox-core';
 
 import normalizeHandler from './lib/normalizeHandler.mjs';
 import './_version.mjs';
@@ -112,26 +112,24 @@ class Router {
         } else {
           // We have a handler, meaning Workbox is handling the route. print to
           // log.
-          if (core.logLevel <= LOG_LEVELS.log) {
-            _private.logger.groupCollapsed(
-              `Router is responding to: ${urlToLog}`);
+          _private.logger.groupCollapsed(
+            `Router is responding to: ${urlToLog}`);
 
-            // The Request object contains a great deal of information,
-            // hide it under a group in case developers wants to see it.
-            _private.logger.groupCollapsed(
-              `    View full request details here.`);
-            console.log(event.request); // eslint-disable-line no-console
-            _private.logger.groupEnd();
+          // The Request object contains a great deal of information,
+          // hide it under a group in case developers wants to see it.
+          _private.logger.groupCollapsed(
+            `    View full request details here.`);
+          _private.logger.unprefixed.log(event.request); // eslint-disable-line no-console
+          _private.logger.groupEnd();
 
-            debugMessages.forEach((msg) => {
-              if (Array.isArray(msg)) {
-                _private.logger.log(...msg);
-              } else {
-                _private.logger.log(msg);
-              }
-            });
-            _private.logger.groupEnd();
-          }
+          debugMessages.forEach((msg) => {
+            if (Array.isArray(msg)) {
+              _private.logger.unprefixed.log(...msg);
+            } else {
+              _private.logger.unprefixed.log(msg);
+            }
+          });
+          _private.logger.groupEnd();
         }
       }
     }

--- a/test/workbox-core/static/logger.html
+++ b/test/workbox-core/static/logger.html
@@ -25,6 +25,8 @@
 <script>
   const logger = workbox.core._private.logger;
 
+  workbox.core.default.setLogLevel(workbox.core.LOG_LEVELS.debug);
+
   const currentLevel = document.querySelector('.js-current-level');
   switch(workbox.core.default.logLevel) {
     case 0:


### PR DESCRIPTION
R: @jeffposnick @addyosmani @philipwalton 

Once I started adding logs for the router (and I had some quirks with the precaching), I quickly wanted to print to the console without any 'workbox' branding because the logs were nested in a group that had the workbox label. I cheated and just used the console.

The down side of this is it went outside the logger filtering and it resulted in some hella messy logs in the test console.

This PR adds a set of methods to `logger.unprefixed.*` that match `logger.* / console.*` that will still go through the workbox filters but will exclude the workbox label.

Also changed up the logger stub to silence all logs in the tests from Workbox-core.

Fixes #930 