### PR TITLE
Runtime-caching Docs + Coverage.

### DIFF
--- a/packages/workbox-core/_private/fetchWrapper.mjs
+++ b/packages/workbox-core/_private/fetchWrapper.mjs
@@ -60,7 +60,7 @@ const wrappedFetch = async (request, fetchOptions, plugins = []) => {
           request: request.clone(),
         });
 
-        // TODO Move to assertion
+        // TODO: Move to assertion
         // isInstance({request}, Request);
       }
     }

--- a/packages/workbox-runtime-caching/CacheFirst.mjs
+++ b/packages/workbox-runtime-caching/CacheFirst.mjs
@@ -31,7 +31,7 @@ import './_version.mjs';
  * such as URLs like `/styles/example.a8f5f1.css`, since they
  * can be cached for long periods of time.
  *
- * @memberof module:workbox-runtime-caching
+ * @memberof workbox.strategies
  */
 class CacheFirst {
   // TODO: Replace `plugins` parameter link with link to d.g.c.
@@ -40,7 +40,7 @@ class CacheFirst {
    * @param {Object} options
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
-   * [workbox-core]{@link module:workbox-core.cacheNames}.
+   * [workbox-core]{@link workbox.core.cacheNames}.
    * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
    * to use in conjunction with this caching strategy.
    */
@@ -52,7 +52,7 @@ class CacheFirst {
   /**
    * This method will perform a request strategy and follows an API that
    * will work with the
-   * [Workbox Router]{@link module:workbox-routing.Router}.
+   * [Workbox Router]{@link workbox.routing.Router}.
    *
    * @param {Object} input
    * @param {FetchEvent} input.event The fetch event to run this strategy

--- a/packages/workbox-runtime-caching/CacheOnly.mjs
+++ b/packages/workbox-runtime-caching/CacheOnly.mjs
@@ -33,14 +33,14 @@ import './_version.mjs';
  *
  * This class is useful if you want to take advantage of any [Workbox plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}.
  *
- * @memberof module:workbox-runtime-caching
+ * @memberof workbox.strategies
  */
 class CacheOnly {
   /**
    * @param {Object} options
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
-   * [workbox-core]{@link module:workbox-core.cacheNames}.
+   * [workbox-core]{@link workbox.core.cacheNames}.
    * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
    * to use in conjunction with this caching strategy.
    */
@@ -52,7 +52,7 @@ class CacheOnly {
   /**
    * This method will perform a request strategy and follows an API that
    * will work with the
-   * [Workbox Router]{@link module:workbox-routing.Router}.
+   * [Workbox Router]{@link workbox.routing.Router}.
    *
    * @param {Object} input
    * @param {FetchEvent} input.event The fetch event to run this strategy

--- a/packages/workbox-runtime-caching/NetworkFirst.mjs
+++ b/packages/workbox-runtime-caching/NetworkFirst.mjs
@@ -38,14 +38,14 @@ import './_version.mjs';
  * Opaque responses are are cross-origin requests where the response doesn't
  * support [CORS]{@link https://enable-cors.org/}.
  *
- * @memberof module:workbox-runtime-caching
+ * @memberof workbox.strategies
  */
 class NetworkFirst {
   /**
    * @param {Object} options
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
-   * [workbox-core]{@link module:workbox-core.cacheNames}.
+   * [workbox-core]{@link workbox.core.cacheNames}.
    * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
    * to use in conjunction with this caching strategy.
    * @param {number} options.networkTimeoutSeconds If set, any network requests
@@ -84,7 +84,7 @@ class NetworkFirst {
   /**
    * This method will perform a request strategy and follows an API that
    * will work with the
-   * [Workbox Router]{@link module:workbox-routing.Router}.
+   * [Workbox Router]{@link workbox.routing.Router}.
    *
    * @param {Object} input
    * @param {FetchEvent} input.event The fetch event to run this strategy

--- a/packages/workbox-runtime-caching/NetworkOnly.mjs
+++ b/packages/workbox-runtime-caching/NetworkOnly.mjs
@@ -33,14 +33,14 @@ import './_version.mjs';
  *
  * This class is useful if you want to take advantage of any [Workbox plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}.
  *
- * @memberof module:workbox-runtime-caching
+ * @memberof workbox.strategies
  */
 class NetworkOnly {
   /**
    * @param {Object} options
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
-   * [workbox-core]{@link module:workbox-core.cacheNames}.
+   * [workbox-core]{@link workbox.core.cacheNames}.
    * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
    * to use in conjunction with this caching strategy.
    */
@@ -52,7 +52,7 @@ class NetworkOnly {
   /**
    * This method will perform a request strategy and follows an API that
    * will work with the
-   * [Workbox Router]{@link module:workbox-routing.Router}.
+   * [Workbox Router]{@link workbox.routing.Router}.
    *
    * @param {Object} input
    * @param {FetchEvent} input.event The fetch event to run this strategy

--- a/packages/workbox-runtime-caching/StaleWhileRevalidate.mjs
+++ b/packages/workbox-runtime-caching/StaleWhileRevalidate.mjs
@@ -44,14 +44,14 @@ import './_version.mjs';
  * Opaque responses are are cross-origin requests where the response doesn't
  * support [CORS]{@link https://enable-cors.org/}.
  *
- * @memberof module:workbox-runtime-caching
+ * @memberof workbox.strategies
  */
 class StaleWhileRevalidate {
   /**
    * @param {Object} options
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
-   * [workbox-core]{@link module:workbox-core.cacheNames}.
+   * [workbox-core]{@link workbox.core.cacheNames}.
    * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
    * to use in conjunction with this caching strategy.
    */
@@ -73,7 +73,7 @@ class StaleWhileRevalidate {
   /**
    * This method will perform a request strategy and follows an API that
    * will work with the
-   * [Workbox Router]{@link module:workbox-routing.Router}.
+   * [Workbox Router]{@link workbox.routing.Router}.
    *
    * @param {Object} input
    * @param {FetchEvent} input.event The fetch event to run this strategy

--- a/packages/workbox-runtime-caching/StaleWhileRevalidate.mjs
+++ b/packages/workbox-runtime-caching/StaleWhileRevalidate.mjs
@@ -140,16 +140,14 @@ class StaleWhileRevalidate {
       this._plugins
     );
 
-    if (response) {
-      event.waitUntil(
-        cacheWrapper.put(
-          this._cacheName,
-          event.request,
-          response.clone(),
-          this._plugins
-        )
-      );
-    }
+    event.waitUntil(
+      cacheWrapper.put(
+        this._cacheName,
+        event.request,
+        response.clone(),
+        this._plugins
+      )
+    );
 
     return response;
   }

--- a/packages/workbox-runtime-caching/_default.mjs
+++ b/packages/workbox-runtime-caching/_default.mjs
@@ -21,6 +21,31 @@ import {StaleWhileRevalidate} from './StaleWhileRevalidate.mjs';
 import pluginBuilder from './utils/pluginBuilder.mjs';
 import './_version.mjs';
 
+/**
+ * @function workbox.strategies.cacheFirst
+ * @param {StrategyOptions} options
+ */
+
+/**
+ * @function workbox.strategies.cacheOnly
+ * @param {StrategyOptions} options
+ */
+
+/**
+ * @function workbox.strategies.networkFirst
+ * @param {StrategyOptions} options
+ */
+
+/**
+ * @function workbox.strategies.networkOnly
+ * @param {StrategyOptions} options
+ */
+
+/**
+ * @function workbox.strategies.staleWhileRevalidate
+ * @param {StrategyOptions} options
+ */
+
 const mapping = {
   cacheFirst: CacheFirst,
   cacheOnly: CacheOnly,

--- a/packages/workbox-runtime-caching/_types.mjs
+++ b/packages/workbox-runtime-caching/_types.mjs
@@ -1,0 +1,30 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import './_version.mjs';
+
+/**
+ * @typedef {Object} StrategyOptions
+ * @property {String} cacheName Name of cache to use
+ * for caching (both lookup and updating).
+ * @property {Object} cacheExpiration Defining this
+ * object will add a cache expiration plugins to this strategy.
+ * @property {Number} cacheExpiration.maxEntries
+ * The maximum number of entries to store in a cache.
+ * @property {Number} cacheExpiration.maxAgeSeconds
+ * The maximum lifetime of a request to stay in the cache before it's removed.
+ * @memberof workbox.strategies
+ */

--- a/packages/workbox-runtime-caching/index.mjs
+++ b/packages/workbox-runtime-caching/index.mjs
@@ -18,7 +18,7 @@
  * There are common caching strategies that most service workers will need
  * and use. This module provides simple implementations of these strategies.
  *
- * @module workbox-runtime-caching
+ * @namespace workbox.strategies
  */
 
 import defaultExport from './_default.mjs';

--- a/packages/workbox-runtime-caching/plugins/cacheOkAndOpaquePlugin.mjs
+++ b/packages/workbox-runtime-caching/plugins/cacheOkAndOpaquePlugin.mjs
@@ -21,11 +21,10 @@ export default {
    * response is ok (i.e. 200) or is opaque.
    *
    * @param {Object} input
-   * @param {Request} input.request
    * @param {Response} input.response
    * @return {Response|null}
    */
-  cacheWillUpdate: ({request, response}) => {
+  cacheWillUpdate: ({response}) => {
     if (response.ok || response.status === 0) {
       return response;
     }

--- a/packages/workbox-runtime-caching/plugins/cacheOkAndOpaquePlugin.mjs
+++ b/packages/workbox-runtime-caching/plugins/cacheOkAndOpaquePlugin.mjs
@@ -23,6 +23,8 @@ export default {
    * @param {Object} input
    * @param {Response} input.response
    * @return {Response|null}
+   *
+   * @private
    */
   cacheWillUpdate: ({response}) => {
     if (response.ok || response.status === 0) {

--- a/test/workbox-runtime-caching/node/test-CacheFirst.mjs
+++ b/test/workbox-runtime-caching/node/test-CacheFirst.mjs
@@ -226,4 +226,21 @@ describe(`[workbox-runtime-caching] CacheFirst`, function() {
     await compareResponses(firstCachedResponse, fetchResponse, true);
     await compareResponses(firstHandleResponse, fetchResponse, true);
   });
+
+  it(`should be able to handle a network error`, async function() {
+    const request = new Request('http://example.io/test/');
+    const event = new FetchEvent('fetch', {request});
+    const injectedError = new Error(`Injected Error.`);
+    sandbox.stub(global, 'fetch').callsFake((req) => {
+      return Promise.reject(injectedError);
+    });
+
+    const cacheFirst = new CacheFirst();
+    try {
+      await cacheFirst.handle({event});
+      throw new Error('Expected an error to be thrown.');
+    } catch (err) {
+      expect(err).to.equal(injectedError);
+    }
+  });
 });

--- a/test/workbox-runtime-caching/node/test-StaleWhileRevalidate.mjs
+++ b/test/workbox-runtime-caching/node/test-StaleWhileRevalidate.mjs
@@ -135,4 +135,16 @@ describe(`[workbox-runtime-caching] StaleWhileRevalidate`, function() {
     const cachedResponse = await cache.match(request);
     expect(cachedResponse.status).to.eql(0);
   });
+
+  it(`should allow adding plugins to override cacheOkAndOpaque`, function() {
+    const plugins = [
+      {
+        cacheWillUpdate: () => {},
+      },
+    ];
+    const staleWhileRevalidate = new StaleWhileRevalidate({
+      plugins,
+    });
+    expect(staleWhileRevalidate._plugins).to.equal(plugins);
+  });
 });

--- a/test/workbox-runtime-caching/node/test-cacheOkAndOpaquePlugin.mjs
+++ b/test/workbox-runtime-caching/node/test-cacheOkAndOpaquePlugin.mjs
@@ -1,0 +1,25 @@
+import {expect} from 'chai';
+import plugin from '../../../packages/workbox-runtime-caching/plugins/cacheOkAndOpaquePlugin.mjs';
+
+describe(`[workbox-runtime-caching] cacheOkAndOpaquePlugin`, function() {
+  it(`should return null if status is not ok and status is not opaque`, function() {
+    const response = new Response('Hello', {
+      status: 404,
+    });
+    expect(plugin.cacheWillUpdate({response})).to.equal(null);
+  });
+
+  it(`should return Response if status is opaque`, function() {
+    const response = new Response('Hello', {
+      status: 0,
+    });
+    expect(plugin.cacheWillUpdate({response})).to.equal(response);
+  });
+
+  it(`should return Response if status is 200`, function() {
+    const response = new Response('Hello', {
+      status: 200,
+    });
+    expect(plugin.cacheWillUpdate({response})).to.equal(response);
+  });
+});


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

Extend coverage for runtime-caching and sort out docs to namespace and document default exports.
