### PR TITLE
Ensure expireEntries is called

### DIFF
--- a/packages/workbox-cache-expiration/CacheExpirationPlugin.mjs
+++ b/packages/workbox-cache-expiration/CacheExpirationPlugin.mjs
@@ -114,6 +114,9 @@ class CacheExpirationPlugin {
       return true;
     }
 
+    // Check if the 'date' header will suffice a quick expiration check.
+    // See https://github.com/GoogleChromeLabs/sw-toolbox/issues/164 for
+    // discussion.
     const dateHeaderTimestamp = this._getDateHeaderTimestamp(cachedResponse);
     if (dateHeaderTimestamp === null) {
       // Unable to parse date, so assume it's fresh.

--- a/packages/workbox-cache-expiration/CacheExpirationPlugin.mjs
+++ b/packages/workbox-cache-expiration/CacheExpirationPlugin.mjs
@@ -52,7 +52,7 @@ class CacheExpirationPlugin {
       }
     }
 
-    this._maxEntries = config.maxEntries;
+    this._config = config;
     this._maxAgeSeconds = config.maxAgeSeconds;
     this._cacheExpirations = new Map();
   }
@@ -70,7 +70,7 @@ class CacheExpirationPlugin {
     let cacheExpiration = this._cacheExpirations.get(cacheName);
     if (!cacheExpiration) {
       cacheExpiration = new CacheExpiration(cacheName, this._config);
-      this._cacheExpirations.put(cacheName, cacheExpiration);
+      this._cacheExpirations.set(cacheName, cacheExpiration);
     }
     return cacheExpiration;
   }
@@ -92,11 +92,47 @@ class CacheExpirationPlugin {
    *         fresh, or `null` if the `Response` is older than `maxAgeSeconds`.
    */
   cachedResponseWillBeUsed({cacheName, cachedResponse} = {}) {
-    if (this.isResponseFresh({cacheName, cachedResponse})) {
-      return cachedResponse;
+    const dateHeaderTimestamp = this._getDateHeaderTimestamp(cachedResponse);
+    let isExpired = false;
+    if (dateHeaderTimestamp !== null) {
+      // If we have a valid headerTime, then our response is fresh iff the
+      // headerTime plus maxAgeSeconds is greater than the current time.
+      const now = Date.now();
+      isExpired = dateHeaderTimestamp < now - (this._maxAgeSeconds * 1000);
     }
 
-    return null;
+    // Expire entries to ensure that even if the expiration date has
+    // expired, it'll only be used once.
+    const cacheExpiration = this._getCacheExpiration(cacheName);
+    cacheExpiration.expireEntries();
+
+    if (isExpired) {
+      return null;
+    }
+
+    return cachedResponse;
+  }
+
+  /**
+   * This method will extract the data header and parse it into a useful
+   * value.
+   *
+   * @param {Response} cachedResponse
+   * @return {number}
+   *
+   * @private
+   */
+  _getDateHeaderTimestamp(cachedResponse) {
+    const dateHeader = cachedResponse.headers['date'];
+    const parsedDate = new Date(dateHeader);
+    const headerTime = parsedDate.getTime();
+    // If the Date header was invalid for some reason, parsedDate.getTime()
+    // will return NaN.
+    if (isNaN(headerTime)) {
+      return null;
+    }
+
+    return headerTime;
   }
 
   /**
@@ -128,82 +164,6 @@ class CacheExpirationPlugin {
     const cacheExpiration = this._getCacheExpiration(cacheName);
     await cacheExpiration.updateTimestamp(url);
     await cacheExpiration.expireEntries();
-  }
-
-  /**
-   * Checks whether a `Response` is "fresh", based on the `Response's`
-   * `Date` header and the `maxAgeSeconds` parameter passed into the
-   * constructor.
-   *
-   * The general approach is to default to fresh unless proven otherwise.
-   *
-   * If `maxAgeSeconds` or the `Date` header is not set then it will
-   * default to returning `true`, i.e. the response is still fresh and should
-   * be used.
-   *
-   * @param {Object} input
-   * @param {string} input.cacheName
-   * @param {Response} input.cachedResponse The `Response` object that's been
-   *        read from a cache and whose freshness should be checked.
-   *
-   * Defaults to the current time.
-   * @return {boolean} Either `true` if the response is fresh, or
-   * `false` if the `Response` is older than `maxAgeSeconds` and should no
-   * longer be used.
-   */
-  isResponseFresh({cacheName, cachedResponse}) {
-    // Only bother checking for freshness if we have a valid response and if
-    // maxAgeSeconds is set.
-    if (cachedResponse && this._maxAgeSeconds) {
-      if (process.env.NODE_ENV !== 'production') {
-        assert.isInstance(cachedResponse, Response, {
-          moduleName: 'workbox-cache-expiration',
-          className: 'CacheExpirationPlugin',
-          funcName: 'isResponseFresh',
-          paramName: 'cachedResponse',
-        });
-      }
-
-      const now = Date.now();
-      const dateHeader = cachedResponse.headers['date'];
-      if (dateHeader) {
-        const parsedDate = new Date(dateHeader);
-        const headerTime = parsedDate.getTime();
-        // If the Date header was invalid for some reason, parsedDate.getTime()
-        // will return NaN. We want to treat that as a fresh response, since we
-        // assume fresh unless proven otherwise.
-        if (isNaN(headerTime)) {
-          return true;
-        }
-
-        // If we have a valid headerTime, then our response is fresh iff the
-        // headerTime plus maxAgeSeconds is greater than the current time.
-        return (headerTime + (this._maxAgeSeconds * 1000)) > now;
-      } else {
-        // TODO (jeffposnick): Change this method interface to be async, and
-        // check for the IDB for the specific URL in order to determine
-        // freshness when Date is not available.
-
-        // If there is no Date header (i.e. if this is a cross-origin response),
-        // then we don't know for sure whether the response is fresh or not.
-        // One thing we can do is trigger cache expiration, which will clean up
-        // any old responses based on IDB timestamps, and ensure that when a
-        // cache-first handler is used, stale responses will eventually be
-        // replaced (though not until the *next* request is made).
-        // See https://github.com/GoogleChrome/workbox/issues/691
-
-        const cacheExpiration = this._getCacheExpiration(cacheName);
-        cacheExpiration.expireEntries();
-
-        // Return true, since otherwise a cross-origin cached response without
-        // a Date header would *never* be considered valid.
-        return true;
-      }
-    }
-
-    // If either cachedResponse or maxAgeSeconds wasn't set, then the response
-    // is "trivially" fresh, so return true.
-    return true;
   }
 }
 


### PR DESCRIPTION
R: @jeffposnick @addyosmani @philipwalton 

If I've understood the logic for CacheExpirationPlugin the only time expireEntries is called is when there is no date or a cache entry is updated

This isn't such a bad problem for maxEntries, but for maxAgeSeconds it has the following negative side effects:

- If there is a date header but it can't be parsed, it'll be treated as fresh, but never expired.
- If the date header can be parsed, we'll mark the response as fresh or not, but we won't remove it from the cache because we never expire it (meaning Cache and iDB will grow).
