### PR TITLE
webpack-docs

### DIFF
--- a/packages/workbox-webpack-plugin/src/index.js
+++ b/packages/workbox-webpack-plugin/src/index.js
@@ -29,6 +29,10 @@ const {setReadFile} = require('./lib/utils/read-file');
  *
  * @module workbox-webpack-plugin
  */
+
+/**
+ * @memberof module:workbox-webpack-plugin
+ */
 class WorkboxWebpackPlugin {
   /**
    * Creates an instance of WorkboxWebpackPlugin.
@@ -55,9 +59,10 @@ class WorkboxWebpackPlugin {
   }
 
   /**
-   * @private
    * @return {Object} All workbox configuration options that can be accepted
    * by {@link module:workbox-build.generateSWString}
+   *
+   * @private
    */
   get generateSWStringOptions() {
     const {
@@ -75,8 +80,9 @@ class WorkboxWebpackPlugin {
   }
 
   /**
-   * @private
    * @param {Object} [compiler] default compiler object passed from webpack
+   *
+   * @private
    */
   apply(compiler) {
     /**

--- a/packages/workbox-webpack-plugin/src/index.js
+++ b/packages/workbox-webpack-plugin/src/index.js
@@ -23,15 +23,13 @@ const copyWorkboxSW = require('./lib/utils/copy-workbox-sw');
 const {setReadFile} = require('./lib/utils/read-file');
 
 /**
- * Use the instance of this in the
+ * This module exports the `WorkboxWebpackPlugin`.
+ *
+ * Use an instance of `WorkboxWebpackPlugin` in the
  * [`plugins` array](https://webpack.js.org/concepts/plugins/#usage) of a
  * webpack config.
  *
  * @module workbox-webpack-plugin
- */
-
-/**
- * @memberof module:workbox-webpack-plugin
  */
 class WorkboxWebpackPlugin {
   /**

--- a/packages/workbox-webpack-plugin/src/lib/generate-manifest-with-webpack.js
+++ b/packages/workbox-webpack-plugin/src/lib/generate-manifest-with-webpack.js
@@ -17,6 +17,7 @@
 /**
  * The variable name that workbox-sw expects manifest entries to be assigned.
  * @type {String}
+ * @private
  */
 const PRECACHE_MANIFEST_VAR = '__precacheManifest';
 
@@ -28,7 +29,7 @@ const PRECACHE_MANIFEST_VAR = '__precacheManifest';
  * @param {Array<module:workbox-build.ManifestEntry>} manifestEntries
  * @return {Promise<string>} service worker manifest file string
  *
- * @memberof module:workbox-webpack-plugin
+ * @private
  */
 module.exports = (manifestEntries) => {
   const entriesJson = JSON.stringify(manifestEntries, null, 2);

--- a/packages/workbox-webpack-plugin/src/lib/generate-or-copy-sw.js
+++ b/packages/workbox-webpack-plugin/src/lib/generate-or-copy-sw.js
@@ -32,7 +32,7 @@ const {readFile} = require('./utils/read-file');
  * @param {string} [swSrc] The path to existing service worker.
  * @return {Promise<string>} The generated service worker string.
  *
- * @memberof module:workbox-webpack-plugin
+ * @private
  */
 module.exports = async (config, swSrc) => {
   if (!swSrc) {

--- a/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-with-webpack.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-with-webpack.js
@@ -95,7 +95,7 @@ function mapAssetsToChunkHash(chunks) {
  * @param {module:workbox-webpack-plugin.Configuration} config
  * @return {Array<module:workbox-build.ManifestEntry>}
  *
- * @memberof module:workbox-webpack-plugin
+ * @private
  */
 module.exports = (compiler, compilation, config) => {
   const {publicPath} = compilation.options.output;
@@ -123,6 +123,8 @@ module.exports = (compiler, compilation, config) => {
    * otherwise we use all of webpack's compilation.assets.
    *
    * @type {Array<string>}
+   *
+   * @private
    */
   const manifestFiles = whitelist
     ? Object.keys(assetsToChunkHash)

--- a/packages/workbox-webpack-plugin/src/lib/utils/read-file.js
+++ b/packages/workbox-webpack-plugin/src/lib/utils/read-file.js
@@ -25,8 +25,9 @@ let readFileFn;
 /**
  * Sets the read file function.
  *
- * @private
  * @param {Function} fn The function to use.
+ *
+ * @private
  */
 function setReadFile(fn) {
   readFileFn = fn;
@@ -35,9 +36,10 @@ function setReadFile(fn) {
 /**
  * A wrapper that calls readFileFn and returns a promise for the contents.
  *
- * @private
  * @param {string} filePath The file to read.
  * @return {Promise<string>} The contents of the file.
+ *
+ * @private
  */
 function readFile(filePath) {
   return new Promise((resolve, reject) => {

--- a/packages/workbox-webpack-plugin/src/lib/utils/resolve-webpack-url.js
+++ b/packages/workbox-webpack-plugin/src/lib/utils/resolve-webpack-url.js
@@ -24,6 +24,6 @@
  * @param {Array<string>} paths File paths to join
  * @return {string} Joined file path
  *
- * @memberof module:workbox-webpack-plugin
+ * @private
  */
 module.exports = (...paths) => paths.join('');

--- a/packages/workbox-webpack-plugin/src/lib/utils/webpack-asset.js
+++ b/packages/workbox-webpack-plugin/src/lib/utils/webpack-asset.js
@@ -29,7 +29,7 @@
  *           webpack.
  * @property {Function} size Returns the byte size of the asset `source` value.
  *
- * @memberof module:workbox-webpack-plugin
+ * @private
  */
 
 /**
@@ -43,7 +43,7 @@
  *        written to the file system by webpack.
  * @return {WebpackAsset}
  *
- * @memberof module:workbox-webpack-plugin
+ * @private
  */
 module.exports = (asset) => {
   return {


### PR DESCRIPTION
R: @jeffposnick @addyosmani @goldhand 

My understanding is that the Webpack plugin exports *just* the `WorkboxWebpackPlugin`. This PR will expose only this class and alters the docs to call out that the class the only thing exported.