### PR TITLE
Nav route helper

### DIFF
--- a/infra/testing/sw-env.js
+++ b/infra/testing/sw-env.js
@@ -11,6 +11,7 @@
  limitations under the License.
  */
 
+const sinon = require('sinon');
 const serviceWorkerMock = require('service-worker-mock');
 const {IDBFactory, IDBKeyRange} = require('shelving-mock-indexeddb');
 const URLSearchParams = require('url-search-params');
@@ -50,3 +51,14 @@ global.registration.sync = new SyncManager();
 global.Request = Request;
 global.SyncEvent = SyncEvent;
 global.URLSearchParams = URLSearchParams;
+
+// TODO: Remove when fixed in service-worker-mock:
+// https://github.com/pinterest/service-workers/issues/71
+const origMatch = caches.match;
+sinon.stub(caches, 'match').callsFake(async (req, options) => {
+  if (options && options.cacheName) {
+    const cache = await caches.open(options.cacheName);
+    return cache.match(req);
+  }
+  return origMatch(req, options);
+});

--- a/packages/workbox-routing/NavigationRoute.mjs
+++ b/packages/workbox-routing/NavigationRoute.mjs
@@ -68,39 +68,50 @@ class NavigationRoute extends Route {
       });
     }
 
-    const match = ({event, url}) => {
-      if (event.request.mode !== 'navigate') {
-        return false;
-      }
+    super((...args) => this._match(...args), handler);
 
-      const pathnameAndSearch = url.pathname + url.search;
+    this._whitelist = whitelist;
+    this._blacklist = blacklist;
+  }
 
-      if (blacklist.some((regExp) => regExp.test(pathnameAndSearch))) {
-        if (process.env.NODE_ENV !== 'production') {
-          logger.debug(`The navigation route is not being used, since the ` +
-            `request URL matches both the whitelist and blacklist.`);
-        }
-        return false;
-      }
-
-      if (whitelist.some((regExp) => regExp.test(pathnameAndSearch))) {
-        if (process.env.NODE_ENV !== 'production') {
-          logger.debug(`The navigation route is being used.`);
-        }
-        return true;
-      } else {
-        if (process.env.NODE_ENV !== 'production') {
-          logger.debug(
-            `The navigation route is not being used, since the ` +
-            `URL being navigated to doesn't match the whitelist.`
-          );
-        }
-      }
-
+  /**
+   * Routes match handler.
+   *
+   * @param {Object} input
+   * @param {FetchEvent} input.event
+   * @param {URL} input.url
+   * @return {boolean}
+   */
+  _match({event, url}) {
+    if (event.request.mode !== 'navigate') {
       return false;
-    };
+    }
 
-    super(match, handler);
+    const pathnameAndSearch = url.pathname + url.search;
+
+    if (this._blacklist.some((regExp) => regExp.test(pathnameAndSearch))) {
+      if (process.env.NODE_ENV !== 'production') {
+        logger.debug(`The navigation route is not being used, since the ` +
+          `request URL matches both the whitelist and blacklist.`);
+      }
+      return false;
+    }
+
+    if (this._whitelist.some((regExp) => regExp.test(pathnameAndSearch))) {
+      if (process.env.NODE_ENV !== 'production') {
+        logger.debug(`The navigation route is being used.`);
+      }
+      return true;
+    } else {
+      if (process.env.NODE_ENV !== 'production') {
+        logger.debug(
+          `The navigation route is not being used, since the ` +
+          `URL being navigated to doesn't match the whitelist.`
+        );
+      }
+    }
+
+    return false;
   }
 }
 

