### PR TITLE
Reset for v3 alpha

### DIFF
--- a/demos/functions/cdn-details.json
+++ b/demos/functions/cdn-details.json
@@ -1,1 +1,1 @@
-{"latestUrl":"https://storage.googleapis.com/workbox-cdn/releases/3.0.0-alpha.23"}
+{"latestUrl":"https://storage.googleapis.com/workbox-cdn/releases/3.0.0-alpha"}

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.0-alpha.24"
+  "version": "3.0.0-alpha"
 }

--- a/packages/workbox-background-sync/_version.mjs
+++ b/packages/workbox-background-sync/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:background-sync:3.0.0-alpha.24']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:background-sync:3.0.0-alpha']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-background-sync/package.json
+++ b/packages/workbox-background-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-background-sync",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "license": "Apache-2.0",
   "author": "Google's Web DevRel Team",
   "description": "Queues failed requests and uses the Background Sync API to replay them when the network is available",
@@ -27,6 +27,6 @@
   "main": "build/workbox-background-sync.prod.js",
   "module": "index.mjs",
   "dependencies": {
-    "workbox-core": "^3.0.0-alpha.24"
+    "workbox-core": "^3.0.0-alpha"
   }
 }

--- a/packages/workbox-broadcast-cache-update/_version.mjs
+++ b/packages/workbox-broadcast-cache-update/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:broadcast-cache-update:3.0.0-alpha.24']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:broadcast-cache-update:3.0.0-alpha']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-broadcast-cache-update/package.json
+++ b/packages/workbox-broadcast-cache-update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-broadcast-cache-update",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "license": "Apache-2.0",
   "author": "Google's Web DevRel Team",
   "description": "A service worker helper library that uses the Broadcast Channel API to announce when a cached response has updated",
@@ -25,6 +25,6 @@
   "main": "build/workbox-broadcast-cache-update.prod.js",
   "module": "index.mjs",
   "dependencies": {
-    "workbox-core": "^3.0.0-alpha.24"
+    "workbox-core": "^3.0.0-alpha"
   }
 }

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-build",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "description": "A module that integrates into your build process, helping you generate a manifest of local files that workbox-sw should precache.",
   "keywords": [
     "workbox",
@@ -26,12 +26,12 @@
     "glob": "^7.1.2",
     "joi": "^11.1.1",
     "lodash.template": "^4.4.0",
-    "workbox-cache-expiration": "^3.0.0-alpha.24",
-    "workbox-core": "^3.0.0-alpha.24",
-    "workbox-precaching": "^3.0.0-alpha.24",
-    "workbox-routing": "^3.0.0-alpha.24",
-    "workbox-strategies": "^3.0.0-alpha.24",
-    "workbox-sw": "^3.0.0-alpha.24"
+    "workbox-cache-expiration": "^3.0.0-alpha",
+    "workbox-core": "^3.0.0-alpha",
+    "workbox-precaching": "^3.0.0-alpha",
+    "workbox-routing": "^3.0.0-alpha",
+    "workbox-strategies": "^3.0.0-alpha",
+    "workbox-sw": "^3.0.0-alpha"
   },
   "main": "build/index.js",
   "scripts": {

--- a/packages/workbox-build/src/cdn-details.json
+++ b/packages/workbox-build/src/cdn-details.json
@@ -2,5 +2,5 @@
   "origin": "https://storage.googleapis.com",
   "bucketName": "workbox-cdn",
   "releasesDir": "releases",
-  "latestVersion": "3.0.0-alpha.24"
+  "latestVersion": "3.0.0-alpha"
 }

--- a/packages/workbox-cache-expiration/_version.mjs
+++ b/packages/workbox-cache-expiration/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:cache-expiration:3.0.0-alpha.24']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:cache-expiration:3.0.0-alpha']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-cache-expiration/package.json
+++ b/packages/workbox-cache-expiration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-cache-expiration",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "license": "Apache-2.0",
   "author": "Google's Web DevRel Team",
   "description": "A service worker helper library that expires cached responses based on age or maximum number of entries.",
@@ -25,6 +25,6 @@
   "main": "build/workbox-cache-expiration.prod.js",
   "module": "index.mjs",
   "dependencies": {
-    "workbox-core": "^3.0.0-alpha.24"
+    "workbox-core": "^3.0.0-alpha"
   }
 }

--- a/packages/workbox-cacheable-response/_version.mjs
+++ b/packages/workbox-cacheable-response/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:cacheable-response:3.0.0-alpha.24']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:cacheable-response:3.0.0-alpha']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-cacheable-response/package.json
+++ b/packages/workbox-cacheable-response/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-cacheable-response",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "license": "Apache-2.0",
   "author": "Google's Web DevRel Team",
   "description": "This library takes a Response object and determines whether it's cacheable based on a specific configuration.",
@@ -25,6 +25,6 @@
   "main": "build/workbox-cacheable-response.prod.js",
   "module": "index.mjs",
   "dependencies": {
-    "workbox-core": "^3.0.0-alpha.24"
+    "workbox-core": "^3.0.0-alpha"
   }
 }

