### PR TITLE
v3: workbox-cacheable-response

### DIFF
--- a/infra/pr-bot/aggregate-size-plugin.js
+++ b/infra/pr-bot/aggregate-size-plugin.js
@@ -16,8 +16,7 @@ class AggregateSizePlugin extends PluginInterface {
   run({afterPath} = {}) {
     const packagesToAggregate = [
       `workbox-cache-expiration`,
-      // TODO: Enable if this should be part of aggregate size
-      // `workbox-cacheable-response`,
+      `workbox-cacheable-response`,
       `workbox-core`,
       `workbox-precaching`,
       `workbox-routing`,

--- a/packages/workbox-cacheable-response/CacheableResponse.mjs
+++ b/packages/workbox-cacheable-response/CacheableResponse.mjs
@@ -21,7 +21,7 @@ import {logger} from 'workbox-core/_private/logger.mjs';
 import './_version.mjs';
 
 /**
- * The `CacheableResponse` class allows you to set up rules determining what
+ * This class allows you to set up rules determining what
  * status codes and/or headers need to be present in order for a
  * [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
  * to be considered cacheable.
@@ -39,9 +39,9 @@ class CacheableResponse {
    * @param {Object} config
    * @param {Array<number>} [config.statuses] One or more status codes that a
    * `Response` can have and be considered cacheable.
-   * @param {Object<string,string>} [config.headers] One or more headers that a
-   * `Response` can have and be considered cacheable. If multiple headers are
-   * provided, only one needs to be present.
+   * @param {Object<string,string>} [config.headers] A mapping of header names
+   * and expected values that a `Response` can have and be considered cacheable.
+   * If multiple headers are provided, only one needs to be present.
    */
   constructor(config = {}) {
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/workbox-cacheable-response/CacheableResponse.mjs
+++ b/packages/workbox-cacheable-response/CacheableResponse.mjs
@@ -1,0 +1,136 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import {WorkboxError} from 'workbox-core/_private/WorkboxError.mjs';
+import {assert} from 'workbox-core/_private/assert.mjs';
+import {getFriendlyURL} from 'workbox-core/_private/getFriendlyURL.mjs';
+import {logger} from 'workbox-core/_private/logger.mjs';
+import './_version.mjs';
+
+/**
+ * The `CacheableResponse` class allows you to set up rules determining what
+ * status codes and/or headers need to be present in order for a
+ * [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
+ * to be considered cacheable.
+ *
+ * @memberof workbox.cacheableResponse
+ */
+class CacheableResponse {
+  /**
+   * To construct a new CacheableResponse instance you must provide at least
+   * one of the `config` properties.
+   *
+   * If both `statuses` and `headers` are specified, then both conditions must
+   * be met for the `Response` to be considered cacheable.
+   *
+   * @param {Object} config
+   * @param {Array<number>} [config.statuses] One or more status codes that a
+   * `Response` can have and be considered cacheable.
+   * @param {Object<string,string>} [config.headers] One or more headers that a
+   * `Response` can have and be considered cacheable. If multiple headers are
+   * provided, only one needs to be present.
+   */
+  constructor(config = {}) {
+    if (process.env.NODE_ENV !== 'production') {
+      if (!(config.statuses || config.headers)) {
+        throw new WorkboxError('statuses-or-headers-required', {
+          moduleName: 'workbox-cacheable-response',
+          className: 'CacheableResponse',
+          funcName: 'constructor',
+        });
+      }
+
+      if (config.statuses) {
+        assert.isArray(config.statuses, {
+          moduleName: 'workbox-cacheable-response',
+          className: 'CacheableResponse',
+          funcName: 'constructor',
+          paramName: 'config.statuses',
+        });
+      }
+
+      if (config.headers) {
+        assert.isType(config.headers, 'object', {
+          moduleName: 'workbox-cacheable-response',
+          className: 'CacheableResponse',
+          funcName: 'constructor',
+          paramName: 'config.headers',
+        });
+      }
+    }
+
+    this._statuses = config.statuses;
+    this._headers = config.headers;
+  }
+
+  /**
+   * Checks a response to see whether it's cacheable or not, based on this
+   * object's configuration.
+   *
+   * @param {Response} response The response whose cacheability is being
+   * checked.
+   * @return {boolean} `true` if the `Response` is cacheable, and `false`
+   * otherwise.
+   */
+  isResponseCacheable(response) {
+    if (process.env.NODE_ENV !== 'production') {
+      assert.isInstance(response, Response, {
+        moduleName: 'workbox-cacheable-response',
+        className: 'CacheableResponse',
+        funcName: 'isResponseCacheable',
+        paramName: 'response',
+      });
+    }
+
+    let cacheable = true;
+
+    if (this._statuses) {
+      cacheable = this._statuses.includes(response.status);
+    }
+
+    if (this._headers && cacheable) {
+      cacheable = Object.keys(this._headers).some((headerName) => {
+        return response.headers.get(headerName) === this._headers[headerName];
+      });
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      if (!cacheable) {
+        logger.groupCollapsed(`The request for ` +
+          `'${getFriendlyURL(response.url)}' returned a response that does ` +
+          `not meet the criteria for being cached.`);
+
+        logger.groupCollapsed(`View response details here.`);
+        logger.unprefixed.log(response);
+        logger.groupEnd();
+
+        logger.groupCollapsed(`View cacheability criteria here.`);
+        logger.unprefixed.log(`Cacheable statuses: ` +
+          JSON.stringify(this._statuses));
+        logger.unprefixed.log(`Cacheable headers: ` +
+          JSON.stringify(this._headers));
+        logger.groupEnd();
+
+        logger.groupEnd();
+        logger.debug();
+      }
+    }
+
+    return cacheable;
+  }
+}
+
+export {CacheableResponse};

--- a/packages/workbox-cacheable-response/CacheableResponsePlugin.mjs
+++ b/packages/workbox-cacheable-response/CacheableResponsePlugin.mjs
@@ -1,0 +1,44 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import './_version.mjs';
+
+/**
+ * A class implementing the `cacheWillUpdate` lifecycle callback. This makes it
+ * easier to add in cacheability checks to requests made via Workbox's built-in
+ * strategies.
+ *
+ * @memberof workbox.cacheableResponse
+ */
+class CacheableResponsePlugin {
+  /**
+   * @param {CacheableResponse} cacheableResponse A configured
+   * `CacheableResponse` instance.
+   */
+  constructor(cacheableResponse) {
+    this._cacheableResponse = cacheableResponse;
+    this.cacheWillUpdate = this.cacheWillUpdate.bind(this);
+  }
+
+  /**
+   * @param {Object} options
+   * @param {Response} options.response
+   * @return {boolean}
+   * @private
+   */
+  cacheWillUpdate({response}) {
+    return this._cacheableResponse.isResponseCacheable(response);
+  }
+}
+
+export {CacheableResponsePlugin};

--- a/packages/workbox-cacheable-response/CacheableResponsePlugin.mjs
+++ b/packages/workbox-cacheable-response/CacheableResponsePlugin.mjs
@@ -11,6 +11,7 @@
  limitations under the License.
 */
 
+import {CacheableResponse} from './CacheableResponse.mjs';
 import './_version.mjs';
 
 /**
@@ -22,12 +23,21 @@ import './_version.mjs';
  */
 class CacheableResponsePlugin {
   /**
-   * @param {CacheableResponse} cacheableResponse A configured
-   * `CacheableResponse` instance.
+   * To construct a new CacheableResponsePlugin instance you must provide at
+   * least one of the `config` properties.
+   *
+   * If both `statuses` and `headers` are specified, then both conditions must
+   * be met for the `Response` to be considered cacheable.
+   *
+   * @param {Object} config
+   * @param {Array<number>} [config.statuses] One or more status codes that a
+   * `Response` can have and be considered cacheable.
+   * @param {Object<string,string>} [config.headers] A mapping of header names
+   * and expected values that a `Response` can have and be considered cacheable.
+   * If multiple headers are provided, only one needs to be present.
    */
-  constructor(cacheableResponse) {
-    this._cacheableResponse = cacheableResponse;
-    this.cacheWillUpdate = this.cacheWillUpdate.bind(this);
+  constructor(config = {}) {
+    this._cacheableResponse = new CacheableResponse(config);
   }
 
   /**

--- a/packages/workbox-cacheable-response/_public.mjs
+++ b/packages/workbox-cacheable-response/_public.mjs
@@ -1,0 +1,24 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import {CacheableResponse} from './CacheableResponse.mjs';
+import {CacheableResponsePlugin} from './CacheableResponsePlugin.mjs';
+import './_version.mjs';
+
+export {
+  CacheableResponse,
+  CacheableResponsePlugin,
+};

--- a/packages/workbox-cacheable-response/_version.mjs
+++ b/packages/workbox-cacheable-response/_version.mjs
@@ -1,0 +1,1 @@
+try{self.workbox.v['workbox:cacheable-response:3.0.0-alpha.24']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-cacheable-response/browser.mjs
+++ b/packages/workbox-cacheable-response/browser.mjs
@@ -1,0 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import './_version.mjs';
+
+export * from './_public.mjs';

--- a/packages/workbox-cacheable-response/index.mjs
+++ b/packages/workbox-cacheable-response/index.mjs
@@ -1,0 +1,23 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/**
+ * @namespace workbox.expiration
+ */
+
+import './_version.mjs';
+
+export * from './_public.mjs';

--- a/packages/workbox-cacheable-response/package.json
+++ b/packages/workbox-cacheable-response/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "workbox-cacheable-response",
+  "version": "3.0.0-alpha.24",
+  "license": "Apache-2.0",
+  "author": "Google's Web DevRel Team",
+  "description": "This library takes a Response object and determines whether it's cacheable based on a specific configuration.",
+  "repository": "googlechrome/workbox",
+  "bugs": "https://github.com/googlechrome/workbox/issues",
+  "homepage": "https://github.com/GoogleChrome/workbox",
+  "keywords": [
+    "workbox",
+    "workboxjs",
+    "service worker",
+    "sw"
+  ],
+  "scripts": {
+    "build": "gulp build-packages --package workbox-cacheable-response",
+    "version": "npm run build",
+    "prepare": "npm run build"
+  },
+  "workbox": {
+    "browserNamespace": "workbox.cacheableResponse",
+    "packageType": "browser"
+  },
+  "main": "build/workbox-cacheable-response.prod.js",
+  "module": "index.mjs",
+  "dependencies": {
+    "workbox-core": "^3.0.0-alpha.24"
+  }
+}

--- a/packages/workbox-core/models/messages/messages.mjs
+++ b/packages/workbox-core/models/messages/messages.mjs
@@ -59,7 +59,7 @@ export default {
     }
     return `The parameter '${paramName}' passed into ` +
       `'${moduleName}.${className}.${funcName}()' must be an instance of ` +
-      `class ${expectedClass}.`;
+      `class ${expectedClass.name}.`;
   },
 
   'missing-a-method': ({expectedMethod, paramName, moduleName, className,
@@ -155,6 +155,11 @@ export default {
 
   'max-entries-or-age-required': ({moduleName, className, funcName}) => {
     return `You must define either config.maxEntries or config.maxAgeSeconds` +
+      `in ${moduleName}.${className}.${funcName}`;
+  },
+
+  'statuses-or-headers-required': ({moduleName, className, funcName}) => {
+    return `You must define either config.statuses or config.headers` +
       `in ${moduleName}.${className}.${funcName}`;
   },
 

--- a/packages/workbox-strategies/package.json
+++ b/packages/workbox-strategies/package.json
@@ -28,6 +28,7 @@
   "module": "index.mjs",
   "dependencies": {
     "workbox-cache-expiration": "^3.0.0-alpha.24",
+    "workbox-cacheable-response": "^3.0.0-alpha.24",
     "workbox-core": "^3.0.0-alpha.24"
   }
 }

--- a/packages/workbox-strategies/utils/pluginBuilder.mjs
+++ b/packages/workbox-strategies/utils/pluginBuilder.mjs
@@ -16,6 +16,8 @@
 import {logger} from 'workbox-core/_private/logger.mjs';
 import {CacheExpirationPlugin} from
   'workbox-cache-expiration/CacheExpirationPlugin.mjs';
+import {CacheableResponsePlugin} from
+  'workbox-cacheable-response/CacheableResponsePlugin.mjs';
 import '../_version.mjs';
 
 const pluginBuilder = (options) => {
@@ -25,8 +27,8 @@ const pluginBuilder = (options) => {
 
   const pluginParamsToClass = {
     cacheExpiration: CacheExpirationPlugin,
+    cacheableResponse: CacheableResponsePlugin,
     // TODO: Add support for 'broadcastCacheUpdate': BroadcastCacheUpdatePlugin,
-    // TODO: Add support for 'cacheableResponse': CacheableResponsePlugin,
   };
 
   for (const [pluginId, config] of Object.entries(options)) {

--- a/test/workbox-build/node/lib/runtime-caching-converter.js
+++ b/test/workbox-build/node/lib/runtime-caching-converter.js
@@ -57,6 +57,7 @@ function validate(runtimeCachingOptions, convertedOptions) {
       if (runtimeCachingOption.options.networkTimeoutSeconds) {
         expectedOptions.networkTimeoutSeconds = runtimeCachingOption.options.networkTimeoutSeconds;
       }
+
       if (runtimeCachingOption.options.cache) {
         if (runtimeCachingOption.options.cache.name) {
           expectedOptions.cacheName = runtimeCachingOption.options.cache.name;
@@ -65,6 +66,10 @@ function validate(runtimeCachingOptions, convertedOptions) {
           expectedOptions.cacheExpiration = Object.assign({}, runtimeCachingOption.options.cache);
           delete expectedOptions.cacheExpiration.name;
         }
+      }
+
+      if (runtimeCachingOption.options.cacheableResponse) {
+        expectedOptions.cacheableResponse = runtimeCachingOption.options.cacheableResponse;
       }
     }
 
@@ -128,6 +133,9 @@ describe(`[workbox-build] src/lib/utils/runtime-caching-converter.js`, function(
       options: {
         cache: {
           maxEntries: 10,
+        },
+        cacheableResponse: {
+          statuses: [0, 200],
         },
       },
     }];

--- a/test/workbox-cacheable-response/node/CacheableResponse.mjs
+++ b/test/workbox-cacheable-response/node/CacheableResponse.mjs
@@ -84,8 +84,6 @@ describe(`[workbox-cacheable-response] CacheableResponse`, function() {
     it(`should return true when one of the statuses match the response`, function() {
       const cacheableResponse = new CacheableResponse({statuses: VALID_STATUSES});
       const response = new Response('', {status: VALID_STATUS});
-      // TODO: Remove after there's a proper Response mock.
-      response.headers = new Map();
 
       expect(cacheableResponse.isResponseCacheable(response)).to.be.true;
     });
@@ -93,8 +91,6 @@ describe(`[workbox-cacheable-response] CacheableResponse`, function() {
     it(`should return false when none of the statuses match the response`, function() {
       const cacheableResponse = new CacheableResponse({statuses: VALID_STATUSES});
       const response = new Response('', {status: INVALID_STATUS});
-      // TODO: Remove after there's a proper Response mock.
-      response.headers = new Map();
 
       expect(cacheableResponse.isResponseCacheable(response)).to.be.false;
     });
@@ -102,8 +98,6 @@ describe(`[workbox-cacheable-response] CacheableResponse`, function() {
     it(`should return true when one of the headers match the response`, function() {
       const cacheableResponse = new CacheableResponse({headers: VALID_HEADERS});
       const response = new Response('', {headers: VALID_HEADERS});
-      // TODO: Remove after there's a proper Response mock.
-      response.headers = new Map(Object.entries(response.headers));
 
       expect(cacheableResponse.isResponseCacheable(response)).to.be.true;
     });
@@ -111,8 +105,6 @@ describe(`[workbox-cacheable-response] CacheableResponse`, function() {
     it(`should return false when none of the headers match the response`, function() {
       const cacheableResponse = new CacheableResponse({headers: VALID_HEADERS});
       const response = new Response('');
-      // TODO: Remove after there's a proper Response mock.
-      response.headers = new Map();
 
       expect(cacheableResponse.isResponseCacheable(response)).to.be.false;
     });
@@ -123,8 +115,6 @@ describe(`[workbox-cacheable-response] CacheableResponse`, function() {
         headers: VALID_HEADERS,
       });
       const response = new Response('', {status: VALID_STATUS});
-      // TODO: Remove after there's a proper Response mock.
-      response.headers = new Map();
 
       expect(cacheableResponse.isResponseCacheable(response)).to.be.false;
     });
@@ -138,8 +128,6 @@ describe(`[workbox-cacheable-response] CacheableResponse`, function() {
         headers: VALID_HEADERS,
         status: INVALID_STATUS,
       });
-      // TODO: Remove after there's a proper Response mock.
-      response.headers = new Map(Object.entries(response.headers));
 
       expect(cacheableResponse.isResponseCacheable(response)).to.be.false;
     });
@@ -153,8 +141,6 @@ describe(`[workbox-cacheable-response] CacheableResponse`, function() {
         headers: VALID_HEADERS,
         status: VALID_STATUS,
       });
-      // TODO: Remove after there's a proper Response mock.
-      response.headers = new Map(Object.entries(response.headers));
 
       expect(cacheableResponse.isResponseCacheable(response)).to.be.true;
     });

--- a/test/workbox-cacheable-response/node/CacheableResponse.mjs
+++ b/test/workbox-cacheable-response/node/CacheableResponse.mjs
@@ -1,0 +1,162 @@
+import {expect} from 'chai';
+
+import {CacheableResponse} from '../../../packages/workbox-cacheable-response/CacheableResponse.mjs';
+import expectError from '../../../infra/testing/expectError';
+import {devOnly} from '../../../infra/testing/env-it';
+
+describe(`[workbox-cacheable-response] CacheableResponse`, function() {
+  const VALID_STATUS = 418;
+  const INVALID_STATUS = 500;
+  const VALID_STATUSES = [VALID_STATUS];
+  const VALID_HEADERS = {
+    'x-test': 'true',
+  };
+
+  describe(`constructor`, function() {
+    devOnly.it(`should throw with no config`, async function() {
+      await expectError(() => {
+        new CacheableResponse();
+      }, 'statuses-or-headers-required', (err) => {
+        expect(err.details).to.have.property('moduleName').that.eql('workbox-cacheable-response');
+        expect(err.details).to.have.property('className').that.eql('CacheableResponse');
+        expect(err.details).to.have.property('funcName').that.eql('constructor');
+      });
+    });
+
+    devOnly.it(`should throw with bad config.statuses`, async function() {
+      await expectError(() => {
+        new CacheableResponse({statuses: 'bad input'});
+      }, 'not-an-array', (err) => {
+        expect(err.details).to.have.property('moduleName').that.eql('workbox-cacheable-response');
+        expect(err.details).to.have.property('className').that.eql('CacheableResponse');
+        expect(err.details).to.have.property('funcName').that.eql('constructor');
+        expect(err.details).to.have.property('paramName').that.eql('config.statuses');
+      });
+    });
+
+    devOnly.it(`should throw with bad config.headers`, async function() {
+      await expectError(() => {
+        new CacheableResponse({headers: 'bad input'});
+      }, 'incorrect-type', (err) => {
+        expect(err.details).to.have.property('moduleName').that.eql('workbox-cacheable-response');
+        expect(err.details).to.have.property('className').that.eql('CacheableResponse');
+        expect(err.details).to.have.property('funcName').that.eql('constructor');
+        expect(err.details).to.have.property('paramName').that.eql('config.headers');
+      });
+    });
+
+    it(`should be able to construct with config.statuses`, function() {
+      const cacheableResponse = new CacheableResponse({statuses: VALID_STATUSES});
+
+      expect(cacheableResponse._statuses).to.eql(VALID_STATUSES);
+    });
+
+    it(`should be able to construct with config.headers`, function() {
+      const cacheableResponse = new CacheableResponse({headers: VALID_HEADERS});
+
+      expect(cacheableResponse._headers).to.eql(VALID_HEADERS);
+    });
+
+    it(`should be able to construct with config.statuses and config.headers`, function() {
+      const cacheableResponse = new CacheableResponse({
+        statuses: VALID_STATUSES,
+        headers: VALID_HEADERS,
+      });
+
+      expect(cacheableResponse._statuses).to.eql(VALID_STATUSES);
+      expect(cacheableResponse._headers).to.eql(VALID_HEADERS);
+    });
+  });
+
+  describe(`isResponseCacheable`, function() {
+    devOnly.it(`should throw when passed bad input`, async function() {
+      const cacheableResponse = new CacheableResponse({statuses: VALID_STATUSES});
+      await expectError(() => {
+        cacheableResponse.isResponseCacheable(null);
+      }, 'incorrect-class', (err) => {
+        expect(err.details).to.have.property('moduleName').that.eql('workbox-cacheable-response');
+        expect(err.details).to.have.property('className').that.eql('CacheableResponse');
+        expect(err.details).to.have.property('funcName').that.eql('isResponseCacheable');
+        expect(err.details).to.have.property('paramName').that.eql('response');
+      });
+    });
+
+    it(`should return true when one of the statuses match the response`, function() {
+      const cacheableResponse = new CacheableResponse({statuses: VALID_STATUSES});
+      const response = new Response('', {status: VALID_STATUS});
+      // TODO: Remove after there's a proper Response mock.
+      response.headers = new Map();
+
+      expect(cacheableResponse.isResponseCacheable(response)).to.be.true;
+    });
+
+    it(`should return false when none of the statuses match the response`, function() {
+      const cacheableResponse = new CacheableResponse({statuses: VALID_STATUSES});
+      const response = new Response('', {status: INVALID_STATUS});
+      // TODO: Remove after there's a proper Response mock.
+      response.headers = new Map();
+
+      expect(cacheableResponse.isResponseCacheable(response)).to.be.false;
+    });
+
+    it(`should return true when one of the headers match the response`, function() {
+      const cacheableResponse = new CacheableResponse({headers: VALID_HEADERS});
+      const response = new Response('', {headers: VALID_HEADERS});
+      // TODO: Remove after there's a proper Response mock.
+      response.headers = new Map(Object.entries(response.headers));
+
+      expect(cacheableResponse.isResponseCacheable(response)).to.be.true;
+    });
+
+    it(`should return false when none of the headers match the response`, function() {
+      const cacheableResponse = new CacheableResponse({headers: VALID_HEADERS});
+      const response = new Response('');
+      // TODO: Remove after there's a proper Response mock.
+      response.headers = new Map();
+
+      expect(cacheableResponse.isResponseCacheable(response)).to.be.false;
+    });
+
+    it(`should return false when one of the statuses match the response, but none of the headers match`, function() {
+      const cacheableResponse = new CacheableResponse({
+        statuses: VALID_STATUSES,
+        headers: VALID_HEADERS,
+      });
+      const response = new Response('', {status: VALID_STATUS});
+      // TODO: Remove after there's a proper Response mock.
+      response.headers = new Map();
+
+      expect(cacheableResponse.isResponseCacheable(response)).to.be.false;
+    });
+
+    it(`should return false when one of the headers match the response, but none of the statuses match`, function() {
+      const cacheableResponse = new CacheableResponse({
+        statuses: VALID_STATUSES,
+        headers: VALID_HEADERS,
+      });
+      const response = new Response('', {
+        headers: VALID_HEADERS,
+        status: INVALID_STATUS,
+      });
+      // TODO: Remove after there's a proper Response mock.
+      response.headers = new Map(Object.entries(response.headers));
+
+      expect(cacheableResponse.isResponseCacheable(response)).to.be.false;
+    });
+
+    it(`should return true when both the headers and statuses match the response`, function() {
+      const cacheableResponse = new CacheableResponse({
+        statuses: VALID_STATUSES,
+        headers: VALID_HEADERS,
+      });
+      const response = new Response('', {
+        headers: VALID_HEADERS,
+        status: VALID_STATUS,
+      });
+      // TODO: Remove after there's a proper Response mock.
+      response.headers = new Map(Object.entries(response.headers));
+
+      expect(cacheableResponse.isResponseCacheable(response)).to.be.true;
+    });
+  });
+});

--- a/test/workbox-cacheable-response/node/CacheableResponsePlugin.mjs
+++ b/test/workbox-cacheable-response/node/CacheableResponsePlugin.mjs
@@ -1,0 +1,27 @@
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import {CacheableResponse} from '../../../packages/workbox-cacheable-response/CacheableResponse.mjs';
+import {CacheableResponsePlugin} from '../../../packages/workbox-cacheable-response/CacheableResponsePlugin.mjs';
+
+describe(`[workbox-cacheable-response] CacheableResponsePlugin`, function() {
+  describe(`constructor`, function() {
+    it(`should store a CacheableResponse instance`, function() {
+      const cacheableResponse = new CacheableResponse({statuses: [200]});
+      const cacheableResponsePlugin = new CacheableResponsePlugin(cacheableResponse);
+      expect(cacheableResponsePlugin._cacheableResponse).to.equal(cacheableResponse);
+    });
+
+    it(`should expose cacheWillUpdate, which calls cacheableResponse.isResponseCacheable()`, function() {
+      const cacheableResponse = new CacheableResponse({statuses: [200]});
+      const isResponseCacheableSpy = sinon.spy(cacheableResponse, 'isResponseCacheable');
+
+      const cacheableResponsePlugin = new CacheableResponsePlugin(cacheableResponse);
+      const response = new Response('');
+      cacheableResponsePlugin.cacheWillUpdate({response});
+
+      expect(isResponseCacheableSpy.calledOnce).to.be.true;
+      expect(isResponseCacheableSpy.calledWithExactly(response)).to.be.true;
+    });
+  });
+});

--- a/test/workbox-cacheable-response/node/CacheableResponsePlugin.mjs
+++ b/test/workbox-cacheable-response/node/CacheableResponsePlugin.mjs
@@ -6,17 +6,17 @@ import {CacheableResponsePlugin} from '../../../packages/workbox-cacheable-respo
 
 describe(`[workbox-cacheable-response] CacheableResponsePlugin`, function() {
   describe(`constructor`, function() {
-    it(`should store a CacheableResponse instance`, function() {
-      const cacheableResponse = new CacheableResponse({statuses: [200]});
-      const cacheableResponsePlugin = new CacheableResponsePlugin(cacheableResponse);
-      expect(cacheableResponsePlugin._cacheableResponse).to.equal(cacheableResponse);
+    const STATUSES = [200];
+
+    it(`should construct a properly-configured internal CacheableResponse instance`, function() {
+      const cacheableResponsePlugin = new CacheableResponsePlugin({statuses: STATUSES});
+      expect(cacheableResponsePlugin._cacheableResponse).to.be.instanceOf(CacheableResponse);
+      expect(cacheableResponsePlugin._cacheableResponse._statuses).to.eql(STATUSES);
     });
 
     it(`should expose cacheWillUpdate, which calls cacheableResponse.isResponseCacheable()`, function() {
-      const cacheableResponse = new CacheableResponse({statuses: [200]});
-      const isResponseCacheableSpy = sinon.spy(cacheableResponse, 'isResponseCacheable');
-
-      const cacheableResponsePlugin = new CacheableResponsePlugin(cacheableResponse);
+      const cacheableResponsePlugin = new CacheableResponsePlugin({statuses: STATUSES});
+      const isResponseCacheableSpy = sinon.spy(cacheableResponsePlugin._cacheableResponse, 'isResponseCacheable');
       const response = new Response('');
       cacheableResponsePlugin.cacheWillUpdate({response});
 

--- a/test/workbox-cacheable-response/node/index.mjs
+++ b/test/workbox-cacheable-response/node/index.mjs
@@ -1,0 +1,13 @@
+import {expect} from 'chai';
+
+import * as cacheableResponse from '../../../packages/workbox-cacheable-response/index.mjs';
+
+describe(`[workbox-cacheable-response] exports`, function() {
+  const expectedExports = ['CacheableResponse', 'CacheableResponsePlugin'];
+
+  for (const expectedExport of expectedExports) {
+    it(`should expose a ${expectedExport} property`, function() {
+      expect(cacheableResponse).to.have.property(expectedExport);
+    });
+  }
+});


### PR DESCRIPTION
R: @philipwalton @addyosmani @gauntface

This re-adds `workbox-cacheable-response` for v3.

An open question I had is whether [`cacheOkAndOpaquePlugin.mjs`](https://github.com/GoogleChrome/workbox/blob/v3/packages/workbox-strategies/plugins/cacheOkAndOpaquePlugin.mjs) should stick around, or whether it should be replaced by an instance of `CacheableResponsePlugin`.