### PR TITLE
More compliant Response mock

### DIFF
--- a/infra/testing/sw-env-mocks/Headers.js
+++ b/infra/testing/sw-env-mocks/Headers.js
@@ -21,6 +21,10 @@ class Headers {
     this.obj = obj;
   }
 
+  has(key) {
+    return (key in this.obj);
+  }
+
   get(key) {
     return this.obj[key];
   }

--- a/infra/testing/sw-env-mocks/Response.js
+++ b/infra/testing/sw-env-mocks/Response.js
@@ -35,7 +35,7 @@ class Response {
       throw new TypeError(`Failed to execute 'clone' on 'Response': ` +
         `Response body is already used`);
     } else {
-      return new Request(this.url, Object.assign({body: this._body}, this));
+      return new Response(this._body, this);
     }
   }
 

--- a/infra/testing/sw-env-mocks/Response.js
+++ b/infra/testing/sw-env-mocks/Response.js
@@ -1,0 +1,62 @@
+/*
+ Copyright 2017 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+const Blob = require('./Blob');
+const Headers = require('./Headers');
+
+// Stub missing/broken Response API methods in `service-worker-mock`.
+// https://fetch.spec.whatwg.org/#response-class
+class Response {
+  constructor(body, options = {}) {
+    this._body = new Blob([body]);
+    this.status = typeof options.status === 'number' ? options.status : 200;
+    this.ok = this.status >= 200 && this.status < 300;
+    this.statusText = options.statusText || 'OK';
+    this.headers = new Headers(options.headers);
+    this.type = this.status === 0 ? 'opaque' : 'basic';
+    this.redirected = false;
+    this.url = 'http://example.com/asset';
+  }
+
+  clone() {
+    if (this.bodyUsed) {
+      throw new TypeError(`Failed to execute 'clone' on 'Response': ` +
+        `Response body is already used`);
+    } else {
+      return new Request(this.url, Object.assign({body: this._body}, this));
+    }
+  }
+
+  async blob() {
+    if (this.bodyUsed) {
+      throw new TypeError('Already read');
+    } else {
+      this.bodyUsed = true;
+      return this._body;
+    }
+  }
+
+  async text() {
+    if (this.bodyUsed) {
+      throw new TypeError('Already read');
+    } else {
+      this.bodyUsed = true;
+      // Limitionation: this assumes the stored Blob is text-based.
+      return this._body._text;
+    }
+  }
+}
+
+module.exports = Response;

--- a/infra/testing/sw-env.js
+++ b/infra/testing/sw-env.js
@@ -29,6 +29,7 @@ const FetchEvent = require('./sw-env-mocks/FetchEvent');
 const FileReader = require('./sw-env-mocks/FileReader');
 const Headers = require('./sw-env-mocks/Headers');
 const Request = require('./sw-env-mocks/Request');
+const Response = require('./sw-env-mocks/Response');
 const SyncEvent = require('./sw-env-mocks/SyncEvent');
 const SyncManager = require('./sw-env-mocks/SyncManager');
 
@@ -56,6 +57,7 @@ global.importScripts = () => {};
 global.location = new URL('https://example.com');
 global.registration.sync = new SyncManager();
 global.Request = Request;
+global.Response = Response;
 global.SyncEvent = SyncEvent;
 global.URLSearchParams = URLSearchParams;
 

--- a/packages/workbox-cache-expiration/CacheExpirationPlugin.mjs
+++ b/packages/workbox-cache-expiration/CacheExpirationPlugin.mjs
@@ -159,7 +159,7 @@ class CacheExpirationPlugin {
    * @private
    */
   _getDateHeaderTimestamp(cachedResponse) {
-    const dateHeader = cachedResponse.headers['date'];
+    const dateHeader = cachedResponse.headers.get('date');
     const parsedDate = new Date(dateHeader);
     const headerTime = parsedDate.getTime();
 

--- a/test/workbox-precaching/node/utils/test-cleanRedirect.mjs
+++ b/test/workbox-precaching/node/utils/test-cleanRedirect.mjs
@@ -14,7 +14,7 @@ describe(`[workbox-precaching] cleanRedirect()`, function() {
     sandbox.restore();
   });
 
-  it(`should use blob where there is no body in the reponse`, async function() {
+  it(`should use blob() when there is no 'body' stream in the response`, async function() {
     const response = new Response('Original Response');
     sandbox.stub(response, 'clone').callsFake(() => {
       const newResponse = new Response('Repeated Response');
@@ -26,6 +26,7 @@ describe(`[workbox-precaching] cleanRedirect()`, function() {
     });
 
     const cleanedResponse = await cleanRedirect(response);
-    expect(cleanedResponse.body).to.equal('Blob Body');
+    const cleanedResponseBody = await cleanedResponse.text();
+    expect(cleanedResponseBody).to.equal('Blob Body');
   });
 });


### PR DESCRIPTION
R: @philipwalton @addyosmani @gauntface

This brings the `Response` mock into closer compliance to the spec than what `service-worker-mocks` offers.

It also fixes some unit tests that relied on the old, incorrectly mocked behavior.

Once this is merged I can get rid of some [hacks](https://github.com/GoogleChrome/workbox/pull/1057#pullrequestreview-76995397) in the `workbox-cacheable-response` tests.
