### PR TITLE
Fix env-it to pass through done(), and fix up webpack plugin test

### DIFF
--- a/infra/testing/env-it.js
+++ b/infra/testing/env-it.js
@@ -3,24 +3,49 @@ const constants = require('../../gulp-tasks/utils/constants');
 module.exports = {
   devOnly: {
     it: function(title, cb) {
-      it(title, function(done) {
-        if (process.env.NODE_ENV !== constants.BUILD_TYPES.dev) {
-          return this.skip();
-        }
+      // If the wrapped callback expects done, then we need to call it() with
+      // a function that expects done.
+      if (cb.length === 1) {
+        it(title, function(done) {
+          if (process.env.NODE_ENV !== constants.BUILD_TYPES.dev) {
+            return this.skip();
+          }
 
-        return cb(done);
-      });
+          return cb(done);
+        });
+      } else {
+        it(title, function() {
+          if (process.env.NODE_ENV !== constants.BUILD_TYPES.dev) {
+            return this.skip();
+          }
+
+          return cb();
+        });
+      }
     },
   },
+
   prodOnly: {
     it: function(title, cb) {
-      it(title, function(done) {
-        if (process.env.NODE_ENV !== constants.BUILD_TYPES.prod) {
-          return this.skip();
-        }
+      // If the wrapped callback expects done, then we need to call it() with
+      // a function that expects done.
+      if (cb.length === 1) {
+        it(title, function(done) {
+          if (process.env.NODE_ENV !== constants.BUILD_TYPES.prod) {
+            return this.skip();
+          }
 
-        return cb(done);
-      });
+          return cb(done);
+        });
+      } else {
+        it(title, function() {
+          if (process.env.NODE_ENV !== constants.BUILD_TYPES.prod) {
+            return this.skip();
+          }
+
+          return cb();
+        });
+      }
     },
   },
 };

--- a/infra/testing/env-it.js
+++ b/infra/testing/env-it.js
@@ -3,23 +3,23 @@ const constants = require('../../gulp-tasks/utils/constants');
 module.exports = {
   devOnly: {
     it: function(title, cb) {
-      it(title, function() {
+      it(title, function(done) {
         if (process.env.NODE_ENV !== constants.BUILD_TYPES.dev) {
           return this.skip();
         }
 
-        return cb();
+        return cb(done);
       });
     },
   },
   prodOnly: {
     it: function(title, cb) {
-      it(title, function() {
+      it(title, function(done) {
         if (process.env.NODE_ENV !== constants.BUILD_TYPES.prod) {
           return this.skip();
         }
 
-        return cb();
+        return cb(done);
       });
     },
   },


### PR DESCRIPTION
R: @addyosmani @gauntface

In the course of looking into some of the webpack issues, I realized that the existing webpack plugin test wasn't failing when it should be.

The underlying issue was that the `env-it` module didn't pass through the `done` callback to the wrapped test case.

I've fixed that bug in `env-it`, and also cleaned up in the webpack plugin test so that it's legitimately working with the new v3 service worker format.

I've also modified the test so that it includes an asset with a `[chunkhash]`, in preparation for some further work.