### PR TITLE
Adding a more accurate theme for web fundamentals

### DIFF
--- a/gulp-tasks/docs.js
+++ b/gulp-tasks/docs.js
@@ -16,14 +16,41 @@ gulp.task('docs:clean', () => {
 const getJSDocFunc = (debug) => {
   return () => {
     logHelper.log(`Building docs...`);
+    const queryString = [
+      `projectRoot=/`,
+      `basepath=/`,
+      `productName=Workbox`,
+    ].join('&');
+
     const params = [
       'run', 'local-jsdoc', '--',
       '-c', path.join(__dirname, '..', 'jsdoc.conf'),
       '-d', DOCS_DIRECTORY,
     ];
+
+
+    if (!global.cliOptions.pretty) {
+      logHelper.warn(`
+
+These docs will look ugly, but they will more accurately match what
+is shown on developers.google.com.
+
+You can view a friendlier UI by running
+
+  'gulp docs --pretty'
+`);
+      params.push(
+        '--template', path.join(
+          __dirname, '..', 'infra', 'templates', 'reference-docs', 'jsdoc'
+        ),
+        '--query', queryString,
+      );
+    }
+
     if (debug) {
       params.push('--debug');
     }
+
     return spawn(getNpmCmd(), params, {
       cwd: path.join(__dirname, '..'),
     })

--- a/infra/templates/reference-docs/jsdoc/lang/en.yaml
+++ b/infra/templates/reference-docs/jsdoc/lang/en.yaml
@@ -1,0 +1,58 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+constructor:
+    prefix: 'new '
+returnTypesSeparator: '&nbsp;returns&nbsp;'
+tables:
+    body:
+        defaultValue: 'Defaults to {valueString}.'
+        defaultValueString: '<code>{value}</code>'
+        eachValueHasProperties: 'Values in <code>{name}</code> have the following properties:'
+        isOptional: 'Optional'
+        isRequired: '&nbsp;'
+        nonNullable:
+            long: 'Value must not be null.'
+            short: 'non-null'
+        nullable:
+            long: 'Value may be null.'
+            short: 'nullable'
+        repeatable:
+            long: 'Value may be repeated.'
+            short: 'repeatable'
+        unknownType: '?'
+    emptyCellPlaceholder: '&nbsp;'
+    header:
+        description: 'Description'
+        name: 'Name'
+        optional: 'Optional'
+        type: 'Type'
+    notApplicable: '&#8212;'
+params:
+    all: '({params})'
+    joiner: |
+        {items, plural,
+            =0 {{param}}
+            other {, {param}}}
+    optional: '{param}'
+    repeatable: '...{param}'
+headings:
+    enums: |
+        {items, plural,
+            =1 {Enumeration}
+            other {Enumerations}}
+    values: |
+        {items, plural,
+            =1 {Value}
+            other {Values}}

--- a/infra/templates/reference-docs/jsdoc/lib/publishjob.js
+++ b/infra/templates/reference-docs/jsdoc/lib/publishjob.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+/* eslint-disable valid-jsdoc, require-jsdoc */
+
+const name = require('jsdoc/name');
+const BaselinePublishJob = require('jsdoc-baseline/lib/publishjob');
+
+class PublishJob extends BaselinePublishJob {
+  constructor(...args) {
+    super(...args);
+    this._symbolNames = {};
+    this._data;
+  }
+
+  generateTocYaml(symbols, basepath) {
+    symbols.sort(function(a, b) {
+      let aName = a.kind === 'namespace' ? a.longname : a.name;
+      let bName = b.kind === 'namespace' ? b.longname : b.name;
+
+      aName = aName.toLowerCase();
+      bName = bName.toLowerCase();
+
+      if (aName > bName) {
+        return 1;
+      }
+
+      if (aName < bName) {
+        return -1;
+      }
+
+      return 0;
+    });
+
+    // check for duplicated names
+    symbols.forEach((symbol) => {
+      const symbolName = symbol.kind === 'namespace' ?
+        symbol.longname : symbol.name;
+      if ({}.hasOwnProperty.call(this._symbolNames, symbolName)) {
+        this._symbolNames[symbolName] = true;
+      } else {
+        this._symbolNames[symbolName] = false;
+      }
+    });
+
+    // To disambiguate duplicated names, prepend the name and scope of the
+    // parent. For example, if you have foo.bar.Qux and foo.baz.Qux, the
+    // disambiguated names are bar.Quxand baz.Qux.
+    symbols.forEach((symbol) => {
+      let mappedName = null;
+      const symbolName = symbol.kind === 'namespace' ?
+        symbol.longname : symbol.name;
+
+      if (this._symbolNames[symbolName] === true) {
+        if (symbol.kind !== 'namespace') {
+          // get info for the parent's name
+          const atomized = name.shorten(symbol.longname);
+          const atomizedParent = name.shorten(atomized.memberof);
+          // prepend the parent's name and the symbol's scope to the name
+          mappedName = atomizedParent.name + atomized.scope + symbol.name;
+        } else {
+          mappedName = symbol.longname;
+        }
+      }
+
+      symbol.tocYamlName = mappedName || (symbol.kind === 'namespace' ?
+        symbol.longname : symbol.name);
+    });
+
+    const data = {
+      symbols,
+      basepath,
+    };
+
+    this.generate('toc-yaml', data, '_toc.yaml');
+  }
+
+  generateIndex(readme) {
+    const data = {
+      allLongnamesTree: this.allLongnamesTree,
+      package: this.package,
+      pageTitle: global.env.opts.query ? global.env.opts.query.productName : '',
+      readme: readme || null,
+    };
+
+    this.generate('index', data, this.indexUrl);
+
+    return this;
+  }
+
+  generateIndexAll(longnames) {
+    longnames.sort();
+    const data = {
+        longnames: longnames,
+        pageTitle: global.env.opts.query ?
+            global.env.opts.query.productName : '',
+    };
+
+    this.generate('index-all', data, 'index-all.html');
+  }
+}
+
+/** const PublishJob = module.exports = function(...args) {
+  Parent.apply(this, [].slice.call(args, 0));
+};
+util.inherits(PublishJob, Parent);**/
+
+module.exports = PublishJob;

--- a/infra/templates/reference-docs/jsdoc/publish.js
+++ b/infra/templates/reference-docs/jsdoc/publish.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+
+const baselineConfig = require('jsdoc-baseline/lib/config');
+const fileFinder = require('jsdoc-baseline/lib/filefinder');
+const helper = require('jsdoc/util/templateHelper');
+const path = require('jsdoc/path');
+
+exports.publish = function(data, opts, tutorials) {
+    baselineConfig.loadSync();
+    baselineConfig.set('l10n', path.join(__dirname, 'lang'))
+        .set('static', path.join(__dirname, 'static'))
+        .set('views.partials', path.join(__dirname, 'views'))
+        .set('views.layouts', path.join(__dirname, 'views'))
+        .set('modules', path.join(__dirname, 'lib'));
+
+    const config = baselineConfig.get();
+
+    // load the core modules using the file finder
+    const modulesFinder = fileFinder.get('modules', config.modules);
+
+    const DocletHelper = modulesFinder.require('./doclethelper');
+    const PublishJob = modulesFinder.require('./publishjob');
+    const Template = modulesFinder.require('./template');
+
+    const docletHelper = new DocletHelper();
+    const template = new Template(config);
+    const job = new PublishJob(template, opts);
+
+    // set up tutorials
+    helper.setTutorials(tutorials);
+
+    docletHelper.addDoclets(data);
+
+    job.setPackage(docletHelper.getPackage())
+        .setNavTree(docletHelper.navTree)
+        .setAllLongnamesTree(docletHelper.allLongnamesTree);
+
+    // create the output directory so we can start generating files
+    job.createOutputDirectory()
+        // then generate the source files so we can link to them
+        .generateSourceFiles(docletHelper.shortPaths);
+
+    // generate globals page if necessary
+    job.generateGlobals(docletHelper.globals);
+
+    // generate TOC data and index page
+    job.generateTocData({hasGlobals: docletHelper.hasGlobals()})
+        .generateIndex(opts.readme);
+
+    // generate the rest of the output files (excluding tutorials)
+    docletHelper.getOutputLongnames().forEach(function(longname) {
+        job.generateByLongname(longname, docletHelper.getLongname(longname),
+            docletHelper.getMemberof(longname));
+    });
+
+    // finally, generate the tutorials, and copy static files to the output
+    // directory
+    job.generateTutorials(tutorials)
+        .copyStaticFiles();
+
+    // custom Cast pages
+    job.generateTocYaml(
+        docletHelper.getCategory('classes')
+            .concat(docletHelper.getCategory('namespaces'))
+            .concat(docletHelper.getCategory('interfaces')),
+        global.env.opts.query ? global.env.opts.query.basepath : ''
+    );
+    job.generateIndexAll(Object.keys(docletHelper.longname));
+};

--- a/infra/templates/reference-docs/jsdoc/static/jsdoc.css
+++ b/infra/templates/reference-docs/jsdoc/static/jsdoc.css
@@ -1,0 +1,71 @@
+
+.label {
+  font-style: italic;
+  text-transform: uppercase;
+}
+
+.dl-compact dt {
+  margin:8px 0px 0px 0px;
+}
+
+h1.devsite-page-title {
+    display: none;
+}
+
+h1 {
+  margin-bottom: 8px;
+}
+
+h2 {
+  margin: 48px 0px 0px 0px;
+}
+
+h3.symbol-name {
+  margin: 32px 0px 8px 0px;
+}
+
+h3.class-list:first-child {
+  display: block;
+  margin: 16px 0px 0px 0px;
+}
+
+h3.class-list {
+  display: block;
+  margin: 12px 0px 0px 0px;
+  font-size: 16px;
+}
+
+h3.class-list + p {
+  margin: 0px 0px 0px 0px;
+}
+
+h4 {
+  margin: 8px 0px 0px 0px;
+}
+
+td p {
+  margin: 6px 0px 0px 0px;
+}
+
+p.type-signature {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 80%;
+  font-style: normal;
+  font-variant: normal;
+  font-weight: 500;
+  font-stretch: normal;
+  line-height: normal;
+  margin-top: 0px;
+}
+
+p.symbol-index-name {
+  margin: 8px 0px 0px 0px;
+}
+
+h2.symbol-header {
+  margin: 36px 0px 0px 0px;
+}
+
+table.function.param tr {
+  background: #80A7B9;
+}

--- a/infra/templates/reference-docs/jsdoc/views/augments.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/augments.hbs
@@ -1,0 +1,6 @@
+{{#any augments}}
+  <dt>{{translateHeading 'augments' augments}}</dt>
+  {{#each augments}}
+    <dd><small>{{link this}}</small></dd>
+  {{/each}}
+{{/any}}

--- a/infra/templates/reference-docs/jsdoc/views/classes-links.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/classes-links.hbs
@@ -1,0 +1,13 @@
+{{#any items}}
+<h>{{translateHeading headingKey items}}</h>
+  <section id='members-links'>
+  {{#each items}}
+    <h3 {{~cssClass '!class-list'}}>{{link longname name}}</h3>
+    {{#if classdesc}}
+      {{#markdown}}{{resolveLinks classdesc}}{{/markdown}}
+    {{else}}
+      {{#markdown}}{{resolveLinks description}}{{/markdown}}
+    {{/if}}
+  {{/each}}
+  </section>
+{{/any}}

--- a/infra/templates/reference-docs/jsdoc/views/details-table-row.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/details-table-row.hbs
@@ -1,0 +1,40 @@
+<tr>
+  {{#block 'details-table-name'}}
+    <td {{~cssClass '!details-table-name'}}>
+      <p>{{#if name}}{{name}}{{else}}{{translate 'tables.notApplicable'}}{{/if}}</p>
+    </td>
+  {{/block}}
+  <td>
+  {{#block 'details-table-optional'}}
+    {{#if optional}}
+      <p {{~cssClass '!details-table-optional'}}>{{translate 'tables.body.isOptional'}}</p>
+    {{/if}}
+  {{/block}}
+  {{#block 'details-table-types'}}
+    {{#if type}}
+      {{#all type type.parsedType}}
+        <p {{~cssClass '!details-table-types'}}>{{describeType type.parsedType 'extended'}}</p>
+      {{/all}}
+    {{/if}}
+  {{/block}}
+  {{#block 'details-table-description'}}
+    {{#if description}}
+      {{#markdown}}{{resolveLinks description}}{{/markdown}}
+    {{/if}}
+    {{#if (hasModifiers this)}}
+      <p>{{modifierText this}}</p>
+    {{/if}}
+    {{#if ../children}}
+      <p>{{translate 'tables.body.eachValueHasProperties' name=name}}</p>
+        {{#withOnly values=../children}}
+          {{#embed 'details-table'}}{{/embed}}
+        {{/withOnly}}
+    {{/if}}
+  {{/block}}
+  </td>
+</tr>
+
+{{!-- This produces extra <p>'s in the output
+<p {{~cssClass '!details-table-description'}}>
+  {{#markdown}}{{resolveLinks description}}{{/markdown}}</p>
+--}}

--- a/infra/templates/reference-docs/jsdoc/views/details-table.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/details-table.hbs
@@ -1,0 +1,20 @@
+<table class="function param responsive">
+  {{#block 'details-table-header'}}
+    <tr>
+      <th colspan="2">
+        {{#if isEnum}}
+          <h>{{translateHeading 'values' params}}</h>
+        {{else}}
+          <h>{{translateHeading 'parameters' params}}</h>
+        {{/if}}
+      </th>
+    </tr>
+  {{/block}}
+  {{#block 'details-table-body'}}
+    <tbody>
+      {{#each values}}
+        {{#embed 'details-table-row'}}{{/embed}}
+      {{/each}}
+    </tbody>
+  {{/block}}
+</table>

--- a/infra/templates/reference-docs/jsdoc/views/implements.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/implements.hbs
@@ -1,0 +1,6 @@
+{{#any implements}}
+  <dt>{{translateHeading 'implements' implements}}</dt>
+  {{#each implements}}
+    <dd><small>{{link this}}</small></dd>
+  {{/each}}
+{{/any}}

--- a/infra/templates/reference-docs/jsdoc/views/index-all.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/index-all.hbs
@@ -1,0 +1,12 @@
+{{#extend 'layout'}}
+  {{#content 'title'}}
+    <title>Index All</title>
+  {{/content}}
+  {{#content 'body-main-content'}}
+    <ul>
+      {{#each longnames}}
+        <li>{{link this}}</li>
+      {{/each}}
+    </ul>
+  {{/content}}
+{{/extend}}

--- a/infra/templates/reference-docs/jsdoc/views/index.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/index.hbs
@@ -1,0 +1,14 @@
+{{#extend 'layout'}}
+  {{#content 'title'}}
+    <title>Overview</title>
+  {{/content}}
+  {{#content 'body-main-content'}}
+    {{#if readme}}
+      {{{ readme }}}
+    {{else}}
+      {{#block 'body-symbol-index'}}
+        {{#embed 'symbol-index'}}{{/embed}}
+      {{/block}}
+    {{/if}}
+  {{/content}}
+{{/extend}}

--- a/infra/templates/reference-docs/jsdoc/views/layout.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/layout.hbs
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html devsite>
+    {{#block 'head'}}
+        <head>
+            {{#block 'meta'}}
+                <meta name="project_path" value="{{query 'projectRoot'}}_project.yaml" />
+                <meta name="book_path" value="{{query 'projectRoot'}}_book.yaml" />
+                <meta name="gtm_var" data-key="docType" data-value="reference">
+            {{/block}}
+            {{#block 'title'}}
+                <title>{{translatePageTitle pageTitlePrefix pageTitle pageCategory}}</title>
+            {{/block}}
+            {{#block 'css'}}
+                <link href="jsdoc.css" rel="stylesheet">
+            {{/block}}
+        </head>
+    {{/block}}
+    {{#block 'body'}}
+        <body>
+            {{#block 'body-container'}}
+                <div id="jsdoc-body-container">
+                    {{#block 'body-content'}}
+                        <div id="jsdoc-content">
+                            {{#block 'body-content-container'}}
+                                <div id="jsdoc-content-container">
+                                    {{#block 'body-banner'}}
+                                        <div id="jsdoc-banner" role="banner">
+                                            {{#block 'body-banner-content'}}
+                                                {{!--
+                                                    Override the `body-banner-content` block
+                                                    to add content.
+                                                --}}
+                                            {{/block}}
+                                        </div>
+                                    {{/block}}
+                                    {{#block 'body-main'}}
+                                        {{!-- Adding a section here causes heading to bump down H1 > H2, etc. --}}
+                                        <div id="jsdoc-main" role="main">
+                                            {{#block 'body-main-content'}}
+                                                {{!--
+                                                    Override the `body-main-content` block
+                                                    to add content.
+                                                --}}
+                                            {{/block}}
+                                        </div>
+                                    {{/block}}
+                                </div>
+                            {{/block}}
+                            {{#block 'body-toc-navbar'}}
+                                {{!-- content is inserted on page load --}}
+                                <nav id="jsdoc-toc-nav" role="navigation"></nav>
+                            {{/block}}
+                        </div>
+                    {{/block}}
+                </div>
+            {{/block}}
+            {{#block 'body-footer'}}
+            {{/block}}
+            {{!-- No scripts in Devsite --}}
+        </body>
+    {{/block}}
+</html>

--- a/infra/templates/reference-docs/jsdoc/views/params.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/params.hbs
@@ -1,0 +1,7 @@
+{{#any params}}
+    <section>
+        {{#withOnly values=(reparentItems this 'params')}}
+            {{#embed 'details-table'}}{{/embed}}
+        {{/withOnly}}
+    </section>
+{{/any}}

--- a/infra/templates/reference-docs/jsdoc/views/properties.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/properties.hbs
@@ -1,0 +1,10 @@
+{{#any (filterProperties properties)}}
+  <section>
+    {{#unless isEnum}}
+      <h>{{translateHeading 'properties' properties}}</h>
+    {{/unless}}
+    {{#withOnly values=(reparentItems this 'properties') isEnum=isEnum}}
+      {{#embed 'details-table'}}{{/embed}}
+    {{/withOnly}}
+  </section>
+{{/any}}

--- a/infra/templates/reference-docs/jsdoc/views/see.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/see.hbs
@@ -1,0 +1,6 @@
+{{#any see}}
+    <dt>{{translateHeading 'see' see}}</dt>
+    {{#each see}}
+        <dd><small>{{link (see this ../longname)}}</small></dd>
+    {{/each}}
+{{/any}}

--- a/infra/templates/reference-docs/jsdoc/views/signature.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/signature.hbs
@@ -1,0 +1,24 @@
+{{!--
+    Note that this section omits the return type for:
+    + Constructors
+    + Methods with no explicit return type
+--}}
+{{#with symbol}}
+  {{~#if (needsSignature this)~}}
+    {{!-- CONSTRUCTOR PREFIX --}}
+    {{#is kind 'class'}}
+      {{#embed 'constructor-prefix'}}{{/embed}}
+    {{/is}}
+    {{name}}{{~formatParams params~}}
+    {{~#isnt kind 'class'~}}
+      {{~#if (returnTypes this)~}}
+        {{~translate 'returnTypesSeparator'~}}
+        {{describeType (returnTypes this)~}}
+      {{~/if~}}
+    {{~/isnt~}}
+  {{~else~}}
+    {{~#if type~}}
+      {{~describeType type.parsedType~}}
+    {{~/if~}}
+  {{~/if~}}
+{{/with}}

--- a/infra/templates/reference-docs/jsdoc/views/symbol-content.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/symbol-content.hbs
@@ -1,0 +1,49 @@
+<section>
+  {{#block 'symbol-content-classes'}}
+    {{#withOnly items=members.classes headingKey='classes'}}
+      {{#embed 'classes-links'}}{{/embed}}
+    {{/withOnly}}
+  {{/block}}
+
+  {{#block 'symbol-content-interfaces'}}
+    {{#withOnly items=members.interfaces headingKey='interfaces'}}
+      {{#embed 'members-links'}}{{/embed}}
+    {{/withOnly}}
+  {{/block}}
+
+  {{#block 'symbol-content-namespaces'}}
+    {{#withOnly items=members.namespaces headingKey='namespaces'}}
+      {{#embed 'members-links'}}{{/embed}}
+    {{/withOnly}}
+  {{/block}}
+
+  {{#block 'symbol-content-enums'}}
+    {{#withOnly items=(where members.properties isEnum=true) headingKey='enums'}}
+      {{#embed 'members-details'}}{{/embed}}
+    {{/withOnly}}
+  {{/block}}
+
+  {{#block 'symbol-content-properties'}}
+    {{#withOnly items=(where members.properties isEnum=undefined) headingKey='properties'}}
+      {{#embed 'members-details'}}{{/embed}}
+    {{/withOnly}}
+  {{/block}}
+
+  {{#block 'symbol-content-methods'}}
+    {{#withOnly items=members.functions headingKey='functions'}}
+      {{#embed 'members-details'}}{{/embed}}
+    {{/withOnly}}
+  {{/block}}
+
+  {{#block 'symbol-content-typedefs'}}
+    {{#withOnly items=members.typedefs headingKey='typedefs'}}
+      {{#embed 'members-details'}}{{/embed}}
+    {{/withOnly}}
+  {{/block}}
+
+  {{#block 'symbol-content-events'}}
+    {{#withOnly items=members.events headingKey='events'}}
+      {{#embed 'members-details'}}{{/embed}}
+    {{/withOnly}}
+  {{/block}}
+</section>

--- a/infra/templates/reference-docs/jsdoc/views/symbol-detail.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/symbol-detail.hbs
@@ -1,0 +1,33 @@
+{{~#unless symbol.hideconstructor~}}
+  <h id="{{id symbol}}" {{~cssClass '!symbol-name'}}>
+    {{~#with symbol~}}
+      {{name}}
+    {{~/with~}}
+  </h>
+{{~/unless~}}
+{{!--
+    Note that we omit the labels for classes, modules, and namespaces, since
+    these labels would duplicate the labels for the page's main heading.
+--}}
+{{~#if symbol.kind~}}
+  {{~#contains 'class' 'module' 'namespace' value=symbol.kind~}}
+  {{~else~}}
+    {{~#embed 'symbol-labels'}}{{/embed~}}
+  {{~/contains~}}
+{{~/if~}}
+{{~#unless symbol.hideconstructor~}}
+  <p {{~cssClass '!type-signature'}}>
+    {{~#embed 'signature'}}{{/embed~}}
+  </p>
+{{~/unless~}}
+{{#with symbol}}
+  {{~#unless symbol.hideconstructor~}}
+    {{#embed 'description'}}{{/embed}}
+    {{#embed 'params'}}{{/embed}}
+    {{#embed 'properties'}}{{/embed}}
+    <dl {{~cssClass '!dl-compact'}}>
+      {{#embed 'details'}}{{/embed}}
+    </dl>
+    {{#embed 'examples'}}{{/embed}}
+  {{~/unless~}}
+{{/with}}

--- a/infra/templates/reference-docs/jsdoc/views/symbol-header.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/symbol-header.hbs
@@ -1,0 +1,41 @@
+<header {{~cssClass '!page-header'}}>
+  {{#block 'symbol-header-heading'}}
+      <h>
+        {{~#isnt longname memberof}}<small>{{ancestors longname}}</small>{{/isnt~}}
+        <span {{~cssClass '!symbol-name'}}>{{name}}</span></h>
+  {{~/block}}
+  {{~#withOnly symbol=this~}}
+    {{~#embed 'symbol-labels'}}{{/embed~}}
+  {{/withOnly~}}
+  {{#block 'symbol-header-classdesc'}}
+    {{#if classdesc}}
+      {{#markdown}}{{resolveLinks classdesc}}{{/markdown}}
+    {{/if}}
+  {{/block}}
+  {{#block 'symbol-header-description'}}
+    {{!--
+      We don't put a description here for classes, or for namespaces that are
+      also functions.
+    --}}
+    {{#isnt kind 'class'}}
+      {{#is kind 'namespace'}}
+        {{#unless (needsSignature this)}}
+          {{#embed 'description'}}{{/embed}}
+        {{/unless}}
+      {{else}}
+        {{#embed 'description'}}{{/embed}}
+      {{/is}}
+    {{/isnt}}
+  {{/block}}
+  {{#block 'symbol-header-class-details'}}
+    {{!--
+      For classes where we're not displaying the constructor, we show the
+      details here.
+    --}}
+    {{#if hideconstructor}}
+      <dl {{~cssClass '!dl-compact'}}>
+        {{#embed 'details'}}{{/embed}}
+      </dl>
+    {{/if}}
+  {{/block}}
+</header>

--- a/infra/templates/reference-docs/jsdoc/views/symbol-index-section.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/symbol-index-section.hbs
@@ -1,0 +1,7 @@
+<div {{~cssClass '!symbol-index-column'}}>
+  {{#each doclets}}
+    <p {{~cssClass '!symbol-index-name'}}>
+      {{linkLongnameWithSignature this '!symbol-index-name'}}
+    </p>
+  {{/each}}
+</div>

--- a/infra/templates/reference-docs/jsdoc/views/symbol-index.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/symbol-index.hbs
@@ -1,0 +1,16 @@
+<div {{~cssClass '!symbol-index'}}>
+  {{#eachIndexGroup allLongnamesTree}}
+    <section>
+      <div {{~cssClass '!symbol-index-content'}}>
+        <h id="{{@groupName}}" {{~cssClass '!symbol-header'}}>{{@groupName}}</h>
+        <div {{~cssClass '!symbol-index-section'}}>
+          {{#each (group this 3)}}
+            {{#withOnly doclets=this}}
+              {{#embed 'symbol-index-section'}}{{/embed}}
+            {{/withOnly}}
+          {{/each}}
+        </div>
+      </div>
+    </section>
+  {{/eachIndexGroup}}
+</div>

--- a/infra/templates/reference-docs/jsdoc/views/symbol-labels.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/symbol-labels.hbs
@@ -1,0 +1,10 @@
+{{~#withOnly allLabels=(labels symbol)~}}
+  {{~#any allLabels~}}
+    <div {{~cssClass '!symbol-detail-labels'}}>
+      {{~#each allLabels~}}
+        <span {{~cssClass '!label' class}}><small>{{text}}</small></span>
+        {{~#unless @last}}&nbsp;&nbsp;&nbsp;{{/unless~}}
+      {{~/each~}}
+    </div>
+  {{~/any~}}
+{{~/withOnly~}}

--- a/infra/templates/reference-docs/jsdoc/views/symbol-overview.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/symbol-overview.hbs
@@ -1,0 +1,75 @@
+{{#any docs}}
+  {{#first docs}}
+    {{#embed 'symbol-header'}}{{/embed}}
+  {{/first}}
+{{/any}}
+
+{{#each docs}}
+  {{#if @first}}
+    {{!-- heading that indicates what we're about to list --}}
+    {{#is pageCategory 'classes'}}
+      <section>
+    {{else}}
+      {{#any exports}}
+        <section>
+          <h>{{translateHeading 'exports' docs}}</h>
+      {{/any}}
+    {{/is}}
+  {{/if}}
+
+  {{!--
+      If a module exports only one symbol, document the symbol in the overview, since it's not a
+      member of anything else.
+  --}}
+  {{#is kind 'module'}}
+    {{#if exports}}
+      {{#each exports}}
+        {{#withOnly symbol=this}}
+          <section>
+            {{#embed 'symbol-detail'}}{{/embed}}
+          </section>
+        {{/withOnly}}
+      {{/each}}
+    {{/if}}
+  {{!-- Classes also need additional information in the overview. --}}
+  {{else is kind 'class'}}
+    {{#unless hideconstructor}}
+      <section>
+        <h>Constructor</h>
+        <section>
+          {{#withOnly symbol=this}}
+            {{#embed 'symbol-detail'}}{{/embed}}
+          {{/withOnly}}
+        </section>
+      </section>
+    {{/unless}}
+  {{!-- Externals also need additional information in the overview. --}}
+  {{else is kind 'external'}}
+    <section>
+      {{#with this}}
+        <dl {{~cssClass '!dl-compact'}}>
+          {{#embed 'details'}}{{/embed}}
+        </dl>
+      {{/with}}
+    </section>
+  {{!-- Namespaces that are functions also need additional information in the overview. --}}
+  {{else is kind 'namespace'}}
+    {{#if (needsSignature this)}}
+      <section>
+        {{#withOnly symbol=this}}
+          {{#embed 'symbol-detail'}}{{/embed}}
+        {{/withOnly}}
+      </section>
+    {{/if}}
+  {{/is}}
+
+  {{#if @last}}
+    {{#is pageCategory 'classes'}}
+      </section>
+    {{else}}
+      {{#any exports}}
+        </section>
+      {{/any}}
+    {{/is}}
+  {{/if}}
+{{/each}}

--- a/infra/templates/reference-docs/jsdoc/views/toc-yaml.hbs
+++ b/infra/templates/reference-docs/jsdoc/views/toc-yaml.hbs
@@ -1,0 +1,7 @@
+toc:
+{{#each symbols~}}
+- title: "{{tocYamlName}}"
+  path: {{../basepath}}/{{basename (url longname) '.html'}}
+{{/each}}
+- title: "Index of all"
+  path: {{basepath}}/index-all

--- a/package-lock.json
+++ b/package-lock.json
@@ -3177,6 +3177,16 @@
         "typedarray": "0.0.6"
       }
     },
+    "config-chain": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+      "dev": true,
+      "requires": {
+        "ini": "1.3.4",
+        "proto-list": "1.2.4"
+      }
+    },
     "configstore": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
@@ -4351,6 +4361,30 @@
       "requires": {
         "base64url": "2.0.0",
         "safe-buffer": "5.1.1"
+      }
+    },
+    "editorconfig": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
+      "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "commander": "2.11.0",
+        "lru-cache": "3.2.0",
+        "semver": "5.4.1",
+        "sigmund": "1.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+          "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2"
+          }
+        }
       }
     },
     "ee-first": {
@@ -7970,6 +8004,12 @@
         }
       }
     },
+    "handlebars-layouts": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/handlebars-layouts/-/handlebars-layouts-3.1.4.tgz",
+      "integrity": "sha1-JrO+uTG0uHffv35v6vQFjuYiiwI=",
+      "dev": true
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -8352,6 +8392,21 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
       "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+      "dev": true
+    },
+    "intl-messageformat": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-1.3.0.tgz",
+      "integrity": "sha1-99kmre16OrGbLcYB79VOmaS9Tq4=",
+      "dev": true,
+      "requires": {
+        "intl-messageformat-parser": "1.2.0"
+      }
+    },
+    "intl-messageformat-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.2.0.tgz",
+      "integrity": "sha1-WQa3+VOrdHDg3IVJCXtki5kYkv8=",
       "dev": true
     },
     "invariant": {
@@ -8844,6 +8899,18 @@
         "valid-url": "1.0.9"
       }
     },
+    "js-beautify": {
+      "version": "1.6.14",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.14.tgz",
+      "integrity": "sha1-07j3Mi0CuSd9WL0jgmTDJ+WARM0=",
+      "dev": true,
+      "requires": {
+        "config-chain": "1.1.11",
+        "editorconfig": "0.13.3",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6"
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -8921,6 +8988,47 @@
           "version": "1.8.3",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        }
+      }
+    },
+    "jsdoc-baseline": {
+      "version": "https://github.com/hegemonic/baseline/tarball/master",
+      "integrity": "sha1-7H4toBglK8wP8qNDU/RAJFvHE3k=",
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.4.2",
+        "escape-string-regexp": "1.0.5",
+        "handlebars": "4.0.11",
+        "handlebars-layouts": "3.1.4",
+        "intl-messageformat": "1.3.0",
+        "js-beautify": "1.6.14",
+        "js-yaml": "3.6.1",
+        "semver": "5.3.0",
+        "spdx-license-list": "2.1.0",
+        "underscore-contrib": "0.3.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
       }
@@ -13432,6 +13540,12 @@
         }
       }
     },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
+    },
     "protobufjs": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
@@ -14785,6 +14899,12 @@
         "shelving-mock-event": "1.0.12"
       }
     },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -15086,6 +15206,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
+    },
+    "spdx-license-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-2.1.0.tgz",
+      "integrity": "sha1-N4j/tcgLJK++goOTTp5mhOpqIY0=",
       "dev": true
     },
     "split": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "gulp-sourcemaps": "^2.6.1",
     "gzip-size": "^4.0.0",
     "jsdoc": "^3.5.5",
+    "jsdoc-baseline": "https://github.com/hegemonic/baseline/tarball/master",
     "lerna": "^2.4.0",
     "mocha": "^4.0.1",
     "nyc": "^11.2.1",

--- a/packages/workbox-core/_private/DBWrapper.mjs
+++ b/packages/workbox-core/_private/DBWrapper.mjs
@@ -50,6 +50,8 @@ class DBWrapper {
    * callback, and added an onversionchange callback to the database.
    *
    * @return {IDBDatabase}
+   *
+   * @private
    */
   async open() {
     if (this._db) return;
@@ -96,6 +98,8 @@ class DBWrapper {
    * @param {string} storeName The name of the object store to put the value.
    * @param {...*} args The values passed to the delegated method.
    * @return {*} The key of the entry.
+   *
+   * @private
    */
   async get(storeName, ...args) {
     return await this._call('get', storeName, 'readonly', ...args);
@@ -107,6 +111,8 @@ class DBWrapper {
    * @param {string} storeName The name of the object store to put the value.
    * @param {...*} args The values passed to the delegated method.
    * @return {*} The key of the entry.
+   *
+   * @private
    */
   async add(storeName, ...args) {
     return await this._call('add', storeName, 'readwrite', ...args);
@@ -118,6 +124,8 @@ class DBWrapper {
    * @param {string} storeName The name of the object store to put the value.
    * @param {...*} args The values passed to the delegated method.
    * @return {*} The key of the entry.
+   *
+   * @private
    */
   async put(storeName, ...args) {
     return await this._call('put', storeName, 'readwrite', ...args);
@@ -128,6 +136,8 @@ class DBWrapper {
    *
    * @param {string} storeName
    * @param {...*} args The values passed to the delegated method.
+   *
+   * @private
    */
   async delete(storeName, ...args) {
     await this._call('delete', storeName, 'readwrite', ...args);
@@ -141,6 +151,8 @@ class DBWrapper {
    * @param {*} query
    * @param {number} count
    * @return {Array}
+   *
+   * @private
    */
   async getAll(storeName, query, count) {
     if ('getAll' in IDBObjectStore.prototype) {
@@ -165,6 +177,8 @@ class DBWrapper {
    *     returned objects is changed from an array of values to an array of
    *     objects in the form {key, primaryKey, value}.
    * @return {Array}
+   *
+   * @private
    */
   async getAllMatching(storeName, opts = {}) {
     return await this.transaction([storeName], 'readonly', (stores, done) => {
@@ -205,6 +219,8 @@ class DBWrapper {
    * @param {string} type Can be `readonly` or `readwrite`.
    * @param {function(Object, function(), function(*)):?IDBRequest} callback
    * @return {*} The result of the transaction ran by the callback.
+   *
+   * @private
    */
   async transaction(storeNames, type, callback) {
     await this.open();
@@ -236,6 +252,8 @@ class DBWrapper {
    * @param {string} type Can be `readonly` or `readwrite`.
    * @param {...*} args The list of args to pass to the native method.
    * @return {*} The result of the transaction.
+   *
+   * @private
    */
   async _call(method, storeName, type, ...args) {
     await this.open();
@@ -253,6 +271,8 @@ class DBWrapper {
    * connections can open without being blocked.
    *
    * @param {Event} evt
+   *
+   * @private
    */
   _onversionchange(evt) {
     this.close();
@@ -268,6 +288,8 @@ class DBWrapper {
    * The primary use case for needing to close a connection is when another
    * reference (typically in another tab) needs to upgrade it and would be
    * blocked by the current, open connection.
+   *
+   * @private
    */
   close() {
     if (this._db) this._db.close();


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

I noticed the docs on WebFundamentals are more "loose" with respect to showing functions or Classes that aren't assigned a module.

This theme is more inline with WebFundamentals, although it's ugly as hell.

I've added a `--pretty` option to make it possible to switch to jsdocs theme for reviews etc.