--- a/packages/workbox-cli/package.json
+++ b/packages/workbox-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-cli",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "description": "workbox-cli is the command line interface for Workbox.",
   "keywords": [
     "workbox",
@@ -38,7 +38,7 @@
     "ora": "^1.3.0",
     "pretty-bytes": "^4.0.2",
     "update-notifier": "^2.3.0",
-    "workbox-build": "^3.0.0-alpha.24"
+    "workbox-build": "^3.0.0-alpha"
   },
   "workbox": {
     "packageType": "node"

--- a/packages/workbox-core/_version.mjs
+++ b/packages/workbox-core/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:core:3.0.0-alpha.24']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:core:3.0.0-alpha']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-core/package.json
+++ b/packages/workbox-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-core",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "license": "Apache-2.0",
   "author": "Google's Web DevRel Team",
   "description": "This module is used by a number of the other workboxjs.org modules to share common code.",

--- a/packages/workbox-google-analytics/_version.mjs
+++ b/packages/workbox-google-analytics/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:google-analytics:3.0.0-alpha.24']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:google-analytics:3.0.0-alpha']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-google-analytics/package.json
+++ b/packages/workbox-google-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-google-analytics",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "license": "Apache-2.0",
   "author": "Google's Web DevRel Team",
   "description": "Queues failed requests and uses the Background Sync API to replay them when the network is available",
@@ -28,9 +28,9 @@
   "main": "build/workbox-google-analytics.prod.js",
   "module": "index.mjs",
   "dependencies": {
-    "workbox-background-sync": "^3.0.0-alpha.24",
-    "workbox-core": "^3.0.0-alpha.24",
-    "workbox-routing": "^3.0.0-alpha.24",
-    "workbox-strategies": "^3.0.0-alpha.24"
+    "workbox-background-sync": "^3.0.0-alpha",
+    "workbox-core": "^3.0.0-alpha",
+    "workbox-routing": "^3.0.0-alpha",
+    "workbox-strategies": "^3.0.0-alpha"
   }
 }

--- a/packages/workbox-precaching/_version.mjs
+++ b/packages/workbox-precaching/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:precaching:3.0.0-alpha.24']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:precaching:3.0.0-alpha']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-precaching/package.json
+++ b/packages/workbox-precaching/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-precaching",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "license": "Apache-2.0",
   "author": "Google's Web DevRel Team",
   "description": "This module efficiently precaches assets.",
@@ -25,6 +25,6 @@
   "main": "build/workbox-precaching.prod.js",
   "module": "index.mjs",
   "dependencies": {
-    "workbox-core": "^3.0.0-alpha.24"
+    "workbox-core": "^3.0.0-alpha"
   }
 }

--- a/packages/workbox-routing/_version.mjs
+++ b/packages/workbox-routing/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:routing:3.0.0-alpha.24']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:routing:3.0.0-alpha']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-routing/package.json
+++ b/packages/workbox-routing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-routing",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "license": "Apache-2.0",
   "author": "Google's Web DevRel Team",
   "description": "A service worker helper library to route request URLs to handlers.",
@@ -27,6 +27,6 @@
   "main": "build/workbox-routing.prod.js",
   "module": "index.mjs",
   "dependencies": {
-    "workbox-core": "^3.0.0-alpha.24"
+    "workbox-core": "^3.0.0-alpha"
   }
 }

--- a/packages/workbox-strategies/_version.mjs
+++ b/packages/workbox-strategies/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:strategies:3.0.0-alpha.24']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:strategies:3.0.0-alpha']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-strategies/package.json
+++ b/packages/workbox-strategies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-strategies",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "license": "Apache-2.0",
   "author": "Google's Web DevRel Team",
   "description": "A service worker helper library implementing common caching strategies.",
@@ -27,8 +27,8 @@
   "main": "build/workbox-strategies.prod.js",
   "module": "index.mjs",
   "dependencies": {
-    "workbox-cache-expiration": "^3.0.0-alpha.24",
-    "workbox-cacheable-response": "^3.0.0-alpha.24",
-    "workbox-core": "^3.0.0-alpha.24"
+    "workbox-cache-expiration": "^3.0.0-alpha",
+    "workbox-cacheable-response": "^3.0.0-alpha",
+    "workbox-core": "^3.0.0-alpha"
   }
 }

--- a/packages/workbox-sw/_version.mjs
+++ b/packages/workbox-sw/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:sw:3.0.0-alpha.24']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:sw:3.0.0-alpha']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-sw/package.json
+++ b/packages/workbox-sw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-sw",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "license": "Apache-2.0",
   "author": "Google's Web DevRel Team",
   "description": "This module makes it easy to get started with the Workbox service worker libraries.",

--- a/packages/workbox-webpack-plugin/package.json
+++ b/packages/workbox-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-webpack-plugin",
-  "version": "3.0.0-alpha.24",
+  "version": "3.0.0-alpha",
   "description": "A plugin for your Webpack build process, helping you generate a manifest of local files that workbox-sw should precache.",
   "keywords": [
     "workbox",
@@ -28,7 +28,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "workbox-build": "^3.0.0-alpha.24"
+    "workbox-build": "^3.0.0-alpha"
   },
   "author": "Will Farley <a.will.farley@gmail.com> (http://www.willfarley.org/)",
   "license": "Apache-2.0",


### PR DESCRIPTION
R: @jeffposnick @addyosmani @philipwalton 

We haven't actually been publishing the v3 stuff to git or NPM, just to the CDN.

I'd like to reset the version numbers so the release on NPM and docs etc are 3.0.0-alpha.0 or .1.

