### PR TITLE
Check packageType in package.json to figure out whether we should publish

### DIFF
--- a/gulp-tasks/utils/get-packages-of-type.js
+++ b/gulp-tasks/utils/get-packages-of-type.js
@@ -1,0 +1,14 @@
+const glob = require('glob');
+const path = require('path');
+
+module.exports = (root, type) => {
+  const pathToPkgJsons = glob.sync('packages/*/package.json', {cwd: root});
+  return pathToPkgJsons.filter((pathToPkgJson) => {
+    const pkg = require(`${path.resolve(root)}/${pathToPkgJson}`);
+    return pkg.workbox && (pkg.workbox.packageType === type);
+  }).map((pathToPkgJson) => {
+    // Since we matched the glob pattern then we know that this will always
+    // return the name of the package.
+    return pathToPkgJson.split('/')[1];
+  });
+};

--- a/gulp-tasks/utils/publish-helpers.js
+++ b/gulp-tasks/utils/publish-helpers.js
@@ -4,9 +4,10 @@ const glob = require('glob');
 const archiver = require('archiver');
 const oneLine = require('common-tags').oneLine;
 
-const spawn = require('./spawn-promise-wrapper');
 const constants = require('./constants');
+const getPackagesOfType = require('./get-packages-of-type');
 const logHelper = require('../../infra/utils/log-helper');
+const spawn = require('./spawn-promise-wrapper');
 
 const SOURCE_CODE_DIR = 'source-code';
 const GROUPED_BUILD_FILES = 'grouped-build-files';
@@ -93,10 +94,11 @@ const groupBuildFiles = async (tagName, gitBranch) => {
 
     const sourceCodePath = path.join(getBuildPath(tagName), SOURCE_CODE_DIR);
 
-    const pattern = path.posix.join(
-      sourceCodePath, 'packages', '**',
-      constants.PACKAGE_BUILD_DIRNAME, '*.{js,map}');
+    const browserPackages = getPackagesOfType(sourceCodePath, 'browser');
 
+    const pattern = path.posix.join(
+      sourceCodePath, 'packages', `{${browserPackages.join(',')}}`,
+      constants.PACKAGE_BUILD_DIRNAME, '*.{js,map}');
 
     logHelper.log(oneLine`
       Grouping Build Files into
@@ -113,7 +115,7 @@ const groupBuildFiles = async (tagName, gitBranch) => {
       );
     }
   } else {
-    logHelper.log(`   Builds files already grouped.`);
+    logHelper.log(`   Build files already grouped.`);
   }
 
   return groupedBuildFiles;


### PR DESCRIPTION
R: @addyosmani @gauntface

I could take a different approach to this, but using the `packageType` in `package.json` to determine which packages got picked up for CDN publishing made sense to me.