### PR TITLE
Adding JSDocs checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ install:
 
 script:
   - gulp test
-  - gulp docs:build
 
 after_success:
   - npm run coveralls

--- a/gulp-tasks/docs.js
+++ b/gulp-tasks/docs.js
@@ -43,7 +43,7 @@ You can view a friendlier UI by running
         '--template', path.join(
           __dirname, '..', 'infra', 'templates', 'reference-docs', 'jsdoc'
         ),
-        '--query', `"${queryString}"`,
+        '--query', queryString,
       );
     }
 

--- a/gulp-tasks/docs.js
+++ b/gulp-tasks/docs.js
@@ -43,7 +43,7 @@ You can view a friendlier UI by running
         '--template', path.join(
           __dirname, '..', 'infra', 'templates', 'reference-docs', 'jsdoc'
         ),
-        '--query', queryString,
+        '--query', `"${queryString}"`,
       );
     }
 

--- a/jsdoc.conf
+++ b/jsdoc.conf
@@ -7,7 +7,7 @@
       "packages/workbox-cli"
     ],
     "includePattern": ".+\\.(js(doc|x)?|mjs)$",
-    "excludePattern": "((^|\\/|\\\\)build(\\/|\\\\)|(^|\\/|\\\\)test(\\/|\\\\)|(^|\\/|\\\\)node_modules(\\/|\\\\)|(^|\\/|\\\\)demo(\\/|\\\\))"
+    "excludePattern": "((^|\\/|\\\\)packages\\/.*\\/build(\\/|\\\\)|(^|\\/|\\\\)test(\\/|\\\\)|(^|\\/|\\\\)node_modules(\\/|\\\\)|(^|\\/|\\\\)demo(\\/|\\\\))"
   },
   "opts": {
     "recurse": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11525,7 +11525,7 @@
         "arr-flatten": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-          "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
           "dev": true
         },
         "array-unique": {
@@ -11637,7 +11637,7 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         },
         "balanced-match": {
@@ -11976,7 +11976,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -12009,7 +12009,7 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
           "dev": true
         },
         "graceful-fs": {
@@ -12059,7 +12059,7 @@
         "hosted-git-info": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-          "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
+          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
           "dev": true
         },
         "imurmurhash": {
@@ -12231,7 +12231,7 @@
         "istanbul-lib-coverage": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-          "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
+          "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
           "dev": true
         },
         "istanbul-lib-hook": {
@@ -12406,7 +12406,7 @@
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -12476,7 +12476,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
@@ -12506,7 +12506,7 @@
         "normalize-package-data": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
             "hosted-git-info": "2.5.0",
@@ -12583,7 +12583,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
             "execa": "0.7.0",
@@ -12728,7 +12728,7 @@
         "randomatic": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-          "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+          "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
           "dev": true,
           "requires": {
             "is-number": "3.0.0",
@@ -12802,13 +12802,13 @@
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE=",
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
           "dev": true
         },
         "regex-cache": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-          "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+          "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
           "dev": true,
           "requires": {
             "is-equal-shallow": "0.1.3"
@@ -12881,7 +12881,7 @@
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         },
         "set-blocking": {
@@ -12926,7 +12926,7 @@
         "spawn-wrap": {
           "version": "1.3.8",
           "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.8.tgz",
-          "integrity": "sha1-+ip5uZDLsLsAGNymdI2INnsZ7DE=",
+          "integrity": "sha512-Yfkd7Yiwz4RcBPrDWzvhnTzQINBHNqOEhUzOdWZ67Y9b4wzs3Gz6ymuptQmRBpzlpOzroM7jwzmBdRec7JJ0UA==",
           "dev": true,
           "requires": {
             "foreground-child": "1.5.6",
@@ -12961,7 +12961,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -13024,7 +13024,7 @@
         "test-exclude": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-          "integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
+          "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
           "dev": true,
           "requires": {
             "arrify": "1.0.1",
@@ -13093,7 +13093,7 @@
         "which": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-          "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
             "isexe": "2.0.0"

--- a/test/all/node/test-jsdocs.mjs
+++ b/test/all/node/test-jsdocs.mjs
@@ -6,14 +6,19 @@ import spawn from '../../../gulp-tasks/utils/spawn-promise-wrapper';
 
 describe('[all] JSDocs', function() {
   it('should run JSDocs and have no unexpected results', async function() {
+    // Windows is super unhappy with the JSDocs build pipeline.
+    // With gulp.cmd in spawn, the query string used by the baseline template
+    // causes issues.
+    if (process.platform === 'win32') {
+      this.skip();
+      return;
+    }
     // Building docs takes time.
     this.timeout(60 * 1000);
 
     const projectRoot = path.join(__dirname, '..', '..', '..');
     const docsPath = path.join(projectRoot, 'docs');
-    const gulpCommand = process.platform === 'win32' ?
-      'gulp.cmd' : 'gulp';
-    await spawn(gulpCommand, ['docs:build'], {
+    await spawn('gulp', ['docs:build'], {
       cwd: projectRoot,
     });
 

--- a/test/all/node/test-jsdocs.mjs
+++ b/test/all/node/test-jsdocs.mjs
@@ -19,6 +19,9 @@ describe('[all] JSDocs', function() {
       cwd: docsPath,
     });
 
+    console.log('Docs path: ', docsPath);
+    console.log('Globbed Docs: ', docs);
+
     // global.html is only added when the docs have stray global values.
     if (docs.indexOf('global.html') !== -1) {
       throw new Error('There should be **no** globals in the JSDocs.');

--- a/test/all/node/test-jsdocs.mjs
+++ b/test/all/node/test-jsdocs.mjs
@@ -11,27 +11,26 @@ describe('[all] JSDocs', function() {
     this.timeout(60 * 1000);
 
     const projectRoot = path.join(__dirname, '..', '..', '..');
-    const docsPath = path.join(projectRoot, 'docs');
     await spawn('gulp', ['docs:build'], {
       cwd: projectRoot,
     });
 
-    const docs = glob.sync('**/*.html', {
-      cwd: docsPath,
+    const docs = glob.sync('docs/**/*.html', {
+      cwd: projectRoot,
     });
 
-    logHelper.log('Docs path: ', docsPath);
+    logHelper.log('Project Root path: ', projectRoot);
     logHelper.log('Globbed Docs: ', docs);
 
     // global.html is only added when the docs have stray global values.
-    if (docs.indexOf('global.html') !== -1) {
+    if (docs.indexOf('docs/global.html') !== -1) {
       throw new Error('There should be **no** globals in the JSDocs.');
     }
 
     // On some occassions module.exports can leak into JSDocs and breaks
     // in the final template.
-    expect(docs.indexOf('index-all.html')).to.not.equal(-1);
-    const indexAllContents = fs.readFileSync(path.join(docsPath, 'index-all.html'))
+    expect(docs.indexOf('docs/index-all.html')).to.not.equal(-1);
+    const indexAllContents = fs.readFileSync(path.join(projectRoot, 'docs', 'index-all.html'))
       .toString();
     if (indexAllContents.indexOf('<a href="module.html#.exports">module.exports</a>') !== -1) {
       throw new Error('There is a stray `module.exports` in the docs. ' +

--- a/test/all/node/test-jsdocs.mjs
+++ b/test/all/node/test-jsdocs.mjs
@@ -3,7 +3,6 @@ import glob from 'glob';
 import {expect} from 'chai';
 import fs from 'fs-extra';
 import spawn from '../../../gulp-tasks/utils/spawn-promise-wrapper';
-import logHelper from '../../../infra/utils/log-helper';
 
 describe('[all] JSDocs', function() {
   it('should run JSDocs and have no unexpected results', async function() {
@@ -11,26 +10,24 @@ describe('[all] JSDocs', function() {
     this.timeout(60 * 1000);
 
     const projectRoot = path.join(__dirname, '..', '..', '..');
+    const docsPath = path.join(projectRoot, 'docs');
     await spawn('gulp', ['docs:build'], {
       cwd: projectRoot,
     });
 
-    const docs = glob.sync('docs/**/*.html', {
-      cwd: projectRoot,
+    const docs = glob.sync('*.html', {
+      cwd: docsPath,
     });
 
-    logHelper.log('Project Root path: ', projectRoot);
-    logHelper.log('Globbed Docs: ', docs);
-
     // global.html is only added when the docs have stray global values.
-    if (docs.indexOf('docs/global.html') !== -1) {
+    if (docs.indexOf('global.html') !== -1) {
       throw new Error('There should be **no** globals in the JSDocs.');
     }
 
     // On some occassions module.exports can leak into JSDocs and breaks
     // in the final template.
-    expect(docs.indexOf('docs/index-all.html')).to.not.equal(-1);
-    const indexAllContents = fs.readFileSync(path.join(projectRoot, 'docs', 'index-all.html'))
+    expect(docs.indexOf('index-all.html')).to.not.equal(-1);
+    const indexAllContents = fs.readFileSync(path.join(docsPath, 'index-all.html'))
       .toString();
     if (indexAllContents.indexOf('<a href="module.html#.exports">module.exports</a>') !== -1) {
       throw new Error('There is a stray `module.exports` in the docs. ' +

--- a/test/all/node/test-jsdocs.mjs
+++ b/test/all/node/test-jsdocs.mjs
@@ -16,7 +16,7 @@ describe('[all] JSDocs', function() {
       cwd: projectRoot,
     });
 
-    const docs = glob.sync('*.html', {
+    const docs = glob.sync('**/*.html', {
       cwd: docsPath,
     });
 

--- a/test/all/node/test-jsdocs.mjs
+++ b/test/all/node/test-jsdocs.mjs
@@ -11,7 +11,9 @@ describe('[all] JSDocs', function() {
 
     const projectRoot = path.join(__dirname, '..', '..', '..');
     const docsPath = path.join(projectRoot, 'docs');
-    await spawn('gulp', ['docs:build'], {
+    const gulpCommand = process.platform === 'win32' ?
+      'gulp.cmd' : 'gulp';
+    await spawn(gulpCommand, ['docs:build'], {
       cwd: projectRoot,
     });
 

--- a/test/all/node/test-jsdocs.mjs
+++ b/test/all/node/test-jsdocs.mjs
@@ -3,6 +3,7 @@ import glob from 'glob';
 import {expect} from 'chai';
 import fs from 'fs-extra';
 import spawn from '../../../gulp-tasks/utils/spawn-promise-wrapper';
+import logHelper from '../../../infra/utils/log-helper';
 
 describe('[all] JSDocs', function() {
   it('should run JSDocs and have no unexpected results', async function() {
@@ -19,8 +20,8 @@ describe('[all] JSDocs', function() {
       cwd: docsPath,
     });
 
-    console.log('Docs path: ', docsPath);
-    console.log('Globbed Docs: ', docs);
+    logHelper.log('Docs path: ', docsPath);
+    logHelper.log('Globbed Docs: ', docs);
 
     // global.html is only added when the docs have stray global values.
     if (docs.indexOf('global.html') !== -1) {

--- a/test/all/node/test-jsdocs.mjs
+++ b/test/all/node/test-jsdocs.mjs
@@ -1,0 +1,37 @@
+import path from 'path';
+import glob from 'glob';
+import {expect} from 'chai';
+import fs from 'fs-extra';
+import spawn from '../../../gulp-tasks/utils/spawn-promise-wrapper';
+
+describe('[all] JSDocs', function() {
+  it('should run JSDocs and have no unexpected results', async function() {
+    // Building docs takes time.
+    this.timeout(60 * 1000);
+
+    const projectRoot = path.join(__dirname, '..', '..', '..');
+    const docsPath = path.join(projectRoot, 'docs');
+    await spawn('gulp', ['docs:build'], {
+      cwd: projectRoot,
+    });
+
+    const docs = glob.sync('*.html', {
+      cwd: docsPath,
+    });
+
+    // global.html is only added when the docs have stray global values.
+    if (docs.indexOf('global.html') !== -1) {
+      throw new Error('There should be **no** globals in the JSDocs.');
+    }
+
+    // On some occassions module.exports can leak into JSDocs and breaks
+    // in the final template.
+    expect(docs.indexOf('index-all.html')).to.not.equal(-1);
+    const indexAllContents = fs.readFileSync(path.join(docsPath, 'index-all.html'))
+      .toString();
+    if (indexAllContents.indexOf('<a href="module.html#.exports">module.exports</a>') !== -1) {
+      throw new Error('There is a stray `module.exports` in the docs. ' +
+        'Find and fix this issue.');
+    }
+  });
+});


### PR DESCRIPTION
This will fail the test until #1080 is merged, then we can re-run and check the tests pass.

Checks for:
- No globals
- No module.exports (Something that is showing up in the WebFundamentals build for v3.0.0-alpha.1) at the moment.