### PR TITLE
Adds ability to add plugins to precaching lifecycle

### DIFF
--- a/packages/workbox-precaching/_default.mjs
+++ b/packages/workbox-precaching/_default.mjs
@@ -28,6 +28,7 @@ if (process.env.NODE_ENV !== 'production') {
 let installActivateListenersAdded = false;
 let fetchListenersAdded = false;
 let suppressWarnings = false;
+let plugins = [];
 
 const cacheName = cacheNames.getPrecacheName();
 const precacheController = new PrecacheController(cacheName);
@@ -149,7 +150,10 @@ moduleExports.precache = (entries) => {
 
   installActivateListenersAdded = true;
   self.addEventListener('install', (event) => {
-    event.waitUntil(precacheController.install({suppressWarnings}));
+    event.waitUntil(precacheController.install({
+      suppressWarnings,
+      plugins,
+    }));
   });
   self.addEventListener('activate', (event) => {
     event.waitUntil(precacheController.cleanup());
@@ -252,6 +256,17 @@ moduleExports.precacheAndRoute = (entries, options) => {
  */
 moduleExports.suppressWarnings = (suppress) => {
   suppressWarnings = suppress;
+};
+
+/**
+ * Add plugins to precaching.
+ *
+ * @param {Array<Object>} newPlugins
+ *
+ * @alias workbox.precaching.suppressWarnings
+ */
+moduleExports.addPlugins = (newPlugins) => {
+  plugins = plugins.concat(newPlugins);
 };
 
 export default moduleExports;

--- a/packages/workbox-precaching/_default.mjs
+++ b/packages/workbox-precaching/_default.mjs
@@ -263,7 +263,7 @@ moduleExports.suppressWarnings = (suppress) => {
  *
  * @param {Array<Object>} newPlugins
  *
- * @alias workbox.precaching.suppressWarnings
+ * @alias workbox.precaching.addPlugins
  */
 moduleExports.addPlugins = (newPlugins) => {
   plugins = plugins.concat(newPlugins);

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -143,6 +143,8 @@ class PrecacheController {
    *
    * @param {Object} options
    * @param {boolean} options.suppressWarnings Suppress warning messages.
+   * @param {Array<Object>} options.plugins Plugins to be used for fetching
+   * and caching during install.
    * @return {
    * Promise<module:workbox-precaching.PrecacheController.InstallResult>}
    */

--- a/test/workbox-precaching/node/controllers/test-default.mjs
+++ b/test/workbox-precaching/node/controllers/test-default.mjs
@@ -345,9 +345,44 @@ describe(`[workbox-precaching] default export`, function() {
 
       await installPromise;
 
-      expect(PrecacheController.prototype.install.args[0][0]).to.deep.equal({
-        suppressWarnings: true,
+      expect(PrecacheController.prototype.install.args[0][0].suppressWarnings).to.equal(true);
+    });
+  });
+
+  describe(`addPlugins()`, function() {
+    it(`should add plugins during install`, async function() {
+      let eventCallbacks = {};
+      sandbox.stub(self, 'addEventListener').callsFake((eventName, cb) => {
+        eventCallbacks[eventName] = cb;
       });
+      sandbox.spy(PrecacheController.prototype, 'install');
+
+      const precacheArgs = ['/'];
+
+      const plugin1 = {
+        name: 'plugin1',
+      };
+      const plugin2 = {
+        name: 'plugin2',
+      };
+
+      precaching.precache(precacheArgs);
+      precaching.addPlugins([plugin1]);
+      precaching.addPlugins([plugin2]);
+
+      const installEvent = new ExtendableEvent('install');
+      let installPromise;
+      installEvent.waitUntil = (promise) => {
+        installPromise = promise;
+      };
+      eventCallbacks['install'](installEvent);
+
+      await installPromise;
+
+      expect(PrecacheController.prototype.install.args[0][0].plugins).to.deep.equal([
+        plugin1,
+        plugin2,
+      ]);
     });
   });
 });

--- a/test/workbox-precaching/node/test-precaching-module.mjs
+++ b/test/workbox-precaching/node/test-precaching-module.mjs
@@ -34,6 +34,7 @@ describe(`[workbox-precaching] Module`, function() {
         'addRoute',
         'precacheAndRoute',
         'suppressWarnings',
+        'addPlugins',
       ]);
     });
 


### PR DESCRIPTION
R: @jeffposnick 

This adds plugins to precaching so a developer could add in the broadcast cache update behavior if they want it.

```javascript
workbox.precaching.addPlugins([
    new workbox.broadcastUpdate.Plugin({ channelName: 'example-channel' })
]);
```
