### PR TITLE
pkg.browser => pkg.main, and update the build path.

### DIFF
--- a/gulp-tasks/demos.js
+++ b/gulp-tasks/demos.js
@@ -10,8 +10,7 @@ const spawn = require('./utils/spawn-promise-wrapper');
 gulp.task('demos:groupBuildFiles', async () => {
   const pattern = path.posix.join(
     __dirname, '..', 'packages', '**',
-    constants.PACKAGE_BUILD_DIRNAME, constants.BROWSER_BUILD_DIRNAME,
-    '*.{js,map}');
+    constants.PACKAGE_BUILD_DIRNAME, '*.{js,map}');
 
   const localBuildPath = path.join(__dirname, '..', 'demos', 'public',
     constants.LOCAL_BUILDS_DIR);

--- a/gulp-tasks/utils/analyse-properties.js
+++ b/gulp-tasks/utils/analyse-properties.js
@@ -34,9 +34,9 @@ class AnalyseBuildForProperties {
   }
 
   getBuildFiles() {
+    // workbox-sw doesn't include .prod. in the build name.
     const buildGlob = path.join(__dirname, '..', '..', 'packages',
-      '*', constants.PACKAGE_BUILD_DIRNAME, constants.BROWSER_BUILD_DIRNAME,
-      '*.prod.js');
+      '*', constants.PACKAGE_BUILD_DIRNAME, '{*.prod.js,workbox-sw.js}');
     return glob.sync(buildGlob);
   }
 

--- a/gulp-tasks/utils/build-browser-bundle.js
+++ b/gulp-tasks/utils/build-browser-bundle.js
@@ -100,7 +100,7 @@ module.exports = (packagePath, buildType) => {
 
   const namespace = pkgJson.workbox.browserNamespace;
   const outputDirectory = path.join(packagePath,
-    constants.PACKAGE_BUILD_DIRNAME, constants.BROWSER_BUILD_DIRNAME);
+    constants.PACKAGE_BUILD_DIRNAME);
 
   logHelper.log(oneLine`
     Building Browser Bundle for

--- a/gulp-tasks/utils/constants.js
+++ b/gulp-tasks/utils/constants.js
@@ -3,7 +3,6 @@ module.exports = {
   // to git and will be removed and rebuilt between
   // test runs.
   PACKAGE_BUILD_DIRNAME: 'build',
-  BROWSER_BUILD_DIRNAME: 'browser',
   GENERATED_RELEASE_FILES_DIRNAME: 'generated-release-files',
 
   // This is used in the publish-bundle step to avoid doing anything

--- a/gulp-tasks/utils/publish-helpers.js
+++ b/gulp-tasks/utils/publish-helpers.js
@@ -95,8 +95,7 @@ const groupBuildFiles = async (tagName, gitBranch) => {
 
     const pattern = path.posix.join(
       sourceCodePath, 'packages', '**',
-      constants.PACKAGE_BUILD_DIRNAME, constants.BROWSER_BUILD_DIRNAME,
-      '*.{js,map}');
+      constants.PACKAGE_BUILD_DIRNAME, '*.{js,map}');
 
 
     logHelper.log(oneLine`

--- a/infra/pr-bot/aggregate-size-plugin.js
+++ b/infra/pr-bot/aggregate-size-plugin.js
@@ -26,7 +26,7 @@ class AggregateSizePlugin extends PluginInterface {
     const files = packagesToAggregate.map((pkg) => {
       const prefix = `${afterPath}/packages/${pkg}/`;
       const pkgJson = require(`${prefix}package.json`);
-      const posixPath = prefix + pkgJson.browser;
+      const posixPath = prefix + pkgJson.main;
       return posixPath.split('/').join(path.sep);
     });
 

--- a/infra/testing/test-server.js
+++ b/infra/testing/test-server.js
@@ -21,7 +21,7 @@ app.get(/\/__WORKBOX\/buildFile\/(workbox-[A-z]*)(\.(?:dev|prod)\.(.*))*/, (req,
     path.join(modulePath, 'package.json')
   );
 
-  const browserFile = pkg.browser;
+  const browserFile = pkg.main;
   const libraryPath = path.dirname(path.join(modulePath, browserFile));
   let libraryFileName = path.basename(browserFile);
   switch (process.env.NODE_ENV) {

--- a/packages/workbox-background-sync/package.json
+++ b/packages/workbox-background-sync/package.json
@@ -24,9 +24,8 @@
     "browserNamespace": "workbox.backgroundSync",
     "packageType": "browser"
   },
-  "main": "index.mjs",
+  "main": "build/workbox-background-sync.prod.js",
   "module": "index.mjs",
-  "browser": "build/browser/workbox-background-sync.prod.js",
   "dependencies": {
     "workbox-core": "^3.0.0-alpha.23"
   }

--- a/packages/workbox-build/src/entry-points/generate-sw.js
+++ b/packages/workbox-build/src/entry-points/generate-sw.js
@@ -64,8 +64,7 @@ async function generateSW(input) {
     ].concat(options.globIgnores || []);
 
     const workboxSWPkg = require(`workbox-sw/package.json`);
-    // TODO: This will change to workboxSWPkg.main at some point.
-    const workboxSWFilename = path.basename(workboxSWPkg.browser);
+    const workboxSWFilename = path.basename(workboxSWPkg.main);
 
     // importScripts may or may not already be an array containing other URLs.
     // Either way, list workboxSWFilename first.

--- a/packages/workbox-build/src/lib/copy-workbox-libraries.js
+++ b/packages/workbox-build/src/lib/copy-workbox-libraries.js
@@ -60,8 +60,7 @@ module.exports = async (destDirectory) => {
     (dependency) => dependency.startsWith(WORKBOX_PREFIX));
   for (const library of librariesToCopy) {
     const pkg = require(`${library}/package.json`);
-    // TODO: This will change to pkg.main at some point.
-    const defaultPathToLibrary = require.resolve(`${library}/${pkg.browser}`);
+    const defaultPathToLibrary = require.resolve(`${library}/${pkg.main}`);
 
     for (const buildType of BUILD_TYPES) {
       const srcPath = useBuildType(defaultPathToLibrary, buildType);

--- a/packages/workbox-cache-expiration/package.json
+++ b/packages/workbox-cache-expiration/package.json
@@ -22,9 +22,8 @@
     "browserNamespace": "workbox.expiration",
     "packageType": "browser"
   },
-  "main": "index.mjs",
+  "main": "build/workbox-cache-expiration.prod.js",
   "module": "index.mjs",
-  "browser": "build/browser/workbox-cache-expiration.prod.js",
   "dependencies": {
     "workbox-core": "^3.0.0-alpha.23"
   }

--- a/packages/workbox-core/package.json
+++ b/packages/workbox-core/package.json
@@ -22,7 +22,6 @@
     "browserNamespace": "workbox.core",
     "packageType": "browser"
   },
-  "main": "index.mjs",
-  "module": "index.mjs",
-  "browser": "build/browser/workbox-core.prod.js"
+  "main": "build/workbox-core.prod.js",
+  "module": "index.mjs"
 }

--- a/packages/workbox-google-analytics/package.json
+++ b/packages/workbox-google-analytics/package.json
@@ -25,9 +25,8 @@
     "browserNamespace": "workbox.googleAnalytics",
     "packageType": "browser"
   },
-  "main": "index.mjs",
+  "main": "build/workbox-google-analytics.prod.js",
   "module": "index.mjs",
-  "browser": "build/browser/workbox-google-analytics.prod.js",
   "dependencies": {
     "workbox-background-sync": "^3.0.0-alpha.23",
     "workbox-core": "^3.0.0-alpha.23",

--- a/packages/workbox-precaching/package.json
+++ b/packages/workbox-precaching/package.json
@@ -22,9 +22,8 @@
     "browserNamespace": "workbox.precaching",
     "packageType": "browser"
   },
-  "main": "index.mjs",
+  "main": "build/workbox-precaching.prod.js",
   "module": "index.mjs",
-  "browser": "build/browser/workbox-precaching.prod.js",
   "dependencies": {
     "workbox-core": "^3.0.0-alpha.23"
   }

--- a/packages/workbox-routing/package.json
+++ b/packages/workbox-routing/package.json
@@ -24,9 +24,8 @@
     "browserNamespace": "workbox.routing",
     "packageType": "browser"
   },
