### PR TITLE
v3: workbox-range-requests module

### DIFF
--- a/infra/testing/sw-env-mocks/Blob.js
+++ b/infra/testing/sw-env-mocks/Blob.js
@@ -49,6 +49,12 @@ class Blob {
     }
     return text;
   }
+
+  slice(start, end, type) {
+    const bodyString = this._text;
+    const slicedBodyString = bodyString.substring(start, end);
+    return new Blob([slicedBodyString], {type});
+  }
 }
 
 module.exports = Blob;

--- a/packages/workbox-core/models/messages/messages.mjs
+++ b/packages/workbox-core/models/messages/messages.mjs
@@ -53,7 +53,7 @@ export default {
 
   'incorrect-class': ({expectedClass, paramName, moduleName, className,
                        funcName}) => {
-    if (!expectedClass || !paramName || !moduleName  || !funcName) {
+    if (!expectedClass || !paramName || !moduleName || !funcName) {
       throw new Error(`Unexpected input to 'incorrect-class' error.`);
     }
     return `The parameter '${paramName}' passed into ` +

--- a/packages/workbox-core/models/messages/messages.mjs
+++ b/packages/workbox-core/models/messages/messages.mjs
@@ -43,23 +43,22 @@ export default {
 
   'incorrect-type': ({expectedType, paramName, moduleName, className,
                    funcName}) => {
-    if (!expectedType || !paramName || !moduleName || !className || !funcName) {
+    if (!expectedType || !paramName || !moduleName || !funcName) {
       throw new Error(`Unexpected input to 'incorrect-type' error.`);
     }
     return `The parameter '${paramName}' passed into ` +
-      `'${moduleName}.${className}.${funcName}()' must be of type ` +
-      `${expectedType}.`;
+      `'${moduleName}.${className ? (className + '.') : ''}` +
+      `${funcName}()' must be of type ${expectedType}.`;
   },
 
   'incorrect-class': ({expectedClass, paramName, moduleName, className,
                        funcName}) => {
-    if (!expectedClass || !paramName || !moduleName || !className ||
-      !funcName) {
+    if (!expectedClass || !paramName || !moduleName  || !funcName) {
       throw new Error(`Unexpected input to 'incorrect-class' error.`);
     }
     return `The parameter '${paramName}' passed into ` +
-      `'${moduleName}.${className}.${funcName}()' must be an instance of ` +
-      `class ${expectedClass.name}.`;
+      `'${moduleName}.${className ? (className + '.') : ''}.${funcName}()' ` +
+      `must be an instance of class ${expectedClass.name}.`;
   },
 
   'missing-a-method': ({expectedMethod, paramName, moduleName, className,
@@ -179,5 +178,35 @@ export default {
   'invalid-responses-are-same-args': () => {
     return `The arguments passed into responsesAreSame() appear to be ` +
       `invalid. Please ensure valid Responses are used.`;
+  },
+  'unit-must-be-bytes': ({normalizedRangeHeader}) => {
+    if (!normalizedRangeHeader) {
+      throw new Error(`Unexpected input to 'unit-must-be-bytes' error.`);
+    }
+    return `The 'unit' portion of the Range header must be set to 'bytes'. ` +
+      `The Range header provided was "${normalizedRangeHeader}"`;
+  },
+  'single-range-only': ({normalizedRangeHeader}) => {
+    if (!normalizedRangeHeader) {
+      throw new Error(`Unexpected input to 'single-range-only' error.`);
+    }
+    return `Multiple ranges are not supported. Please use a  single start ` +
+      `value, and optional end value. The Range header provided was ` +
+      `"${normalizedRangeHeader}"`;
+  },
+  'invalid-range-values': ({normalizedRangeHeader}) => {
+    if (!normalizedRangeHeader) {
+      throw new Error(`Unexpected input to 'invalid-range-values' error.`);
+    }
+    return `The Range header is missing both start and end values. At least ` +
+      `one of those values is needed. The Range header provided was ` +
+      `"${normalizedRangeHeader}"`;
+  },
+  'no-range-header': () => {
+    return `No Range header was found in the Request provided.`;
+  },
+  'range-not-satisfiable': ({size, start, end}) => {
+    return `The start (${start}) and end (${end}) values in the Range are ` +
+      `not satisfiable by the cached response, which is ${size} bytes.`;
   },
 };

--- a/packages/workbox-range-requests/Plugin.mjs
+++ b/packages/workbox-range-requests/Plugin.mjs
@@ -1,0 +1,55 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import {createPartialResponse} from './createPartialResponse.mjs';
+
+import './_version.mjs';
+
+/**
+ * A class implementing the `cachedResponseWillBeUsed` lifecycle callback.
+ * This makes it easier to add in support for used cached responses to fulfill
+ * requests with `Range:` headers.
+ *
+ * If an incoming request does contain a `Range:` header, then the appropriate
+ * subset of the cached body will be returned as part of a HTTP 416 response.
+ *
+ * If the incoming request does not contain a `Range:` header, then the cached
+ * response will be used as-is.
+ *
+ * @memberof workbox.rangeRequests
+ */
+class Plugin {
+  /**
+   * @param {Object} options
+   * @param {Request} options.request The original request, which may or may not
+   * contain a Range: header.
+   * @param {Response} options.cachedResponse The complete cached response.
+   * @return {Promise<Response>} If request contains a Range: header, then
+   * a Response with status 206 whose body is a subset of cachedResponse. If
+   * request does not have a Range: header, then cachedResponse is returned
+   * as-is.
+   *
+   * @private
+   */
+  static async cachedResponseWillBeUsed({request, cachedResponse} = {}) {
+    // Only return a sliced response if there's a Range: header in the request.
+    if (request.headers.has('range')) {
+      return await createPartialResponse(request, cachedResponse);
+    }
+
+    // If there was no Range: header, return the original response as-is.
+    return cachedResponse;
+  }
+}
+
+export {Plugin};

--- a/packages/workbox-range-requests/Plugin.mjs
+++ b/packages/workbox-range-requests/Plugin.mjs
@@ -16,15 +16,11 @@ import {createPartialResponse} from './createPartialResponse.mjs';
 import './_version.mjs';
 
 /**
- * A class implementing the `cachedResponseWillBeUsed` lifecycle callback.
- * This makes it easier to add in support for used cached responses to fulfill
- * requests with `Range:` headers.
+ * The range request plugin makes it easy for a request with a 'Range' header to
+ * be fulfilled by a cached response.
  *
- * If an incoming request does contain a `Range:` header, then the appropriate
- * subset of the cached body will be returned as part of a HTTP 416 response.
- *
- * If the incoming request does not contain a `Range:` header, then the cached
- * response will be used as-is.
+ * It does this by intercepting the `cachedResponseWillBeUsed` plugin callback
+ * and returning the appropriate subset of the cached response body.
  *
  * @memberof workbox.rangeRequests
  */
@@ -34,10 +30,9 @@ class Plugin {
    * @param {Request} options.request The original request, which may or may not
    * contain a Range: header.
    * @param {Response} options.cachedResponse The complete cached response.
-   * @return {Promise<Response>} If request contains a Range: header, then
-   * a Response with status 206 whose body is a subset of cachedResponse. If
-   * request does not have a Range: header, then cachedResponse is returned
-   * as-is.
+   * @return {Promise<Response>} If request contains a 'Range' header, then a
+   * new response with status 206 whose body is a subset of `cachedResponse` is
+   * returned. Otherwise, `cachedResponse` is returned as-is.
    *
    * @private
    */

--- a/packages/workbox-range-requests/_public.mjs
+++ b/packages/workbox-range-requests/_public.mjs
@@ -1,0 +1,24 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import {createPartialResponse} from './createPartialResponse.mjs';
+import {Plugin} from './Plugin.mjs';
+import './_version.mjs';
+
+export {
+  createPartialResponse,
+  Plugin,
+};

--- a/packages/workbox-range-requests/_version.mjs
+++ b/packages/workbox-range-requests/_version.mjs
@@ -1,0 +1,1 @@
+try{self.workbox.v['workbox:range-requests:3.0.0-alpha.2']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-range-requests/browser.mjs
+++ b/packages/workbox-range-requests/browser.mjs
@@ -1,0 +1,19 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import './_version.mjs';
+
+export * from './_public.mjs';

--- a/packages/workbox-range-requests/createPartialResponse.mjs
+++ b/packages/workbox-range-requests/createPartialResponse.mjs
@@ -1,0 +1,105 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import {WorkboxError} from 'workbox-core/_private/WorkboxError.mjs';
+import {assert} from 'workbox-core/_private/assert.mjs';
+import {logger} from 'workbox-core/_private/logger.mjs';
+
+import {calculateEffectiveBoundaries} from
+  './utils/calculateEffectiveBoundaries.mjs';
+import {parseRangeHeader} from './utils/parseRangeHeader.mjs';
+
+import './_version.mjs';
+
+/**
+ * Given a `Request` and `Response` objects as input, this will return a
+ * promise for a new `Response`.
+ *
+ * @param {Request} request A request, which should contain a Range:
+ * header.
+ * @param {Response} originalResponse An original response containing the full
+ * content.
+ * @return {Promise<Response>} Either a `206 Partial Content` response, with
+ * the response body set to the slice of content specified by the request's
+ * `Range:` header, or a `416 Range Not Satisfiable` response if the
+ * conditions of the `Range:` header can't be met.
+ *
+ * @memberof workbox.rangeRequests
+ */
+async function createPartialResponse(request, originalResponse) {
+  try {
+    if (process.env.NODE_ENV !== 'production') {
+      assert.isInstance(request, Request, {
+        moduleName: 'workbox-range-requests',
+        funcName: 'createPartialResponse',
+        paramName: 'request',
+      });
+
+      assert.isInstance(originalResponse, Response, {
+        moduleName: 'workbox-range-requests',
+        funcName: 'createPartialResponse',
+        paramName: 'originalResponse',
+      });
+    }
+
+    const rangeHeader = request.headers.get('range');
+    if (!rangeHeader) {
+      throw new WorkboxError('no-range-header');
+    }
+
+    const boundaries = parseRangeHeader(rangeHeader);
+    const originalBlob = await originalResponse.blob();
+
+    const effectiveBoundaries = calculateEffectiveBoundaries(
+      originalBlob, boundaries.start, boundaries.end);
+
+    const slicedBlob = originalBlob.slice(effectiveBoundaries.start,
+      effectiveBoundaries.end);
+    const slicedBlobSize = slicedBlob.size;
+
+    const slicedResponse = new Response(slicedBlob, {
+      // Status code 206 is for a Partial Content response.
+      // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/206
+      status: 206,
+      statusText: 'Partial Content',
+      headers: originalResponse.headers,
+    });
+
+    slicedResponse.headers.set('Content-Length', slicedBlobSize);
+    slicedResponse.headers.set('Content-Range',
+      `bytes ${effectiveBoundaries.start}-${effectiveBoundaries.end - 1}/` +
+      originalBlob.size);
+
+    return slicedResponse;
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      logger.warn(`Unable to construct a partial response; returning a ` +
+        `416 Range Not Satisfiable response instead.`);
+      logger.groupCollapsed(`View details here.`);
+      logger.unprefixed.log(error);
+      logger.unprefixed.log(request);
+      logger.unprefixed.log(originalResponse);
+      logger.groupEnd();
+    }
+
+    return new Response('', {
+      status: 416,
+      statusText: 'Range Not Satisfiable',
+    });
+  }
+}
+
+export {createPartialResponse};

--- a/packages/workbox-range-requests/index.mjs
+++ b/packages/workbox-range-requests/index.mjs
@@ -1,0 +1,23 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/**
+ * @namespace workbox.rangeRequests
+ */
+
+import './_version.mjs';
+
+export * from './_public.mjs';

--- a/packages/workbox-range-requests/package.json
+++ b/packages/workbox-range-requests/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "workbox-range-requests",
+  "version": "3.0.0-alpha.2",
+  "license": "Apache-2.0",
+  "author": "Google's Web DevRel Team",
+  "description": "This library creates a new Response, given a source Response and a Range header value.",
+  "repository": "googlechrome/workbox",
+  "bugs": "https://github.com/googlechrome/workbox/issues",
+  "homepage": "https://github.com/GoogleChrome/workbox",
+  "keywords": [
+    "workbox",
+    "workboxjs",
+    "service worker",
+    "sw",
+    "caching",
+    "cache",
+    "range",
+    "media"
+  ],
+  "scripts": {
+    "build": "gulp build-packages --package workbox-range-requests",
+    "version": "npm run build",
+    "prepare": "npm run build"
+  },
+  "workbox": {
+    "browserNamespace": "workbox.rangeRequests",
+    "packageType": "browser"
+  },
+  "main": "build/workbox-range-requests.prod.js",
+  "module": "index.mjs",
+  "dependencies": {
+    "workbox-core": "^3.0.0-alpha.2"
+  }
+}

--- a/packages/workbox-range-requests/utils/calculateEffectiveBoundaries.mjs
+++ b/packages/workbox-range-requests/utils/calculateEffectiveBoundaries.mjs
@@ -1,0 +1,72 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import {WorkboxError} from 'workbox-core/_private/WorkboxError.mjs';
+import {assert} from 'workbox-core/_private/assert.mjs';
+
+import '../_version.mjs';
+
+/**
+ * @param {Blob} blob A source blob.
+ * @param {Number|null} start The offset to use as the start of the
+ * slice.
+ * @param {Number|null} end The offset to use as the end of the slice.
+ * @return {Object} An object with `start` and `end` properties, reflecting
+ * the effective boundaries to use given the size of the blob.
+ *
+ * @private
+ */
+function calculateEffectiveBoundaries(blob, start, end) {
+  if (process.env.NODE_ENV !== 'production') {
+    assert.isInstance(blob, Blob, {
+      moduleName: 'workbox-range-requests',
+      funcName: 'calculateEffectiveBoundaries',
+      paramName: 'blob',
+    });
+  }
+
+  const blobSize = blob.size;
+
+  if (end > blobSize || start < 0) {
+    throw new WorkboxError('range-not-satisfiable', {
+      size: blobSize,
+      end,
+      start,
+    });
+  }
+
+  let effectiveStart;
+  let effectiveEnd;
+
+  if (start === null) {
+    effectiveStart = blobSize - end;
+    effectiveEnd = blobSize;
+  } else if (end === null) {
+    effectiveStart = start;
+    effectiveEnd = blobSize;
+  } else {
+    effectiveStart = start;
+    // Range values are inclusive, so add 1 to the value.
+    effectiveEnd = end + 1;
+  }
+
+  return {
+    start: effectiveStart,
+    end: effectiveEnd,
+  };
+}
+
+export {calculateEffectiveBoundaries};

--- a/packages/workbox-range-requests/utils/parseRangeHeader.mjs
+++ b/packages/workbox-range-requests/utils/parseRangeHeader.mjs
@@ -1,0 +1,63 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import {WorkboxError} from 'workbox-core/_private/WorkboxError.mjs';
+import {assert} from 'workbox-core/_private/assert.mjs';
+
+import '../_version.mjs';
+
+/**
+ * @param {string} rangeHeader A Range: header value.
+ * @return {Object} An object with `start` and `end` properties, reflecting
+ * the parsed value of the Range: header. If either the `start` or `end` are
+ * omitted, then `null` will be returned.
+ *
+ * @private
+ */
+function parseRangeHeader(rangeHeader) {
+  if (process.env.NODE_ENV !== 'production') {
+    assert.isType(rangeHeader, 'string', {
+      moduleName: 'workbox-range-requests',
+      funcName: 'parseRangeHeader',
+      paramName: 'rangeHeader',
+    });
+  }
+
+  const normalizedRangeHeader = rangeHeader.trim().toLowerCase();
+  if (!normalizedRangeHeader.startsWith('bytes=')) {
+    throw new WorkboxError('unit-must-be-bytes', {normalizedRangeHeader});
+  }
+
+  // Specifying multiple ranges separate by commas is valid syntax, but this
+  // library only attempts to handle a single, contiguous sequence of bytes.
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range#Syntax
+  if (normalizedRangeHeader.includes(',')) {
+    throw new WorkboxError('single-range-only', {normalizedRangeHeader});
+  }
+
+  const rangeParts = /(\d*)-(\d*)/.exec(normalizedRangeHeader);
+  // We need either at least one of the start or end values.
+  if (rangeParts === null || !(rangeParts[1] || rangeParts[2])) {
+    throw new WorkboxError('invalid-range-values', {normalizedRangeHeader});
+  }
+
+  return {
+    start: rangeParts[1] === '' ? null : Number(rangeParts[1]),
+    end: rangeParts[2] === '' ? null : Number(rangeParts[2]),
+  };
+}
+
+export {parseRangeHeader};

--- a/packages/workbox-sw/controllers/WorkboxSW.mjs
+++ b/packages/workbox-sw/controllers/WorkboxSW.mjs
@@ -30,6 +30,7 @@ const MODULE_KEY_TO_NAME_MAPPING = {
   routing: 'routing',
   cacheableResponse: 'cacheable-response',
   broadcastUpdate: 'broadcast-cache-update',
+  rangeRequests: 'range-requests',
 };
 
 /**

--- a/test/workbox-range-requests/node/Plugin.mjs
+++ b/test/workbox-range-requests/node/Plugin.mjs
@@ -1,0 +1,9 @@
+import {expect} from 'chai';
+
+import {Plugin} from '../../../packages/workbox-range-requests/Plugin.mjs';
+
+describe(`[workbox-range-requests] Plugin`, function() {
+  it(`should expose a static cachedResponseWillBeUsed method`, function() {
+    expect(Plugin).itself.to.respondTo('cachedResponseWillBeUsed');
+  });
+});

--- a/test/workbox-range-requests/node/createPartialResponse.mjs
+++ b/test/workbox-range-requests/node/createPartialResponse.mjs
@@ -1,0 +1,55 @@
+import {expect} from 'chai';
+
+import {createPartialResponse} from '../../../packages/workbox-range-requests/createPartialResponse.mjs';
+
+describe(`[workbox-range-requests] createPartialResponse`, function() {
+  // This uses an interface that matches what our Blob mock currently supports.
+  // It's *not* the same way we'd use native browser implementation.
+  function constructBlob(length) {
+    let string = '';
+    for (let i = 0; i < length; i++) {
+      string += i % 10;
+    }
+    return new Blob([string]);
+  }
+
+  const SOURCE_BLOB_SIZE = 256;
+  const SOURCE_BLOB = constructBlob(SOURCE_BLOB_SIZE);
+
+  describe(`Tests for the createPartialResponse() function`, function() {
+    const VALID_REQUEST = new Request('/', {
+      headers: {
+        range: 'bytes=100-200',
+      },
+    });
+
+    const VALID_RESPONSE = new Response(SOURCE_BLOB);
+
+    it(`should return a Response with status 416 when the 'request' parameter isn't valid`, async function() {
+      const response = await createPartialResponse(null, VALID_RESPONSE);
+      expect(response.status).to.eql(416);
+    });
+
+    it(`should return a Response with status 416 when the 'response' parameter isn't valid`, async function() {
+      const response = await createPartialResponse(VALID_REQUEST, null);
+      expect(response.status).to.eql(416);
+    });
+
+    it(`should return a Response with status 416 when there's no Range: header in the request`, async function() {
+      const noRangeHeaderRequest = new Request('/');
+      const response = await createPartialResponse(noRangeHeaderRequest, VALID_RESPONSE);
+      expect(response.status).to.eql(416);
+    });
+
+    it(`should return the expected Response when it's called with valid parameters`, async function() {
+      const response = await createPartialResponse(VALID_REQUEST, VALID_RESPONSE);
+      expect(response.status).to.eql(206);
+      expect(response.headers.get('Content-Length')).to.eql(101);
+      expect(response.headers.get('Content-Range')).to.eql(`bytes 100-200/${SOURCE_BLOB_SIZE}`);
+
+      const responseBlob = await response.blob();
+      const expectedBlob = constructBlob(101);
+      expect(responseBlob._text).to.eql(expectedBlob._text);
+    });
+  });
+});

--- a/test/workbox-range-requests/node/exports.mjs
+++ b/test/workbox-range-requests/node/exports.mjs
@@ -1,0 +1,13 @@
+import {expect} from 'chai';
+
+import * as rangeRequests from '../../../packages/workbox-range-requests/index.mjs';
+
+describe(`[workbox-range-requests] exports`, function() {
+  const expectedExports = ['createPartialResponse', 'Plugin'];
+
+  for (const expectedExport of expectedExports) {
+    it(`should expose a ${expectedExport} property`, function() {
+      expect(rangeRequests).to.have.property(expectedExport);
+    });
+  }
+});

--- a/test/workbox-range-requests/node/utils/calculateEffectiveBoundaries.mjs
+++ b/test/workbox-range-requests/node/utils/calculateEffectiveBoundaries.mjs
@@ -1,0 +1,67 @@
+import {expect} from 'chai';
+
+import {calculateEffectiveBoundaries} from '../../../../packages/workbox-range-requests/utils/calculateEffectiveBoundaries.mjs';
+import expectError from '../../../../infra/testing/expectError';
+import {devOnly} from '../../../../infra/testing/env-it';
+
+describe(`[workbox-range-requests] utils/calculateEffectiveBoundaries`, function() {
+  // This uses an interface that matches what our Blob mock currently supports.
+  // It's *not* the same way we'd use native browser implementation.
+  function constructBlob(length) {
+    let string = '';
+    for (let i = 0; i < length; i++) {
+      string += i % 10;
+    }
+    return new Blob([string]);
+  }
+
+  const SOURCE_BLOB_SIZE = 256;
+  const SOURCE_BLOB = constructBlob(SOURCE_BLOB_SIZE);
+
+  devOnly.it(`should throw when it's is called with an invalid 'blob' parameter`, async function() {
+    const invalidBlob = null;
+    await expectError(
+      () => calculateEffectiveBoundaries(invalidBlob),
+      'incorrect-class', (error) => {
+        expect(error.details).to.have.property('moduleName', 'workbox-range-requests');
+        expect(error.details).to.have.property('funcName', 'calculateEffectiveBoundaries');
+        expect(error.details).to.have.property('paramName', 'blob');
+        expect(error.details).to.have.property('expectedClass', Blob);
+      }
+    );
+  });
+
+  it(`should throw when it's is called with a 'start' parameter less than zero`, async function() {
+    const start = -1;
+    const end = 1;
+    await expectError(
+      () => calculateEffectiveBoundaries(SOURCE_BLOB, start, end),
+      'range-not-satisfiable'
+    );
+  });
+
+  it(`should throw when it's is called with an 'end' parameter larger than the blob's size`, async function() {
+    const start = 0;
+    const end = SOURCE_BLOB_SIZE + 1;
+    await expectError(
+      () => calculateEffectiveBoundaries(SOURCE_BLOB, start, end),
+      'range-not-satisfiable'
+    );
+  });
+
+  it(`should return the expected boundaries when it's called with valid parameters`, function() {
+    const testCases = [
+      [{start: 100, end: 200}, {start: 100, end: 201}],
+      [{start: null, end: 200}, {start: 56, end: 256}],
+      [{start: 100, end: null}, {start: 100, end: 256}],
+    ];
+
+    for (const [sourceBoundaries, expectedBoundaries] of testCases) {
+      const calculatedBoundaries = calculateEffectiveBoundaries(
+        SOURCE_BLOB, sourceBoundaries.start, sourceBoundaries.end);
+
+      expect(expectedBoundaries).to.eql(calculatedBoundaries,
+        `for test case '${sourceBoundaries.start}-${sourceBoundaries.end}'`);
+    }
+  });
+});

--- a/test/workbox-range-requests/node/utils/parseRangeHeader.mjs
+++ b/test/workbox-range-requests/node/utils/parseRangeHeader.mjs
@@ -1,0 +1,66 @@
+import {expect} from 'chai';
+
+import {parseRangeHeader} from '../../../../packages/workbox-range-requests/utils/parseRangeHeader.mjs';
+import expectError from '../../../../infra/testing/expectError';
+import {devOnly} from '../../../../infra/testing/env-it';
+
+describe(`[workbox-range-requests] utils/parseRangeHeader`, function() {
+  devOnly.it(`should throw when it's is called with an invalid 'rangeHeader' parameter`, async function() {
+    const rangeHeader = null;
+    await expectError(
+      () => parseRangeHeader(rangeHeader),
+      'incorrect-type', (error) => {
+        expect(error.details).to.have.property('moduleName', 'workbox-range-requests');
+        expect(error.details).to.have.property('funcName', 'parseRangeHeader');
+        expect(error.details).to.have.property('paramName', 'rangeHeader');
+        expect(error.details).to.have.property('expectedType', 'string');
+      }
+    );
+  });
+
+  it(`should throw when it's is called with a rangeHeader that doesn't start with 'bytes='`, async function() {
+    const rangeHeader = 'not-bytes=';
+    await expectError(
+      () => parseRangeHeader(rangeHeader),
+      'unit-must-be-bytes'
+    );
+  });
+
+  it(`should throw when it's is called with a rangeHeader contains multiple ranges`, async function() {
+    const rangeHeader = 'bytes=1-2, 3-4';
+    await expectError(
+      () => parseRangeHeader(rangeHeader),
+      'single-range-only'
+    );
+  });
+
+  it(`should throw when it's is called with a rangeHeader contains invalid ranges`, async function() {
+    const badRanges = [
+      'invalid',
+      '-',
+      'abc-def',
+      '123 - 456',
+    ];
+
+    for (const badRange of badRanges) {
+      const rangeHeader = `bytes=${badRange}`;
+      await expectError(
+        () => parseRangeHeader(rangeHeader),
+        'invalid-range-values'
+      );
+    }
+  });
+
+  it(`should return the expected start and end values when it's is called with a valid rangeHeader`, function() {
+    const testCases = [
+      ['bytes=100-200', {start: 100, end: 200}],
+      ['bytes=-200', {start: null, end: 200}],
+      ['bytes=100-', {start: 100, end: null}],
+    ];
+
+    for (const [rangeHeader, expectedValue] of testCases) {
+      const boundaries = parseRangeHeader(rangeHeader);
+      expect(boundaries).to.eql(expectedValue, `for test case '${rangeHeader}'`);
+    }
+  });
+});


### PR DESCRIPTION
R: @addyosmani @gauntface

Fairly straightforward port of the `workbox-range-requests` code from v2, with some test changes to accommodate the mocked interfaces, and some additional error messages.

I updated the `workbox-sw` mapping, but I might be missing some other "meta" things that need to be changed when we add a new library.