### PR TITLE
Precaching warning tweaks

### DIFF
--- a/packages/workbox-precaching/_default.mjs
+++ b/packages/workbox-precaching/_default.mjs
@@ -194,7 +194,6 @@ moduleExports.precacheAndRoute = (entries, options) => {
  */
 moduleExports.suppressWarnings = (suppress) => {
   suppressWarnings = suppress;
-  console.log('Function Called: ', suppressWarnings);
 };
 
 export default moduleExports;

--- a/packages/workbox-precaching/_default.mjs
+++ b/packages/workbox-precaching/_default.mjs
@@ -24,6 +24,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 let installActivateListenersAdded = false;
 let fetchListenersAdded = false;
+let suppressWarnings = false;
 
 const cacheName = cacheNames.getPrecacheName();
 const precacheController = new PrecacheController(cacheName);
@@ -122,7 +123,7 @@ moduleExports.precache = (entries) => {
 
   installActivateListenersAdded = true;
   self.addEventListener('install', (event) => {
-    event.waitUntil(precacheController.install());
+    event.waitUntil(precacheController.install({suppressWarnings}));
   });
   self.addEventListener('activate', (event) => {
     event.waitUntil(precacheController.cleanup());
@@ -180,6 +181,20 @@ moduleExports.addRoute = (options) => {
 moduleExports.precacheAndRoute = (entries, options) => {
   moduleExports.precache(entries);
   moduleExports.addRoute(options);
+};
+
+/**
+ * Warnings will be logged if any of the precached assets are entered without
+ * a `revision` property. This is extremely dangerous if the URL's aren't
+ * revisioned. However, the warnings can be supressed with this method.
+ *
+ * @param {boolean} suppress
+ *
+ * @alias module:workbox-precahcing.suppressWarnings
+ */
+moduleExports.suppressWarnings = (suppress) => {
+  suppressWarnings = suppress;
+  console.log('Function Called: ', suppressWarnings);
 };
 
 export default moduleExports;

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -141,11 +141,15 @@ class PrecacheController {
    * Call this method from a service work install event to start
    * precaching assets.
    *
+   * @param {Object} options
+   * @param {boolean} options.suppressWarnings Suppress warning messages.
    * @return {Promise<Object>}
    */
-  async install() {
+  async install(options = {}) {
     if (process.env.NODE_ENV !== 'production') {
-      showWarningsIfNeeded(this._entriesToCacheMap);
+      if (options.suppressWarnings !== true) {
+        showWarningsIfNeeded(this._entriesToCacheMap);
+      }
     }
 
     const updatedEntries = [];

--- a/packages/workbox-precaching/utils/showWarningsIfNeeded.mjs
+++ b/packages/workbox-precaching/utils/showWarningsIfNeeded.mjs
@@ -56,9 +56,8 @@ export default (entriesMap) => {
     `\n\n`
   );
 
-  // TODO (gauntface) Before launch swap for d.g.c/web URL and use
-  // logger.unprefixed.warn for these messages.
-  logger.warn(`You can learn more about why this might be a ` +
+  // TODO (gauntface) Before launch swap for d.g.c/web URL
+  logger.unprefixed.warn(`You can learn more about why this might be a ` +
     `problem here: https://docs.google.com/document/d/1i83D4x_1Jz2JT3BCRjO` +
     `18m-vdL9uG7ksscqZ_E0XjO0/edit?usp=sharing`);
 

--- a/packages/workbox-precaching/utils/showWarningsIfNeeded.mjs
+++ b/packages/workbox-precaching/utils/showWarningsIfNeeded.mjs
@@ -56,7 +56,8 @@ export default (entriesMap) => {
     `\n\n`
   );
 
-  // TODO (gauntface) Before launch swap for d.g.c/web URL.
+  // TODO (gauntface) Before launch swap for d.g.c/web URL and use
+  // logger.unprefixed.warn for these messages.
   logger.warn(`You can learn more about why this might be a ` +
     `problem here: https://docs.google.com/a/google.com/document/d/` +
     `1lM_fVQZpohD8N1QLuxobmrYrq9lOJh4jYF3MJhNrMvs/edit?usp=sharing`);

--- a/packages/workbox-precaching/utils/showWarningsIfNeeded.mjs
+++ b/packages/workbox-precaching/utils/showWarningsIfNeeded.mjs
@@ -50,39 +50,16 @@ export default (entriesMap) => {
   }).join(`\n`);
 
   logger.warn(
-    `The following precache entries might not be revisioned:\n` +
-    `\n` +
+    `The following precache entries might not be revisioned:` +
+    `\n\n` +
     urlsList +
     `\n\n`
   );
 
-  logger.log(
-    `'workbox-precaching' ensures assets are only downloaded when needed, ` +
-    `saving user's data and speeding up the install time of new service ` +
-    `workers.\n` +
-    `\n` +
-    `To do this, 'workbox-precaching' needs assets to by revisioned so it ` +
-    `can detect when a file has changed. Without revisioning, your users ` +
-    `may not get the latest files, causing problems when you a new ` +
-    `service worker is deployed.\n` +
-    `\n` +
-    `For example, the following entries have URLs without revisioning:\n` +
-    `\n` +
-    `        '/styles/example.css'\n` +
-    `        { url: '/index.html' }\n` +
-    `\n` +
-    `Compare this to URLs which are revisioned:\n` +
-    `\n` +
-    `        '/styles/example.1234.css'\n` +
-    `        { url: '/index.1234.html' }\n` +
-    `\n` +
-    `If your URLs aren't revisioned, please remove them from ` +
-    `precaching to make sure your users don't end up in a broken state.\n`
-  );
-
-  // TODO Add link to docs here.....
-  logger.debug(`You can learn more about this issue and possible ` +
-    `solutions here...`);
+  // TODO (gauntface) Before launch swap for d.g.c/web URL.
+  logger.warn(`You can learn more about why this might be a ` +
+    `problem here: https://docs.google.com/a/google.com/document/d/` +
+    `1lM_fVQZpohD8N1QLuxobmrYrq9lOJh4jYF3MJhNrMvs/edit?usp=sharing`);
 
   logger.groupEnd();
 };

--- a/packages/workbox-precaching/utils/showWarningsIfNeeded.mjs
+++ b/packages/workbox-precaching/utils/showWarningsIfNeeded.mjs
@@ -59,8 +59,8 @@ export default (entriesMap) => {
   // TODO (gauntface) Before launch swap for d.g.c/web URL and use
   // logger.unprefixed.warn for these messages.
   logger.warn(`You can learn more about why this might be a ` +
-    `problem here: https://docs.google.com/a/google.com/document/d/` +
-    `1lM_fVQZpohD8N1QLuxobmrYrq9lOJh4jYF3MJhNrMvs/edit?usp=sharing`);
+    `problem here: https://docs.google.com/document/d/1i83D4x_1Jz2JT3BCRjO` +
+    `18m-vdL9uG7ksscqZ_E0XjO0/edit?usp=sharing`);
 
   logger.groupEnd();
 };

--- a/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
@@ -205,6 +205,21 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       return precacheController.install();
     });
 
+    devOnly.it('should not print warnings if suppressWarnings is passed in', async function() {
+      const precacheController = new PrecacheController();
+      precacheController.addToCacheList(['/']);
+
+      await precacheController.install({
+        suppressWarnings: true,
+      });
+      expect(logger.warn.callCount).to.equal(0);
+
+      await precacheController.install({
+        suppressWarnings: false,
+      });
+      expect(logger.warn.callCount).to.be.gt(0);
+    });
+
     it('should precache assets (with cache busting via search params)', async function() {
       const precacheController = new PrecacheController();
       const cacheList = [

--- a/test/workbox-precaching/node/test-precaching-module.mjs
+++ b/test/workbox-precaching/node/test-precaching-module.mjs
@@ -33,6 +33,7 @@ describe(`[workbox-precaching] Module`, function() {
         'precache',
         'addRoute',
         'precacheAndRoute',
+        'suppressWarnings',
       ]);
     });
 

--- a/test/workbox-precaching/node/utils/test-showWarningsIfNeeded.mjs
+++ b/test/workbox-precaching/node/utils/test-showWarningsIfNeeded.mjs
@@ -35,6 +35,6 @@ describe(`[workbox-precaching] showWarningsIfNeeded`, function() {
 
     showWarningsIfNeeded(entriesMap);
 
-    expect(logger.log.callCount).to.be.gt(0);
+    expect(logger.warn.callCount).to.be.gt(0);
   });
 });


### PR DESCRIPTION
R: @jeffposnick @addyosmani @philipwalton 

- This swaps out the hella long precaching warnig with a link to docs (This will need to be substituted for a d.g.c link but for now it gets the point across
- Also added the ability to surpess this warning in case developers who are revisioning assets that are revisioned want to shut it up. I doubt it'll get much use but I know I'd want it if I used this.

This is the last bit of precaching I want to touch. I'll add some integration tests for workbox routing and upgrading / changing service workers, but that'll be it apart from docs.