-  "main": "index.mjs",
+  "main": "build/workbox-routing.prod.js",
   "module": "index.mjs",
-  "browser": "build/browser/workbox-routing.prod.js",
   "dependencies": {
     "workbox-core": "^3.0.0-alpha.23"
   }

--- a/packages/workbox-runtime-caching/package.json
+++ b/packages/workbox-runtime-caching/package.json
@@ -24,9 +24,8 @@
     "browserNamespace": "workbox.strategies",
     "packageType": "browser"
   },
-  "main": "index.mjs",
+  "main": "build/workbox-runtime-caching.prod.js",
   "module": "index.mjs",
-  "browser": "build/browser/workbox-runtime-caching.prod.js",
   "dependencies": {
     "workbox-core": "^3.0.0-alpha.23",
     "workbox-cache-expiration": "^3.0.0-alpha.23"

--- a/packages/workbox-sw/package.json
+++ b/packages/workbox-sw/package.json
@@ -23,7 +23,6 @@
     "packageType": "browser",
     "prodOnly": true
   },
-  "main": "index.mjs",
-  "module": "index.mjs",
-  "browser": "build/browser/workbox-sw.js"
+  "main": "build/workbox-sw.js",
+  "module": "index.mjs"
 }

--- a/test/all/node/test-package.mjs
+++ b/test/all/node/test-package.mjs
@@ -20,7 +20,6 @@ describe(`[all] Test package.json`, function() {
           const propertiesToCheck = [
             'main',
             'module',
-            'browser',
           ];
 
           propertiesToCheck.forEach((propertyName) => {


### PR DESCRIPTION
R: @philipwalton @addyosmani @gauntface

Fixes #911

While moving from `browser` to `main`, I've also taken the opportunity to remove the `browser/` subdirectory from `build/`. I don't think there are any packages that have both browser and non-browser builds, so it doesn't seem necessary.