### PR TITLE
Use importWorkboxFrom instead of importWorkboxFromCDN

### DIFF
--- a/packages/workbox-build/src/entry-points/generate-sw.js
+++ b/packages/workbox-build/src/entry-points/generate-sw.js
@@ -47,14 +47,14 @@ async function generateSW(config) {
 
   const destDirectory = path.dirname(options.swDest);
 
-  if (options.importWorkboxFromCDN) {
+  // Do nothing if importWorkboxFrom is set to 'disabled'. Otherwise, check:
+  if (options.importWorkboxFrom === 'cdn') {
     const cdnUrl = cdnUtils.getModuleUrl('workbox-sw');
     // importScripts may or may not already be an array containing other URLs.
     // Either way, list cdnUrl first.
     options.importScripts = [cdnUrl].concat(options.importScripts || []);
-  } else {
-    // If we're not importing the Workbox scripts from the CDN, then copy
-    // over the dev + prod version of all of the core libraries.
+  } else if (options.importWorkboxFrom === 'local') {
+    // Copy over the dev + prod version of all of the core libraries.
     const workboxDirectoryName = await copyWorkboxLibraries(destDirectory);
 
     // The Workbox library files should not be precached, since they're cached

--- a/packages/workbox-build/src/entry-points/options/defaults.js
+++ b/packages/workbox-build/src/entry-points/options/defaults.js
@@ -25,6 +25,6 @@ module.exports = {
   clientsClaim: false,
   navigateFallback: undefined,
   skipWaiting: false,
-  importWorkboxFromCDN: true,
+  importWorkboxFrom: 'cdn',
   injectionPointRegexp: /(\.precacheAndRoute\()\s*\[\s*\]\s*(\))/,
 };

--- a/packages/workbox-build/src/entry-points/options/generate-sw-schema.js
+++ b/packages/workbox-build/src/entry-points/options/generate-sw-schema.js
@@ -23,6 +23,10 @@ const defaults = require('./defaults');
 module.exports = commonGenerateSchema.keys({
   globDirectory: joi.string().required(),
   importScripts: joi.array().items(joi.string()),
-  importWorkboxFromCDN: joi.boolean().default(defaults.importWorkboxFromCDN),
+  importWorkboxFrom: joi.string().default(defaults.importWorkboxFrom).valid(
+    'cdn',
+    'local',
+    'disabled'
+  ),
   swDest: joi.string().required(),
 });

--- a/packages/workbox-build/src/lib/copy-workbox-libraries.js
+++ b/packages/workbox-build/src/lib/copy-workbox-libraries.js
@@ -39,7 +39,7 @@ const BUILD_TYPES = [
  * prefer not to use the CDN copies of Workbox. Developers using
  * [generateSW()]{@link module:workbox-build.generateSW} don't need to
  * explicitly call this method, as it's called automatically when
- * `importWorkboxFromCDN` is set to `false`.
+ * `importWorkboxFrom` is set to `local`.
  *
  * @param {string} destDirectory The path to the parent directory under which
  * the new directory of libraries will be created.

--- a/test/workbox-build/node/entry-points/generate-sw-string.js
+++ b/test/workbox-build/node/entry-points/generate-sw-string.js
@@ -35,7 +35,7 @@ describe(`[workbox-build] entry-points/generate-sw-string.js (End to End)`, func
     'templatedUrls',
   ].concat(REQUIRED_PARAMS);
   const UNSUPPORTED_PARAMS = [
-    'importWorkboxFromCDN',
+    'importWorkboxFrom',
     'injectionPointRegexp',
     'swDest',
     'swSrc',

--- a/test/workbox-build/node/entry-points/generate-sw.js
+++ b/test/workbox-build/node/entry-points/generate-sw.js
@@ -32,7 +32,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
     'globStrict',
     'ignoreUrlParametersMatching',
     'importScripts',
-    'importWorkboxFromCDN',
+    'importWorkboxFrom',
     'manifestTransforms',
     'maximumFileSizeToCacheInBytes',
     'modifyUrlPrefix',
@@ -132,11 +132,11 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       }});
     });
 
-    it(`should use defaults and make local copies of the Workbox libraries when importWorkboxFromCDN is false`, async function() {
+    it(`should use defaults and make local copies of the Workbox libraries when importWorkboxFrom is 'local'`, async function() {
       const swDest = path.join(tempy.directory(), 'sw.js');
       const options = Object.assign({}, BASE_OPTIONS, {
         swDest,
-        importWorkboxFromCDN: false,
+        importWorkboxFrom: 'local',
       });
 
       const {count, size} = await generateSW(options);
@@ -241,7 +241,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       const options = Object.assign({}, BASE_OPTIONS, {
         globDirectory,
         swDest,
-        importWorkboxFromCDN: false,
+        importWorkboxFrom: 'local',
       });
 
       const {count, size} = await generateSW(options);

--- a/test/workbox-build/node/entry-points/get-manifest.js
+++ b/test/workbox-build/node/entry-points/get-manifest.js
@@ -28,7 +28,7 @@ describe(`[workbox-build] entry-points/get-manifest.js (End to End)`, function()
     'directoryIndex',
     'ignoreUrlParametersMatching',
     'importScripts',
-    'importWorkboxFromCDN',
+    'importWorkboxFrom',
     'injectionPointRegexp',
     'navigateFallback',
     'navigateFallbackWhitelist',

--- a/test/workbox-build/node/entry-points/inject-manifest.js
+++ b/test/workbox-build/node/entry-points/inject-manifest.js
@@ -37,7 +37,7 @@ describe(`[workbox-build] entry-points/inject-manifest.js (End to End)`, functio
     'directoryIndex',
     'ignoreUrlParametersMatching',
     'importScripts',
-    'importWorkboxFromCDN',
+    'importWorkboxFrom',
     'navigateFallback',
     'navigateFallbackWhitelist',
     'runtimeCaching',


### PR DESCRIPTION
R: @gauntface

This is part of the work for #933.

I wanted to break it into multiple PRs, which this one just covering the removal of `importWorkboxFromCDN` and addition of `importWorkboxFrom`.

I'll put together a separate PR to support `importWorkboxFrom` in the `workbox-webpack-plugin`, since that requires introducing `joi` as a dependency in the webpack package, and will end up being a fair chunk of independent work to modify how we deal with options there.