### PR TITLE
Adding log for opaque responses

### DIFF
--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -137,8 +137,9 @@ const _isResponseSafeToCache = async (request, response, plugins) => {
     if (process.env.NODE_ENV !== 'production') {
       if (!responseToCache.ok) {
         if (responseToCache.status === 0) {
+          // TODO: Add a link to guide on third-party request handling
           logger.warn(`The response for '${request.url}' is an opaque ` +
-            `response. Workbox will not cache this by default.`);
+            `response. Workbox does not cache opaque responses by default.`);
         } else {
           logger.debug(`The response for '${request.url}' returned ` +
           `a status code of '${response.status}' and won't be cached as a ` +

--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -139,7 +139,8 @@ const _isResponseSafeToCache = async (request, response, plugins) => {
         if (responseToCache.status === 0) {
           // TODO: Add a link to guide on third-party request handling
           logger.warn(`The response for '${request.url}' is an opaque ` +
-            `response. Workbox does not cache opaque responses by default.`);
+            `response. The caching strategy that you're using will not ` +
+            `cache opaque responses by default.`);
         } else {
           logger.debug(`The response for '${request.url}' returned ` +
           `a status code of '${response.status}' and won't be cached as a ` +

--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -134,6 +134,18 @@ const _isResponseSafeToCache = async (request, response, plugins) => {
   }
 
   if (!pluginsUsed) {
+    if (process.env.NODE_ENV !== 'production') {
+      if (!responseToCache.ok) {
+        if (responseToCache.status === 0) {
+          logger.warn(`The response for '${request.url}' is an opaque ` +
+            `response. Workbox will not cache this by default.`);
+        } else {
+          logger.debug(`The response for '${request.url}' returned ` +
+          `a status code of '${response.status}' and won't be cached as a ` +
+          `result.`);
+        }
+      }
+    }
     responseToCache = responseToCache.ok ? responseToCache : null;
   }
 


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

@jeffposnick is there anywhere else you think it would be helpful to log when we are working with opaque responses and drop them?