### PR TITLE
Updating references to point to new docs pages

### DIFF
--- a/packages/workbox-build/src/templates/sw-template.js
+++ b/packages/workbox-build/src/templates/sw-template.js
@@ -17,20 +17,16 @@
 module.exports = `/**
  * Welcome to your Workbox-powered service worker!
  *
- * Here are some next steps:
- *
- * - Your web app needs to register this file.
- *   See https://goo.gl/DNGzMp
- *
- * - Disable HTTP caching for this file.
- *   See https://goo.gl/rWuKgq
+ * You'll need to register this file in your web app and you should
+ * disable HTTP caching for this file too.
+ * See https://goo.gl/nhQhGp
  *
  * The rest of the code is auto-generated. Please don't update this file
  * directly; instead, make changes to your Workbox build configuration
  * and re-run your build process.
  * See https://goo.gl/YYPcyY
  */
- 
+
 <% if (importScripts) { %>
 importScripts(<%= importScripts.map(JSON.stringify).join(',') %>);
 <% } %>
@@ -45,7 +41,7 @@ importScripts(<%= importScripts.map(JSON.stringify).join(',') %>);
 /**
  * The workboxSW.precacheAndRoute() method efficiently caches and responds to
  * requests for URLs in the manifest.
- * See https://goo.gl/GYZoHL
+ * See https://goo.gl/S9QRab
  */
 self.__precacheManifest = <%= JSON.stringify(manifestEntries, null, 2) %>.concat(self.__precacheManifest || []);
 <% } %>

--- a/packages/workbox-cli/src/lib/help-text.js
+++ b/packages/workbox-cli/src/lib/help-text.js
@@ -16,7 +16,7 @@
 
 module.exports = `Usage:
 $ workbox <command> [options]
-  
+
 Commands:
   wizard
     Runs the configuration wizard, which will generate a
@@ -25,14 +25,14 @@ Commands:
   generateSW [<path/to/config.js>]
     Creates a new service worker file based on the options
     in the config file (defaults to workbox-config.js).
-    See https://goo.gl/zQz4By
+    See https://goo.gl/fdTQBf
 
   injectManifest [<path/to/config.js>]
     Takes an existing service worker file and creates a
     copy of it with a precaching manifest "injected" into
     it. The precaching manifest is generated based on the
     options in the config file (defaults to workbox-config.js).
-    See https://goo.gl/yB6KZL
+    See https://goo.gl/QRjpZj
 
   copyLibraries <path/to/parent/dir>
     Makes a local copy of all of the Workbox libraries inside

--- a/packages/workbox-cli/src/lib/run-wizard.js
+++ b/packages/workbox-cli/src/lib/run-wizard.js
@@ -30,7 +30,7 @@ module.exports = async () => {
 
   workbox generateSW ${configLocation}
 
-as part of a build process. See https://goo.gl/8zZy1P for details.`);
+as part of a build process. See https://goo.gl/fdTQBf for details.`);
 
   logger.log(ol`You can further customize your service worker by making changes
     to ${configLocation}. See https://goo.gl/YYPcyY for details.`);

--- a/packages/workbox-precaching/utils/showWarningsIfNeeded.mjs
+++ b/packages/workbox-precaching/utils/showWarningsIfNeeded.mjs
@@ -56,10 +56,8 @@ export default (entriesMap) => {
     `\n\n`
   );
 
-  // TODO (gauntface) Before launch swap for d.g.c/web URL
   logger.unprefixed.warn(`You can learn more about why this might be a ` +
-    `problem here: https://docs.google.com/document/d/1i83D4x_1Jz2JT3BCRjO` +
-    `18m-vdL9uG7ksscqZ_E0XjO0/edit?usp=sharing`);
+    `problem here: https://developers.google.com/web/tools/workbox/modules/workbox-precaching`);
 
   logger.groupEnd();
 };

--- a/packages/workbox-routing/RegExpRoute.mjs
+++ b/packages/workbox-routing/RegExpRoute.mjs
@@ -26,7 +26,7 @@ import './_version.mjs';
  * requests against third-party servers, you must define a RegExp that matches
  * the start of the URL.
  *
- * [See the module docs for info.]{@link https://developers.google.com/web/tools/workbox/v3/modules/workbox-routing}
+ * [See the module docs for info.]{@link https://developers.google.com/web/tools/workbox/modules/workbox-routing}
  *
  * @memberof workbox.routing
  * @extends workbox.routing.Route

--- a/packages/workbox-strategies/NetworkFirst.mjs
+++ b/packages/workbox-strategies/NetworkFirst.mjs
@@ -32,7 +32,7 @@ import './_version.mjs';
  * request strategy.
  *
  * By default, this strategy will cache responses with a 200 status code as
- * well as [opaque responses]{@link https://docs.google.com/document/d/1nHIjXdmXs9nT6_lcGcsZY5UZ-tL9JxXESlKbzAJdBG4/edit?usp=sharing}.
+ * well as [opaque responses]{@link https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests}.
  * Opaque responses are are cross-origin requests where the response doesn't
  * support [CORS]{@link https://enable-cors.org/}.
  *

--- a/packages/workbox-strategies/StaleWhileRevalidate.mjs
+++ b/packages/workbox-strategies/StaleWhileRevalidate.mjs
@@ -38,7 +38,7 @@ import './_version.mjs';
  * with each successful request.
  *
  * By default, this strategy will cache responses with a 200 status code as
- * well as [opaque responses]{@link https://docs.google.com/document/d/1nHIjXdmXs9nT6_lcGcsZY5UZ-tL9JxXESlKbzAJdBG4/edit?usp=sharing}.
+ * well as [opaque responses]{@link https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests}.
  * Opaque responses are are cross-origin requests where the response doesn't
  * support [CORS]{@link https://enable-cors.org/}.
  *


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

This updates short links to d.g.c where appropriate., Plugins is still missing a doc so will point to drive until we actually write up the content and post.

There is also a short link pointing to a 404 URL at the moment but it will be valid once: https://github.com/google/WebFundamentals/pull/5397 lands.
