### PR TITLE
Switching to namespace and tidying precaching docs

### DIFF
--- a/packages/workbox-cli/src/lib/questions/ask-extensions-to-cache.js
+++ b/packages/workbox-cli/src/lib/questions/ask-extensions-to-cache.js
@@ -28,8 +28,8 @@ const name = 'globPatterns';
 
 /**
  * @param {string} globDirectory The directory used for the root of globbing.
- * @return {Promise<[string]>} The unique file extensions corresponding to all
- * of the files under globDirectory.
+ * @return {Promise<Array<string>>} The unique file extensions corresponding
+ * to all of the files under globDirectory.
  */
 async function getAllFileExtensions(globDirectory) {
   const files = await new Promise((resolve, reject) => {

--- a/packages/workbox-core/_default.mjs
+++ b/packages/workbox-core/_default.mjs
@@ -26,8 +26,8 @@ import './_version.mjs';
  * This class is never exposed publicly. Inidividual methods are exposed
  * using jsdoc alias commands.
  *
+ * @memberof workbox.core
  * @private
- * @memberof module:workbox-core
  */
 class WorkboxCore {
   /**
@@ -72,8 +72,9 @@ class WorkboxCore {
    * store `analytics.js`,
    * and `cacheNames.runtime` is used for everything else.
    *
-   * @alias module:workbox-core.cacheNames
    * @return {Object} An object with `precache` and `runtime` cache names.
+   *
+   * @alias workbox.core.cacheNames
    */
   get cacheNames() {
     return {
@@ -89,7 +90,6 @@ class WorkboxCore {
    *
    * Cache names are generated as `<prefix>-<Cache Name>-<suffix>`.
    *
-   * @alias module:workbox-core.setCacheNameDetails
    * @param {Object} details
    * @param {Object} details.prefix The string to add to the beginning of
    * the precache and runtime cache names.
@@ -100,6 +100,8 @@ class WorkboxCore {
    * @param {Object} details.runtime The cache name to use for runtime caching.
    * @param {Object} details.googleAnalytics The cache name to use for
    * `workbox-google-analytics` caching.
+   *
+   * @alias workbox.core.setCacheNameDetails
    */
   setCacheNameDetails(details) {
     if (process.env.NODE_ENV !== 'production') {
@@ -141,8 +143,9 @@ class WorkboxCore {
   /**
    * Get the current log level.
    *
-   * @alias module:workbox-core.logLevel
    * @return {number}.
+   *
+   * @alias workbox.core.logLevel
    */
   get logLevel() {
     return getLoggerLevel();
@@ -154,7 +157,7 @@ class WorkboxCore {
    *
    * @param {number} newLevel The new log level to use.
    *
-   * @alias module:workbox-core.setLogLevel
+   * @alias workbox.core.setLogLevel
    */
   setLogLevel(newLevel) {
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/workbox-core/index.mjs
+++ b/packages/workbox-core/index.mjs
@@ -24,14 +24,14 @@ import './_version.mjs';
  * code as well as setting default values that need to be shared (like cache
  * names).
  *
- * @module workbox-core
+ * @namespace workbox.core
  */
 
 /**
  * Utilities that are shared with other Workbox modules.
  *
+ * @alias workbox.core._private
  * @private
- * @alias module:workbox-core._private
  */
 
 export {

--- a/packages/workbox-core/models/LogLevels.mjs
+++ b/packages/workbox-core/models/LogLevels.mjs
@@ -19,8 +19,6 @@ import '../_version.mjs';
 /**
  * The available log levels in Workbox: debug, log, warn, error and silent.
  *
- * @alias module:workbox-core.LOG_LEVELS
- *
  * @property {int} debug Prints all logs from Workbox. Useful for debugging.
  * @property {int} log Prints console log, warn, error and groups. Default for
  * debug builds.
@@ -28,6 +26,8 @@ import '../_version.mjs';
  * non-debug builds.
  * @property {int} error Print console error and groups.
  * @property {int} silent Force no logging from Workbox.
+ *
+ * @alias workbox.core.LOG_LEVELS
  */
 
 export default {

--- a/packages/workbox-precaching/_default.mjs
+++ b/packages/workbox-precaching/_default.mjs
@@ -123,7 +123,7 @@ const moduleExports = {};
  *
  * @param {Array<Object|string>} entries Array of entries to precache.
  *
- * @alias module:workbox-precaching.precache
+ * @alias workbox.precaching.precache
  */
 moduleExports.precache = (entries) => {
   precacheController.addToCacheList(entries);
@@ -158,7 +158,7 @@ moduleExports.precache = (entries) => {
  * @param {Array<RegExp>} [options.ignoreUrlParametersMatching=[/^utm_/]] An
  * array of regex's to remove search params when looking for a cache match.
  *
- * @alias module:workbox-precaching.addRoute
+ * @alias workbox.precaching.addRoute
  */
 moduleExports.addRoute = (options) => {
   if (fetchListenersAdded) {
@@ -193,7 +193,7 @@ moduleExports.addRoute = (options) => {
  * @param {Object} options See
  * [addRoute() options]{@link module:workbox-precaching.addRoute}.
  *
- * @alias module:workbox-precaching.precacheAndRoute
+ * @alias workbox.precaching.precacheAndRoute
  */
 moduleExports.precacheAndRoute = (entries, options) => {
   moduleExports.precache(entries);
@@ -207,7 +207,7 @@ moduleExports.precacheAndRoute = (entries, options) => {
  *
  * @param {boolean} suppress
  *
- * @alias module:workbox-precahcing.suppressWarnings
+ * @alias workbox.precaching.suppressWarnings
  */
 moduleExports.suppressWarnings = (suppress) => {
   suppressWarnings = suppress;

--- a/packages/workbox-precaching/_types.mjs
+++ b/packages/workbox-precaching/_types.mjs
@@ -1,0 +1,49 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import './_version.mjs';
+
+/**
+ * @typedef {Object} InstallResult
+ * @property {
+ * Array<module:workbox-precaching.PrecacheController.PrecacheEntry|string>
+ * } updatedEntries List of entries
+ * supplied for precaching that were precached.
+ * @property {
+ * Array<module:workbox-precaching.PrecacheController.PrecacheEntry|string>
+ * } notUpdatedEntries List of entries
+ * supplied for precaching that were already precached.
+ *
+ * @memberof workbox.precaching
+ */
+
+/**
+ * @typedef {Object} CleanupResult
+ * @property {Array<string>} deletedCacheRequests List of URLs that were
+ * deleted from the precache cache.
+ * @property {Array<string>} deletedRevisionDetails
+ * List of URLs that were deleted from the precache cache.
+ *
+ * @memberof workbox.precaching
+ */
+
+/**
+ * @typedef {Object} PrecacheEntry
+ * @property {string} url URL to precache.
+ * @property {string} revision Revision information for the URL.
+ *
+ * @memberof workbox.precaching
+ */

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -33,7 +33,7 @@ import '../_version.mjs';
 /**
  * Performs efficient precaching of assets.
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox.precaching
  */
 class PrecacheController {
   /**
@@ -47,13 +47,6 @@ class PrecacheController {
     this._precacheDetailsModel = new PrecachedDetailsModel(this._cacheName);
   }
 
-  /**
-   * @typedef {Object} PrecacheEntry
-   * @property {string} url URL to precache.
-   * @property {string} revision Revision information for the URL.
-   *
-   * @memberof module:workbox-precaching.PrecacheController
-   */
   /**
    * This method will add items to the precache list, removing duplicates
    * and ensuring the information is valid.
@@ -148,19 +141,6 @@ class PrecacheController {
   }
 
   /**
-   * @typedef {Object} InstallResult
-   * @property {
-   * Array<module:workbox-precaching.PrecacheController.PrecacheEntry|string>
-   * } updatedEntries List of entries
-   * supplied for precaching that were precached.
-   * @property {
-   * Array<module:workbox-precaching.PrecacheController.PrecacheEntry|string>
-   * } notUpdatedEntries List of entries
-   * supplied for precaching that were already precached.
-   *
-   * @memberof module:workbox-precaching.PrecacheController
-   */
-  /**
    * Call this method from a service work install event to start
    * precaching assets.
    *
@@ -233,16 +213,6 @@ class PrecacheController {
 
     return true;
   }
-
-  /**
-   * @typedef {Object} CleanupResult
-   * @property {Array<string>} deletedCacheRequests List of URLs that were
-   * deleted from the precache cache.
-   * @property {Array<string>} deletedRevisionDetails
-   * List of URLs that were deleted from the precache cache.
-   *
-   * @memberof module:workbox-precaching.PrecacheController
-   */
 
   /**
    * Compare the URLs and determines which assets are no longer required

--- a/packages/workbox-precaching/index.mjs
+++ b/packages/workbox-precaching/index.mjs
@@ -19,15 +19,15 @@ import './_version.mjs';
 
 /**
  * Most consumers of this module will want to use the
- * [precacheAndRoute()]{@link module:workbox-precaching.precacheAndRoute}
+ * [precacheAndRoute()]{@link workbox.precaching.precacheAndRoute}
  * method to add assets to the Cache and respond to network requests with these
  * cached assets.
  *
  * If you require finer grained control, you can use the
- * [PrecacheController]{@link module:workbox-precaching.PrecacheController}
+ * [PrecacheController]{@link workbox.precaching.PrecacheController}
  * to determine when performed.
  *
- * @module workbox-precaching
+ * @namespace workbox.precaching
  */
 
 export * from './_public.mjs';

--- a/packages/workbox-precaching/models/PrecachedDetailsModel.mjs
+++ b/packages/workbox-precaching/models/PrecachedDetailsModel.mjs
@@ -26,14 +26,14 @@ const DB_STORE_NAME = 'precached-details-models';
  * are cached and their matching revision details.
  *
  * @private
- * @memberof module:workbox-precaching
  */
 class PrecachedDetailsModel {
   /**
    * Construct a new model for a specific cache.
    *
-   * @private
    * @param {string} cacheName
+   *
+   * @private
    */
   constructor(cacheName) {
     this._cacheName = cacheNames.getPrecacheName(cacheName);
@@ -50,6 +50,8 @@ class PrecachedDetailsModel {
    *
    * @param {PrecacheEntry} precacheEntry
    * @return {boolean}
+   *
+   * @private
    */
   async _isEntryCached(precacheEntry) {
     const revisionDetails = await this._getRevision(precacheEntry._entryId);
@@ -64,6 +66,8 @@ class PrecachedDetailsModel {
 
   /**
    * @return {Promise<Array>}
+   *
+   * @private
    */
   async _getAllEntries() {
     return await this._db.getAll(DB_STORE_NAME);
@@ -74,6 +78,8 @@ class PrecachedDetailsModel {
    *
    * @param {Object} entryId
    * @return {Promise<string|null>}
+   *
+   * @private
    */
   async _getRevision(entryId) {
     const data = await this._db.get(DB_STORE_NAME, entryId);
@@ -84,6 +90,8 @@ class PrecachedDetailsModel {
    * Add an entry to the details model.
    *
    * @param {PrecacheEntry} precacheEntry
+   *
+   * @private
    */
   async _addEntry(precacheEntry) {
     await this._db.put(
@@ -100,6 +108,8 @@ class PrecachedDetailsModel {
    * Delete entry from details model.
    *
    * @param {string} entryId
+   *
+   * @private
    */
   async _deleteEntry(entryId) {
     await this._db.delete(DB_STORE_NAME, entryId);

--- a/test/all/node/test-exports.mjs
+++ b/test/all/node/test-exports.mjs
@@ -15,6 +15,7 @@ describe(`[all] Test Exports of Each Module`, function() {
         case '_public':
         case '_default':
         case '_version':
+        case '_types':
           // These are special files and don't need to be exported.
           break;
         default:


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

Precaching was exposing private docs - new theme exposed it.

Also tried namespace instead of module syntax and it actually reads a little better. Got the idea from firebase reference docs: https://firebase.google.com/docs/reference/js/