### PR TITLE
v2: Warn on usage of Express-style wildcard characters

### DIFF
--- a/packages/workbox-sw/src/lib/router.js
+++ b/packages/workbox-sw/src/lib/router.js
@@ -107,17 +107,18 @@ class Router extends SWRoutingRouter {
       const valueToCheck = capture.startsWith('http') ?
         new URL(capture, location).pathname :
         capture;
-      const match = valueToCheck.match(new RegExp(`${wildcards}`));
-      if (match) {
+      const possibleExpressString = valueToCheck.match(
+        new RegExp(`${wildcards}`));
+      if (possibleExpressString) {
         logHelper.warn({
           message: `registerRoute() was called with a string containing an ` +
-            `Express-style wildcard character. While this is currently ` +
-            `supported, it will no longer be treated as a wildcard match in ` +
-            `an upcoming release of Workbox. For equivalent behavior, please ` +
-            `switch to using a regular expression instead.`,
+            `Express-style wildcard character. In the next version of `+
+            `Workbox, Express-style wildcards won't be supported, and ` +
+            `strings will be treated a exact matches. Please switch to ` +
+            `regular expressions for equivalent behavior.`,
           data: {
             'Path String': capture,
-            'Wildcard Character': match[0],
+            'Wildcard Character': possibleExpressString[0],
             'Learn More': 'https://goo.gl/xZMKEV',
           },
         });


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #1011 

Using `warn()` vs. a lower log level is up for negotiation.

I was planning on writing a test to make sure that `logHelper.warn()` was getting called, but then I realized we had issues in v2 with stubbing out code that is internal to the bundle. I can't find any examples of stubbing out `logHelper` methods, but if someone knows of some prior art, I'll copy it and add in some tests.