### PR TITLE
Use accessSync to ensure ERROR_SERVICE_ACCOUNT is logged

### DIFF
--- a/gulp-tasks/utils/cdn-helper.js
+++ b/gulp-tasks/utils/cdn-helper.js
@@ -32,7 +32,7 @@ class CDNHelper {
   getGCS() {
     if (!this._gcs) {
       try {
-        fs.access(SERVICE_ACCOUNT_PATH);
+        fs.accessSync(SERVICE_ACCOUNT_PATH);
       } catch (err) {
         throw new Error(ERROR_SERVICE_ACCOUNT);
       }


### PR DESCRIPTION
R: @addyosmani @gauntface

Without this, a failure looks like:

```sh
[15:41:34] Starting 'publish-cdn:temp-v3'...
(node:12502) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: ENOENT: no such file or directory, access '/Users/jeffy/git/workbox/workbox-9d39634504ad.json'
(node:12502) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
[Workbox Log]: Error: ENOENT: no such file or directory, open '/Users/jeffy/git/workbox/workbox-9d39634504ad.json'
[15:41:34] 'publish-cdn:temp-v3' errored after 13 ms
```

The custom `ERROR_SERVICE_ACCOUNT` message never gets logged since the exception isn't thrown synchronously.