### PR TITLE
Refactor workbox-build defaults, and update the injection-point-not-found message

### DIFF
--- a/packages/workbox-build/src/entry-points/inject-manifest.js
+++ b/packages/workbox-build/src/entry-points/inject-manifest.js
@@ -18,6 +18,7 @@ const assert = require('assert');
 const fse = require('fs-extra');
 const path = require('path');
 
+const defaults = require('./options/defaults');
 const errors = require('../lib/errors');
 const getFileManifestEntries = require('../lib/get-file-manifest-entries');
 const injectManifestSchema = require('./options/inject-manifest-schema');
@@ -60,7 +61,13 @@ async function injectManifest(input) {
 
   const injectionResults = swFileContents.match(globalRegexp);
   assert(injectionResults, errors['injection-point-not-found'] +
-    ` ${options.injectionPointRegexp}`);
+    // Customize the error message when this happens:
+    // - If the default RegExp is used, then include the expected string that
+    //   matches as a hint to the developer.
+    // - If a custom RegExp is used, then just include the raw RegExp.
+    (options.injectionPointRegexp === defaults.injectionPointRegexp ?
+      'workbox.precaching.precacheAndRoute([])' :
+      options.injectionPointRegexp));
   assert(injectionResults.length === 1, errors['multiple-injection-points'] +
     ` ${options.injectionPointRegexp}`);
 

--- a/packages/workbox-build/src/entry-points/options/base-schema.js
+++ b/packages/workbox-build/src/entry-points/options/base-schema.js
@@ -16,17 +16,16 @@
 
 const joi = require('joi');
 
+const defaults = require('./defaults');
+
 // Define some common constrains used by all methods.
 module.exports = joi.object().keys({
   dontCacheBustUrlsMatching: joi.object().type(RegExp),
-  globIgnores: joi.array().items(joi.string()).default([
-    'node_modules/**/*',
-  ]),
-  globPatterns: joi.array().items(joi.string()).default([
-    '**/*.{js,css,html}',
-  ]),
+  globIgnores: joi.array().items(joi.string()).default(defaults.globIgnores),
+  globPatterns: joi.array().items(joi.string()).default(defaults.globPatterns),
   manifestTransforms: joi.array().items(joi.func().arity(1)),
-  maximumFileSizeToCacheInBytes: joi.number().min(1).default(2 * 1024 * 1024),
+  maximumFileSizeToCacheInBytes: joi.number().min(1)
+    .default(defaults.maximumFileSizeToCacheInBytes),
   modifyUrlPrefix: joi.object(),
   // templatedUrls is an object where any property name is valid, and the values
   // can be either a string or an array of strings.

--- a/packages/workbox-build/src/entry-points/options/common-generate-schema.js
+++ b/packages/workbox-build/src/entry-points/options/common-generate-schema.js
@@ -17,14 +17,15 @@
 const joi = require('joi');
 
 const baseSchema = require('./base-schema');
+const defaults = require('./defaults');
 
 // Add some constraints that apply to both generateSW and generateSWString.
 module.exports = baseSchema.keys({
   cacheId: joi.string(),
-  clientsClaim: joi.boolean().default(false),
+  clientsClaim: joi.boolean().default(defaults.clientsClaim),
   directoryIndex: joi.string(),
   ignoreUrlParametersMatching: joi.array().items(joi.object().type(RegExp)),
-  navigateFallback: joi.string().default(false),
+  navigateFallback: joi.string().default(defaults.navigateFallback),
   navigateFallbackBlacklist: joi.array().items(joi.object().type(RegExp)),
   navigateFallbackWhitelist: joi.array().items(joi.object().type(RegExp)),
   runtimeCaching: joi.array().items(joi.object().keys({
@@ -49,5 +50,5 @@ module.exports = baseSchema.keys({
       }).or('statuses', 'headers'),
     }),
   }).requiredKeys('urlPattern', 'handler')),
-  skipWaiting: joi.boolean().default(false),
+  skipWaiting: joi.boolean().default(defaults.skipWaiting),
 });

--- a/packages/workbox-build/src/entry-points/options/defaults.js
+++ b/packages/workbox-build/src/entry-points/options/defaults.js
@@ -14,15 +14,13 @@
   limitations under the License.
 */
 
-const joi = require('joi');
-
-const baseSchema = require('./base-schema');
-const defaults = require('./defaults');
-
-module.exports = baseSchema.keys({
-  globDirectory: joi.string().required(),
-  injectionPointRegexp: joi.object().type(RegExp)
-    .default(defaults.injectionPointRegexp),
-  swSrc: joi.string().required(),
-  swDest: joi.string().required(),
-});
+module.exports = {
+  globIgnores: ['node_modules/**/*'],
+  globPatterns: ['**/*.{js,css,html}'],
+  maximumFileSizeToCacheInBytes: 2 * 1024 * 1024,
+  clientsClaim: false,
+  navigateFallback: undefined,
+  skipWaiting: false,
+  importWorkboxFromCDN: true,
+  injectionPointRegexp: /(\.precacheAndRoute\()\s*\[\s*\]\s*(\))/,
+};

--- a/packages/workbox-build/src/entry-points/options/generate-sw-schema.js
+++ b/packages/workbox-build/src/entry-points/options/generate-sw-schema.js
@@ -17,11 +17,12 @@
 const joi = require('joi');
 
 const commonGenerateSchema = require('./common-generate-schema');
+const defaults = require('./defaults');
 
 // Define some additional constraints.
 module.exports = commonGenerateSchema.keys({
   globDirectory: joi.string().required(),
   importScripts: joi.array().items(joi.string()),
-  importWorkboxFromCDN: joi.boolean().default(true),
+  importWorkboxFromCDN: joi.boolean().default(defaults.importWorkboxFromCDN),
   swDest: joi.string().required(),
 });

--- a/packages/workbox-build/src/lib/errors.js
+++ b/packages/workbox-build/src/lib/errors.js
@@ -76,7 +76,7 @@ module.exports = {
   'invalid-inject-manifest-arg': ol`The input to 'injectManifest()' must be an
     object.`,
   'injection-point-not-found': ol`Unable to find a place to inject the manifest.
-    Please ensure that your 'swSrc' file contains a match for the RegExp:`,
+    Please ensure that your service worker file contains the following: `,
   'multiple-injection-points': ol`Please ensure that your 'swSrc' file contains
     only one match for the RegExp:`,
   'populating-sw-tmpl-failed': ol`Unable to generate service worker from


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #1053

In the course of addressing the issue I ended up refactoring how defaults are passed through to `joi`, keeping them in an external module instead of inline. That made it easier to tell whether the effective option that we were dealing with was overridden by the developer, or was the default value, which in turn made it possible to customize the error message accurately.