### PR TITLE
Logging changes

### DIFF
--- a/demos/functions/views/demo/workbox-cache-expiration.hbs
+++ b/demos/functions/views/demo/workbox-cache-expiration.hbs
@@ -5,7 +5,6 @@
         <ol>
           <li>Open DevTools</li>
           <li>Go to the Console</li>
-          <li>Click this button:<br /><button class="install-sw btn btn-outline-primary">Install Service Worker</button></li>
           <li>Click the following buttons and look at the Cache and IndexedDB entries.
             <ol>
               <li><button class="entry-1 btn btn-outline-primary">Entry 1</button> (Expires in: <span class="entry-expire-1">Not Added Yet</span>)</li>
@@ -26,10 +25,7 @@
   const TIMEOUT_IN_SECS = 30;
   const MAX_ENTRIES = 3;
 
-  const installSWBtn = document.querySelector('.install-sw');
-  installSWBtn.addEventListener('click', () => {
-    navigator.serviceWorker.register('/demo/workbox-cache-expiration/sw.js');
-  });
+  navigator.serviceWorker.register('/demo/workbox-cache-expiration/sw.js');
 
   const setupTimeout = (btnElement, textElement) => {
     textElement.textContent = `${btnElement.__workbox_timeoutCount}s`;

--- a/demos/functions/views/demo/workbox-cache-expiration/sw.hbs
+++ b/demos/functions/views/demo/workbox-cache-expiration/sw.hbs
@@ -1,8 +1,5 @@
-importScripts('{{CDN_URL}}/workbox-sw.dev.js');
-
-workbox.setConfig({
-  debug: true
-});
+importScripts('{{CDN_URL}}/workbox-core.dev.js');
+importScripts('{{CDN_URL}}/workbox-cache-expiration.dev.js');
 
 const expirationManager = new workbox.expiration.CacheExpiration(
   'cache-expiration', {

--- a/demos/functions/views/demo/workbox-precaching/sw-1.hbs
+++ b/demos/functions/views/demo/workbox-precaching/sw-1.hbs
@@ -1,8 +1,5 @@
-importScripts('{{CDN_URL}}/workbox-sw.dev.js');
-
-workbox.setConfig({
-  debug: true
-});
+importScripts('{{CDN_URL}}/workbox-core.dev.js');
+importScripts('{{CDN_URL}}/workbox-precaching.dev.js');
 
 workbox.precaching.precache([
   {url: '/demo/workbox-precaching', revision: '1'},

--- a/demos/functions/views/demo/workbox-precaching/sw-2.hbs
+++ b/demos/functions/views/demo/workbox-precaching/sw-2.hbs
@@ -1,8 +1,5 @@
-importScripts('{{CDN_URL}}/workbox-sw.dev.js');
-
-workbox.setConfig({
-  debug: true
-});
+importScripts('{{CDN_URL}}/workbox-core.dev.js');
+importScripts('{{CDN_URL}}/workbox-precaching.dev.js');
 
 workbox.precaching.precache([
   {url: '/demo/workbox-precaching', revision: '2'},

--- a/demos/functions/views/demo/workbox-routing/sw.hbs
+++ b/demos/functions/views/demo/workbox-routing/sw.hbs
@@ -1,8 +1,5 @@
-importScripts('{{CDN_URL}}/workbox-sw.dev.js');
-
-workbox.setConfig({
-  debug: true
-});
+importScripts('{{CDN_URL}}/workbox-core.dev.js');
+importScripts('{{CDN_URL}}/workbox-routing.dev.js');
 
 // TODO Skip Waiting
 // TODO Clients Claim

--- a/demos/functions/views/demo/workbox-runtime-caching.hbs
+++ b/demos/functions/views/demo/workbox-runtime-caching.hbs
@@ -5,7 +5,6 @@
         <ol>
           <li>Open DevTools</li>
           <li>Go to the Console</li>
-          <li>Click this button:<br /><button class="install-sw btn btn-outline-primary">Install Service Worker</button></li>
           <li>Click any of the buttons below and view the logs:
             <ul>
               <li>
@@ -27,10 +26,7 @@
 </section>
 
 <script>
-  const installBtn = document.querySelector('.install-sw');
-  installBtn.addEventListener('click', () => {
-    navigator.serviceWorker.register('/demo/workbox-runtime-caching/sw.js');
-  });
+  navigator.serviceWorker.register('/demo/workbox-runtime-caching/sw.js');
 
   const cacheOnlyEmpty = document.querySelector('.cache-only-empty-cache');
   cacheOnlyEmpty.addEventListener('click', () => {

--- a/demos/functions/views/demo/workbox-runtime-caching/sw.hbs
+++ b/demos/functions/views/demo/workbox-runtime-caching/sw.hbs
@@ -15,7 +15,7 @@ self.addEventListener('install', (event) => {
     .then((cache) => {
       return cache.put(
         new Request('/demo/workbox-runtime-caching/cache-only-populated-cache'),
-        new Response('Hello from the populated cache.'),
+        new Response('Hello from the populated cache.')
       );
     })
   );

--- a/demos/functions/views/demo/workbox-runtime-caching/sw.hbs
+++ b/demos/functions/views/demo/workbox-runtime-caching/sw.hbs
@@ -1,4 +1,3 @@
-// TODO Swap for workbox-sw
 importScripts('{{CDN_URL}}/workbox-core.dev.js');
 importScripts('{{CDN_URL}}/workbox-runtime-caching.dev.js');
 

--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -53,7 +53,7 @@ const putWrapper = async (cacheName, request, response, plugins = []) => {
     await matchWrapper(cacheName, request) : null;
 
   if (process.env.NODE_ENV !== 'production') {
-    logger.log(`Updating the '${cacheName}' cache with a new Response for ` +
+    logger.debug(`Updating the '${cacheName}' cache with a new Response for ` +
       `${getFriendlyURL(request.url)}.`);
   }
 
@@ -89,9 +89,9 @@ const matchWrapper = async (cacheName, request, matchOptions, plugins = []) => {
   let cachedResponse = await cache.match(request, matchOptions);
   if (process.env.NODE_ENV !== 'production') {
     if (cachedResponse) {
-      logger.log(`Found a cached response in '${cacheName}'.`);
+      logger.debug(`Found a cached response in '${cacheName}'.`);
     } else {
-      logger.log(`No cached response found in '${cacheName}'.`);
+      logger.debug(`No cached response found in '${cacheName}'.`);
     }
   }
   for (let plugin of plugins) {

--- a/packages/workbox-core/_private/fetchWrapper.mjs
+++ b/packages/workbox-core/_private/fetchWrapper.mjs
@@ -80,7 +80,7 @@ const wrappedFetch = async (request, fetchOptions, plugins = []) => {
   try {
     const response = await fetch(request, fetchOptions);
     if (process.env.NODE_ENV !== 'production') {
-      logger.log(`Network request for `+
+      logger.debug(`Network request for `+
       `'${getFriendlyURL(request.url)}' returned a response with ` +
       `status '${response.status}'.`);
     }

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -156,7 +156,7 @@ class PrecacheController {
     const entriesToPrecache = [];
     const entriesAlreadyPrecached = [];
 
-    for (let precacheEntry of this._entriesToCacheMap.values()) {
+    for (const precacheEntry of this._entriesToCacheMap.values()) {
       if (await this._precacheDetailsModel._isEntryCached(precacheEntry)) {
         entriesAlreadyPrecached.push(precacheEntry);
       } else {
@@ -178,8 +178,8 @@ class PrecacheController {
     }
 
     return {
-      'updatedEntries': entriesToPrecache,
-      'notUpdatedEntries': entriesAlreadyPrecached,
+      updatedEntries: entriesToPrecache,
+      notUpdatedEntries: entriesAlreadyPrecached,
     };
   }
 

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -20,11 +20,12 @@ import {
   fetchWrapper,
   cacheWrapper,
   assert,
+  logger,
 } from 'workbox-core/_private.mjs';
 import PrecacheEntry from '../models/PrecacheEntry.mjs';
 import PrecachedDetailsModel from '../models/PrecachedDetailsModel.mjs';
 import showWarningsIfNeeded from '../utils/showWarningsIfNeeded.mjs';
-import printInstallDetails from '../utils/printInstallDetails.mjs';
+import openInstallLogGroup from '../utils/openInstallLogGroup.mjs';
 import printCleanupDetails from '../utils/printCleanupDetails.mjs';
 import cleanRedirect from '../utils/cleanRedirect.mjs';
 import '../_version.mjs';
@@ -152,33 +153,33 @@ class PrecacheController {
       }
     }
 
-    const updatedEntries = [];
-    const notUpdatedEntries = [];
+    const entriesToPrecache = [];
+    const entriesAlreadyPrecached = [];
 
-    const cachePromises = [];
-    this._entriesToCacheMap.forEach((precacheEntry) => {
-      const promiseChain = this._cacheEntry(precacheEntry)
-      .then((wasUpdated) => {
-        if (wasUpdated) {
-          updatedEntries.push(precacheEntry);
-        } else {
-          notUpdatedEntries.push(precacheEntry);
-        }
-      });
-
-      cachePromises.push(promiseChain);
-    });
-
-    // Wait for all requests to be cached.
-    await Promise.all(cachePromises);
+    for (let precacheEntry of this._entriesToCacheMap.values()) {
+      if (await this._precacheDetailsModel._isEntryCached(precacheEntry)) {
+        entriesAlreadyPrecached.push(precacheEntry);
+      } else {
+        entriesToPrecache.push(precacheEntry);
+      }
+    }
 
     if (process.env.NODE_ENV !== 'production') {
-      printInstallDetails(updatedEntries, notUpdatedEntries);
+      openInstallLogGroup(entriesToPrecache, entriesAlreadyPrecached);
+    }
+
+    // Wait for all requests to be cached.
+    await Promise.all(entriesToPrecache.map((precacheEntry) => {
+      return this._cacheEntry(precacheEntry);
+    }));
+
+    if (process.env.NODE_ENV !== 'production') {
+      logger.groupEnd();
     }
 
     return {
-      'updatedEntries': updatedEntries,
-      'notUpdatedEntries': notUpdatedEntries,
+      'updatedEntries': entriesToPrecache,
+      'notUpdatedEntries': entriesAlreadyPrecached,
     };
   }
 
@@ -194,10 +195,6 @@ class PrecacheController {
    * false if the entry is already cached and up-to-date.
    */
   async _cacheEntry(precacheEntry) {
-    if (await this._precacheDetailsModel._isEntryCached(precacheEntry)) {
-      return false;
-    }
-
     let response = await fetchWrapper.fetch(
       precacheEntry._networkRequest,
     );

--- a/packages/workbox-precaching/utils/openInstallLogGroup.mjs
+++ b/packages/workbox-precaching/utils/openInstallLogGroup.mjs
@@ -23,7 +23,11 @@ import '../_version.mjs';
  *
  * @private
  */
-const logGroup = (groupTitle, entries) => {
+const _nestedGroup = (groupTitle, entries) => {
+  if (entries.length === 0) {
+    return;
+  }
+
   logger.groupCollapsed(groupTitle);
 
   entries.forEach((entry) => {
@@ -34,40 +38,33 @@ const logGroup = (groupTitle, entries) => {
 };
 
 /**
- * @param {Array<Object>} updatedEntries
- * @param {Array<Object>} notUpdatedEntries
+ * @param {Array<Object>} entriesToPrecache
+ * @param {Array<Object>} alreadyPrecachedEntries
  *
  * @private
  * @memberof module:workbox-precachig
  */
-export default (updatedEntries, notUpdatedEntries) => {
+export default (entriesToPrecache, alreadyPrecachedEntries) => {
   // Goal is to print the message:
-  //    Precached X files.
+  //    Precaching X files.
   // Or:
-  //    Precached X files. Y files were cached and up-to-date.
+  //    Precaching X files. Y files were cached and up-to-date.
 
-  const updatedCount = updatedEntries.length;
-  const notUpdatedCount = notUpdatedEntries.length;
+  const precachedCount = entriesToPrecache.length;
+  const alreadyPrecachedCount = alreadyPrecachedEntries.length;
   let printText =
-    `Precached ${updatedCount} file${updatedCount === 1 ? '' : 's'}.`;
-  if (notUpdatedCount > 0) {
-    printText += ` ${notUpdatedCount} ` +
-      `file${notUpdatedCount === 1 ? ' was' : 's were'} already cached.`;
-  }
-  logger.groupCollapsed(printText);
-  if (updatedCount > 0 && notUpdatedCount === 0) {
-    // Don't nest groups, just show the precached entries.
-    updatedEntries.forEach((entry) => {
-      logger.log(entry._originalInput);
-    });
-  } else {
-    logGroup(
-      `Number of entries cached: ${updatedCount}`,
-      updatedEntries);
-    logGroup(
-      `Number of entries already cached: ${notUpdatedCount}`,
-      notUpdatedEntries);
+    `Precaching ${precachedCount} file${precachedCount === 1 ? '' : 's'}.`;
+  if (alreadyPrecachedCount > 0) {
+    printText += ` ${alreadyPrecachedCount} ` +
+      `file${alreadyPrecachedCount === 1 ? ' is' : 's are'} already cached.`;
   }
 
-  logger.groupEnd();
+  logger.groupCollapsed(printText);
+
+  _nestedGroup(
+    `View precached URLs.`,
+    entriesToPrecache);
+  _nestedGroup(
+    `View URLs that were already precached.`,
+    alreadyPrecachedEntries);
 };

--- a/packages/workbox-runtime-caching/CacheFirst.mjs
+++ b/packages/workbox-runtime-caching/CacheFirst.mjs
@@ -97,7 +97,8 @@ class CacheFirst {
       }
     } else {
       if (process.env.NODE_ENV !== 'production') {
-        logger.log(`Found a cached response in the '${this._cacheName}' cache.`);
+        logger.log(`Found a cached response in the '${this._cacheName}' ` +
+          `cache.`);
       }
     }
 

--- a/packages/workbox-runtime-caching/CacheFirst.mjs
+++ b/packages/workbox-runtime-caching/CacheFirst.mjs
@@ -78,10 +78,26 @@ class CacheFirst {
 
     let error;
     if (!response) {
+      if (process.env.NODE_ENV !== 'production') {
+        logger.log(`No response found in the '${this._cacheName}' cache. ` +
+          `Will respond with a network request.`);
+      }
       try {
         response = await this._getFromNetwork(event);
       } catch (err) {
         error = err;
+      }
+
+      if (process.env.NODE_ENV !== 'production') {
+        if (response) {
+          logger.log(`Got response from network.`);
+        } else {
+          logger.log(`Unable to get a response from the network.`);
+        }
+      }
+    } else {
+      if (process.env.NODE_ENV !== 'production') {
+        logger.log(`Found a cached response in the '${this._cacheName}' cache.`);
       }
     }
 

--- a/packages/workbox-runtime-caching/CacheOnly.mjs
+++ b/packages/workbox-runtime-caching/CacheOnly.mjs
@@ -76,7 +76,13 @@ class CacheOnly {
     );
 
     if (process.env.NODE_ENV !== 'production') {
-      messages.printFinalResponse(response);
+      if (response) {
+        logger.log(`Found a cached response in the '${this._cacheName}'` +
+          ` cache.`);
+        messages.printFinalResponse(response);
+      } else {
+        logger.log(`No response found in the '${this._cacheName}' cache.`);
+      }
       logger.groupEnd();
     }
 

--- a/packages/workbox-runtime-caching/NetworkOnly.mjs
+++ b/packages/workbox-runtime-caching/NetworkOnly.mjs
@@ -81,6 +81,11 @@ class NetworkOnly {
     }
 
     if (process.env.NODE_ENV !== 'production') {
+      if (response) {
+        logger.log(`Got response from network.`);
+      } else {
+        logger.log(`Unable to get a response from the network.`);
+      }
       messages.printFinalResponse(response);
       logger.groupEnd();
     }

--- a/packages/workbox-runtime-caching/StaleWhileRevalidate.mjs
+++ b/packages/workbox-runtime-caching/StaleWhileRevalidate.mjs
@@ -99,8 +99,12 @@ class StaleWhileRevalidate {
     );
 
     if (response) {
+      logger.log(`Found a cached response in the '${this._cacheName}'` +
+        ` cache. Will update with the network response in the background.`);
       event.waitUntil(fetchAndCachePromise);
     } else {
+      logger.log(`No response found in the '${this._cacheName}' cache. ` +
+        `Will wait for the network response.`);
       response = await fetchAndCachePromise;
     }
 

--- a/test/workbox-precaching/node/utils/test-openInstallLogGroup.mjs
+++ b/test/workbox-precaching/node/utils/test-openInstallLogGroup.mjs
@@ -3,10 +3,10 @@ import {expect} from 'chai';
 
 import {devOnly} from '../../../../infra/testing/env-it';
 import logger from '../../../../packages/workbox-core/_private/logger.mjs';
-import printInstallDetails from '../../../../packages/workbox-precaching/utils/printInstallDetails.mjs';
+import openInstallLogGroup from '../../../../packages/workbox-precaching/utils/openInstallLogGroup.mjs';
 import PrecacheEntry from '../../../../packages/workbox-precaching/models/PrecacheEntry.mjs';
 
-describe(`[workbox-precaching] printInstallDetails`, function() {
+describe(`[workbox-precaching] openInstallLogGroup`, function() {
   let sandbox = sinon.sandbox.create();
 
   beforeEach(function() {
@@ -19,7 +19,7 @@ describe(`[workbox-precaching] printInstallDetails`, function() {
 
   devOnly.it(`should print with single update`, function() {
     const precacheEntry = new PrecacheEntry({url: '/'}, '/', '/', false);
-    printInstallDetails([], [precacheEntry]);
+    openInstallLogGroup([], [precacheEntry]);
 
     expect(logger.log.callCount).to.equal(1);
   });


### PR DESCRIPTION
R: @jeffposnick @addyosmani @philipwalton 

I noticed that after updating the demos that logging from fetch and cache wrappers were very verbose in precaching so I took another stab at them.

- precaching and runtime caching modules will create groups that will "group" the relevant logs from fetch and cache wrappers under the appropriate request heading
- fetch and cache wrapper now print logs to debug. This means by default they won't be seen. This means developers / bug traces can include all of the fetch and cache wrapper info if needed.
- runtime caching has some more specific logs for each strategy that they didn't have before.