### PR TITLE
Publishing fixes

### DIFF
--- a/gulp-tasks/publish-demos.js
+++ b/gulp-tasks/publish-demos.js
@@ -2,14 +2,15 @@ const gulp = require('gulp');
 const path = require('path');
 const fs = require('fs-extra');
 
-const cdnUtils = require('../packages/workbox-build/src/lib/cdn-utils');
+const {getCDNOrigin} = require('../packages/workbox-build/src/lib/cdn-utils');
+const lernaPkg = require('../lerna.json');
 const getNpmCmd = require('./utils/get-npm-cmd');
 const spawn = require('./utils/spawn-promise-wrapper');
 const constants = require('./utils/constants');
 
 gulp.task('publish-demos:updateCDNDetails', () => {
   const details = {
-    latestUrl: cdnUtils.getRootCDNUrl(),
+    latestUrl: `${getCDNOrigin()}/${lernaPkg.version}`,
   };
   const filePath = path.join(__dirname, '..', 'demos',
     'functions', 'cdn-details.json');

--- a/gulp-tasks/publish-demos.js
+++ b/gulp-tasks/publish-demos.js
@@ -2,15 +2,14 @@ const gulp = require('gulp');
 const path = require('path');
 const fs = require('fs-extra');
 
-const {getCDNOrigin} = require('../packages/workbox-build/src/lib/cdn-utils');
-const lernaPkg = require('../lerna.json');
+const getVersionsCDNUrl = require('./utils/versioned-cdn-url');
 const getNpmCmd = require('./utils/get-npm-cmd');
 const spawn = require('./utils/spawn-promise-wrapper');
 const constants = require('./utils/constants');
 
 gulp.task('publish-demos:updateCDNDetails', () => {
   const details = {
-    latestUrl: `${getCDNOrigin()}/${lernaPkg.version}`,
+    latestUrl: getVersionsCDNUrl(),
   };
   const filePath = path.join(__dirname, '..', 'demos',
     'functions', 'cdn-details.json');

--- a/gulp-tasks/utils/github-helper.js
+++ b/gulp-tasks/utils/github-helper.js
@@ -9,6 +9,11 @@ const github = new GitHubApi();
 // the next request, so it should be called once per method that requires auth.
 // See https://github.com/mikedeboer/node-github#authentication
 const authenticate = () => {
+  if (!process.env.GITHUB_TOKEN) {
+    throw new Error('You must set a GITHUB_TOKEN in your environment to ' +
+      'public a Github release.');
+  }
+
   github.authenticate({
     type: 'token',
     token: process.env.GITHUB_TOKEN,

--- a/gulp-tasks/utils/rollup-helper.js
+++ b/gulp-tasks/utils/rollup-helper.js
@@ -3,9 +3,7 @@ const minify = require('uglify-es').minify;
 const replace = require('rollup-plugin-replace');
 
 const constants = require('./constants');
-const {getCDNOrigin} =
-  require('../../packages/workbox-build/src/lib/cdn-utils.js');
-const lernaPkg = require('../../lerna.json');
+const getVersionsCDNUrl = require('./versioned-cdn-url');
 
 module.exports = {
   // Every use of rollup should have minification and the replace
@@ -44,7 +42,7 @@ module.exports = {
 
     // This is what the build should be
     const replaceOptions = {
-      'WORKBOX_CDN_ROOT_URL': `${getCDNOrigin()}/${lernaPkg.version}`,
+      'WORKBOX_CDN_ROOT_URL': getVersionsCDNUrl(),
     };
 
     if (buildType) {

--- a/gulp-tasks/utils/rollup-helper.js
+++ b/gulp-tasks/utils/rollup-helper.js
@@ -3,8 +3,9 @@ const minify = require('uglify-es').minify;
 const replace = require('rollup-plugin-replace');
 
 const constants = require('./constants');
-const {getRootCDNUrl} =
+const {getCDNOrigin} =
   require('../../packages/workbox-build/src/lib/cdn-utils.js');
+const lernaPkg = require('../../lerna.json');
 
 module.exports = {
   // Every use of rollup should have minification and the replace
@@ -43,7 +44,7 @@ module.exports = {
 
     // This is what the build should be
     const replaceOptions = {
-      'WORKBOX_CDN_ROOT_URL': getRootCDNUrl(),
+      'WORKBOX_CDN_ROOT_URL': `${getCDNOrigin()}/${lernaPkg.version}`,
     };
 
     if (buildType) {

--- a/gulp-tasks/utils/versioned-cdn-url.js
+++ b/gulp-tasks/utils/versioned-cdn-url.js
@@ -1,0 +1,5 @@
+const {getCDNOrigin} = require(
+  '../../packages/workbox-build/src/lib/cdn-utils');
+const lernaPkg = require('../../lerna.json');
+
+module.exports = () => `${getCDNOrigin()}/${lernaPkg.version}`;

--- a/packages/workbox-build/src/lib/cdn-utils.js
+++ b/packages/workbox-build/src/lib/cdn-utils.js
@@ -15,16 +15,19 @@
 */
 const cdn = require('../cdn-details.json');
 
-const getRootCDNUrl = () => {
-  return `${cdn.origin}/${cdn.bucketName}/${cdn.releasesDir}/` +
-    `${cdn.latestVersion}`;
+const getCDNOrigin = () => {
+  return `${cdn.origin}/${cdn.bucketName}/${cdn.releasesDir}`;
+};
+
+const getVersionedCDNUrl = () => {
+  return `${getCDNOrigin()}/${cdn.latestVersion}`;
 };
 
 const getModuleUrl = (moduleName, buildType) => {
-  return `${getRootCDNUrl()}/${moduleName}.${buildType.slice(0, 4)}.js`;
+  return `${getVersionedCDNUrl()}/${moduleName}.${buildType.slice(0, 4)}.js`;
 };
 
 module.exports = {
-  getRootCDNUrl,
+  getCDNOrigin,
   getModuleUrl,
 };

--- a/test/workbox-sw/node/test-WorkboxSW.mjs
+++ b/test/workbox-sw/node/test-WorkboxSW.mjs
@@ -150,7 +150,7 @@ describe(`[workbox-sw] WorkboxSW`, function() {
       sandbox.stub(console, 'error').callsFake((errMsg) => {
         expect(errMsg.includes('workbox-core')).to.be.true;
         expect(errMsg.includes(
-            'WORKBOX_CDN_ROOT_URL/workbox-core.prod.js')).to.be.true;
+            'WORKBOX_CDN_ORIGIN_URL/workbox-core.prod.js')).to.be.true;
       });
 
       try {


### PR DESCRIPTION
I noticed a few issues with the publishing of CDN / demos.

`workbox-sw` was loading older versions of modules even though the released version of `workbox-sw` was newer and the files were available.

The issue was that `workbox-build` was being used to determine the CDN URL but there was no depedency on `workbox-sw` and `workbox-build` meaning that Lerna can build them in order they wanted.

I've removed the versioned function from `workbox-build` and instead switched demos and rollup reference to a function in the build tools that will use the latest lerna version directly.