### PR TITLE
Ensure untranspiled node 4+ compat for the v2 webpack plugin

### DIFF
--- a/packages/workbox-webpack-plugin/index.js
+++ b/packages/workbox-webpack-plugin/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const swBuild = require('workbox-build');
 const path = require('path');
 const url = require('url');
@@ -63,7 +65,7 @@ class WorkboxBuildWebpackPlugin {
     }
 
     if (compilation.options.output.publicPath) {
-      const {publicPath} = compilation.options.output;
+      const publicPath = compilation.options.output.publicPath;
       const compiledAssets = [];
       for (let key in compilation.assets) {
         if (Object.prototype.hasOwnProperty.call(compilation.assets, key)) {


### PR DESCRIPTION
R: @philipwalton  @addyosmani @gauntface

Fixes #950 

I've tested this locally with an `nvm` installed version of `node` 4.x, which is the level we say we support in our `package.json`.

(As mentioned, this isn't a concern in the v3 codebase, as we're transpiling with `@babel/preset-env` against our `node` 4.x target.)