--- a/packages/workbox-routing/_default.mjs
+++ b/packages/workbox-routing/_default.mjs
@@ -115,7 +115,7 @@ class DefaultRouter extends Router {
    * @param {Array<RegExp>} [options.whitelist=[/./]] If any of these patterns
    * match the URL's pathname and search parameter, the route will handle the
    * request (assuming the blacklist doesn't match).
-   * @return {NavigationRoute} Returns the generated Route.
+   * @return {NavigationRoute} Returns the generated Route. travis nudge
    */
   registerNavigationRoute(cachedAssetUrl, options = {}) {
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/workbox-routing/_default.mjs
+++ b/packages/workbox-routing/_default.mjs
@@ -115,7 +115,7 @@ class DefaultRouter extends Router {
    * @param {Array<RegExp>} [options.whitelist=[/./]] If any of these patterns
    * match the URL's pathname and search parameter, the route will handle the
    * request (assuming the blacklist doesn't match).
-   * @return {NavigationRoute} Returns the generated Route. travis nudge
+   * @return {NavigationRoute} Returns the generated Route.
    */
   registerNavigationRoute(cachedAssetUrl, options = {}) {
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/workbox-routing/_default.mjs
+++ b/packages/workbox-routing/_default.mjs
@@ -115,6 +115,7 @@ class DefaultRouter extends Router {
    * @param {Array<RegExp>} [options.whitelist=[/./]] If any of these patterns
    * match the URL's pathname and search parameter, the route will handle the
    * request (assuming the blacklist doesn't match).
+   * @return {NavigationRoute} Returns the generated Route.
    */
   registerNavigationRoute(cachedAssetUrl, options = {}) {
     if (process.env.NODE_ENV !== 'production') {
@@ -128,12 +129,14 @@ class DefaultRouter extends Router {
 
     const cacheName = cacheNames.getPrecacheName(options.cacheName);
     const handler = () => caches.match(cachedAssetUrl, {cacheName});
+    const route = new NavigationRoute(handler, {
+      whitelist: options.whitelist,
+      blacklist: options.blacklist,
+    });
     super.registerRoute(
-      new NavigationRoute(handler, {
-        whitelist: options.whitelist,
-        blacklist: options.blacklist,
-      })
+      route
     );
+    return route;
   }
 }
 

--- a/packages/workbox-routing/_default.mjs
+++ b/packages/workbox-routing/_default.mjs
@@ -14,10 +14,11 @@
   limitations under the License.
 */
 
-import {assert, WorkboxError} from 'workbox-core/_private.mjs';
+import {assert, WorkboxError, cacheNames} from 'workbox-core/_private.mjs';
 import {Router} from './Router.mjs';
 import {Route} from './Route.mjs';
 import {RegExpRoute} from './RegExpRoute.mjs';
+import {NavigationRoute} from './NavigationRoute.mjs';
 import './_version.mjs';
 
 if (process.env.NODE_ENV !== 'production') {
@@ -99,6 +100,40 @@ class DefaultRouter extends Router {
 
     super.registerRoute(route);
     return route;
+  }
+
+  /**
+   * A helper method that will register a NavigationRoute that will respond
+   * to navigation requests with a cached URL.
+   *
+   * @param {string} cachedAssetUrl
+   * @param {Object} options
+   * @param {string} options.cacheName Cache name to store and retrieve
+   * requests. Defaults to precache cache name provided by `workbox-core`.
+   * @param {Array<RegExp>} [options.blacklist] If any of these patterns match,
+   * the route will not handle the request (even if a whitelist entry matches).
+   * @param {Array<RegExp>} [options.whitelist=[/./]] If any of these patterns
+   * match the URL's pathname and search parameter, the route will handle the
+   * request (assuming the blacklist doesn't match).
+   */
+  registerNavigationRoute(cachedAssetUrl, options = {}) {
+    if (process.env.NODE_ENV !== 'production') {
+      assert.isType(cachedAssetUrl, 'string', {
+        moduleName: 'workbox-routing',
+        className: '[default export]',
+        funcName: 'registerNavigationRoute',
+        paramName: 'cachedAssetUrl',
+      });
+    }
+
+    const cacheName = cacheNames.getPrecacheName(options.cacheName);
+    const handler = () => caches.match(cachedAssetUrl, {cacheName});
+    super.registerRoute(
+      new NavigationRoute(handler, {
+        whitelist: options.whitelist,
+        blacklist: options.blacklist,
+      })
+    );
   }
 }
 

--- a/test/workbox-routing/node/test-default.mjs
+++ b/test/workbox-routing/node/test-default.mjs
@@ -1,9 +1,11 @@
 import sinon from 'sinon';
 import {expect} from 'chai';
 import expectError from '../../../infra/testing/expectError';
+import {cacheNames} from '../../../packages/workbox-core/_private.mjs';
 import defaultRouter from '../../../packages/workbox-routing/_default.mjs';
 import {RegExpRoute} from '../../../packages/workbox-routing/RegExpRoute.mjs';
 import {Route} from '../../../packages/workbox-routing/Route.mjs';
+import {NavigationRoute} from '../../../packages/workbox-routing/NavigationRoute.mjs';
 
 describe(`[workbox-routing] Default Router`, function() {
   const sandbox = sinon.sandbox.create();
@@ -121,6 +123,76 @@ describe(`[workbox-routing] Default Router`, function() {
       defaultRouter.unregisterRoute(outputRoute);
       await defaultRouter.handleRequest(event);
       expect(handlerSpy.callCount).to.equal(0);
+    });
+  });
+
+  describe(`registerNavigationRoute()`, function() {
+    it(`should register a navigation route with defaults`, function() {
+      sandbox.spy(NavigationRoute.prototype, 'constructor');
+      const route = defaultRouter.registerNavigationRoute(`/shell.html`);
+      expect(route).to.be.an.instanceof(NavigationRoute);
+      expect(route._whitelist).to.deep.equal([/./]);
+      expect(route._blacklist).to.deep.equal([]);
+    });
+
+    it(`should use supplied whitelist`, function() {
+      const whitelist = [/test/];
+      let route = defaultRouter.registerNavigationRoute(`/shell.html`, {
+        whitelist,
+      });
+      expect(route._whitelist).to.deep.equal(whitelist);
+      expect(route._blacklist).to.deep.equal([]);
+    });
+
+    it(`should use supplied blacklist`, function() {
+      const blacklist = [/test/];
+      let route = defaultRouter.registerNavigationRoute(`/shell.html`, {
+        blacklist,
+      });
+      expect(route._whitelist).to.deep.equal([/./]);
+      expect(route._blacklist).to.deep.equal(blacklist);
+    });
+
+    it(`should use supplied whitelist and blacklist`, function() {
+      const whitelist = [/whitelist/];
+      const blacklist = [/blacklist/];
+      let route = defaultRouter.registerNavigationRoute(`/shell.html`, {
+        whitelist,
+        blacklist,
+      });
+      expect(route._whitelist).to.deep.equal(whitelist);
+      expect(route._blacklist).to.deep.equal(blacklist);
+    });
+
+    it(`should return cached responses from precache by default`, async function() {
+      const injectedResponse = new Response('Injected Response - Precache Cache');
+      const openCache = await caches.open(cacheNames.getPrecacheName());
+      await openCache.put('/shell.html', injectedResponse);
+
+      const route = defaultRouter.registerNavigationRoute(`/shell.html`);
+      const response = await route.handler.handle(new FetchEvent('fetch', {
+        request: new Request('/random/navigation.html', {
+          mode: 'navigate',
+        }),
+      }));
+      expect(response).to.equal(injectedResponse);
+    });
+
+    it(`should use supplied cacheName`, async function() {
+      const cacheName = 'example-cache-name';
+      const injectedResponse = new Response('Injected Response - Custom Cache');
+      const openCache = await caches.open(cacheName);
+      await openCache.put('/shell.html', injectedResponse);
+
+      const route = defaultRouter.registerNavigationRoute(`/shell.html`, {
+        cacheName,
+      });
+      const response = await route.handler.handle(new FetchEvent('fetch', {
+        request: new Request('/random/navigation.html', {
+          mode: 'navigate',
+        }),
+      }));
+      expect(response).to.equal(injectedResponse);
     });
   });
 });


### PR DESCRIPTION
R: @jeffposnick @addyosmani @philipwalton

Adds the workbox-sw style registerNavigationRoute() method.

Only thing to comment is that I had rejig code in the NavigationRoute to test the whitelist and blacklist and I had to alter caches.match to get around an issue in service worker mock library. 
