### PR TITLE
Pass through all webpack config options to generateSWString()

### DIFF
--- a/packages/workbox-build/src/entry-points/options/defaults.js
+++ b/packages/workbox-build/src/entry-points/options/defaults.js
@@ -17,6 +17,8 @@
 module.exports = {
   globIgnores: ['node_modules/**/*'],
   globPatterns: ['**/*.{js,css,html}'],
+  // Use a different default for generateSWString.
+  generateSWStringGlobPatterns: [],
   maximumFileSizeToCacheInBytes: 2 * 1024 * 1024,
   clientsClaim: false,
   navigateFallback: undefined,

--- a/packages/workbox-build/src/entry-points/options/generate-sw-string-schema.js
+++ b/packages/workbox-build/src/entry-points/options/generate-sw-string-schema.js
@@ -17,9 +17,12 @@
 const joi = require('joi');
 
 const commonGenerateSchema = require('./common-generate-schema');
+const defaults = require('./defaults');
 
 // Define some additional constraints.
 module.exports = commonGenerateSchema.keys({
   globDirectory: joi.string(),
+  globPatterns: joi.array().items(joi.string()).default(
+    defaults.generateSWStringGlobPatterns),
   importScripts: joi.array().items(joi.string()).required(),
 });

--- a/packages/workbox-webpack-plugin/src/index.js
+++ b/packages/workbox-webpack-plugin/src/index.js
@@ -120,13 +120,12 @@ class WorkboxWebpackPlugin {
       const manifestFilename = `precache-manifest.${fileManifestHash}.js`;
       compilation.assets[manifestFilename] = fileManifestAsset;
 
-      const importScripts = (this.config.importScripts || []).concat([
+      this.config.importScripts = (this.config.importScripts || []).concat([
         getModuleUrl('workbox-sw'),
         manifestFilename,
       ]);
 
-      const serviceWorker = await generateOrCopySW(Object.assign(
-        this.generateSWStringOptions, {importScripts}), swSrc);
+      const serviceWorker = await generateOrCopySW(this.config, swSrc);
       compilation.assets[serviceWorkerFilename] = formatAsWebpackAsset(
         serviceWorker);
 

--- a/packages/workbox-webpack-plugin/src/lib/generate-or-copy-sw.js
+++ b/packages/workbox-webpack-plugin/src/lib/generate-or-copy-sw.js
@@ -18,6 +18,29 @@ const {generateSWString} = require('workbox-build');
 const {readFile} = require('./utils/read-file');
 
 /**
+ * Given a config object, remove the properties that we know are webpack-plugin
+ * specific, so that the remaining properties can be passed through to
+ * generateSWString().
+ *
+ * @param {Object} config
+ * @return {Object}
+ */
+function sanitizeConfig(config) {
+  const propertiesToRemove = [
+    'chunks',
+    'excludeChunks',
+    'filename',
+    'manifestFilename',
+  ];
+
+  for (const property of propertiesToRemove) {
+    delete config[property];
+  }
+
+  return config;
+}
+
+/**
  * Generate a service worker using {@link module:workbox-build.generateSWString}
  * or append `importScripts('workbox-sw.<version>.js', 'file-manifest.js')` to
  * an existing service worker if `swSrc` is specified
@@ -36,8 +59,8 @@ const {readFile} = require('./utils/read-file');
  */
 module.exports = async (config, swSrc) => {
   if (!swSrc) {
-    // use workbox-build to generate the service worker
-    return generateSWString(config);
+    // use workbox-build to generate the service worker.
+    return generateSWString(sanitizeConfig(config));
   } else {
     const serviceWorkerSource = await readFile(swSrc);
     const scripts = config.importScripts

--- a/packages/workbox-webpack-plugin/src/lib/generate-or-copy-sw.js
+++ b/packages/workbox-webpack-plugin/src/lib/generate-or-copy-sw.js
@@ -24,6 +24,8 @@ const {readFile} = require('./utils/read-file');
  *
  * @param {Object} config
  * @return {Object}
+ *
+ * @private
  */
 function sanitizeConfig(config) {
   const propertiesToRemove = [

--- a/test/workbox-build/node/entry-points/generate-sw-string.js
+++ b/test/workbox-build/node/entry-points/generate-sw-string.js
@@ -130,6 +130,7 @@ describe(`[workbox-build] entry-points/generate-sw-string.js (End to End)`, func
       const options = Object.assign({}, BASE_OPTIONS, {
         importScripts,
         globDirectory: GLOB_DIR,
+        globPatterns: ['**/*.{js,css,html}'],
       });
 
       let swCode = await generateSWString(options);

--- a/test/workbox-webpack-plugin/node/index.js
+++ b/test/workbox-webpack-plugin/node/index.js
@@ -115,6 +115,7 @@ describe(`[workbox-webpack-plugin] index.js (End to End)`, function() {
             ]],
             clientsClaim: [[]],
             skipWaiting: [[]],
+            suppressWarnings: [[]],
             precacheAndRoute: [[[{
               revision: '5cfecbd12c9fa32f03eafe27e2ac798e',
               url: '/shell',

--- a/test/workbox-webpack-plugin/node/index.js
+++ b/test/workbox-webpack-plugin/node/index.js
@@ -71,6 +71,75 @@ describe(`[workbox-webpack-plugin] index.js (End to End)`, function() {
         }
       });
     });
+
+    it(`should pass through the config to workbox-build.generateSWString()`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.b6f6b1b151c4f027ee1e1aa3061eeaf7.js';
+      const outputDir = tempy.directory();
+      const config = {
+        entry: {
+          entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+          entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        },
+        output: {
+          filename: '[name]-[chunkhash].js',
+          path: outputDir,
+        },
+        plugins: [
+          // This is not an exhaustive test of all the supported options, but
+          // it should be enough to confirm that they're being interpreted
+          // by workbox-build.generateSWString() properly.
+          new WorkboxWebpackPlugin({
+            clientsClaim: true,
+            skipWaiting: true,
+            globDirectory: SRC_DIR,
+            templatedUrls: {
+              '/shell': ['index.html', 'styles/*.css'],
+            },
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError) => {
+        if (webpackError) {
+          return done(webpackError);
+        }
+
+        const swFile = path.join(outputDir, 'sw.js');
+        try {
+          // First, validate that the generated sw.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [[
+              WORKBOX_SW_FILE_NAME,
+              FILE_MANIFEST_NAME,
+            ]],
+            clientsClaim: [[]],
+            skipWaiting: [[]],
+            precacheAndRoute: [[[{
+              revision: '5cfecbd12c9fa32f03eafe27e2ac798e',
+              url: '/shell',
+            }], {}]],
+          }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            url: 'entry2-17c2a1b5c94290899539.js',
+          }, {
+            url: 'entry1-d7f4e7088b64a9896b23.js',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
   });
 
   describe(`[workbox-webpack-plugin] html-webpack-plugin and a single chunk`, function() {


### PR DESCRIPTION
R: @goldhand @addyosmani @gauntface
CC: @anilanar 

Fixes #934 

As an initial implementation, it should provide flexibility to handle both webpack-specific precaching as well as take advantage of `runtimeCaching`, `templatedUrls`, and the other options exposed via `workbox-build`.

(This might not be the 100% final interface, as folks who start using the webpack plugin might have feedback about certain options that feel awkward when used in this context.)