### PR TITLE
Support for importWorkboxFrom: <chunkname> and associated fixes

### DIFF
--- a/packages/workbox-build/src/entry-points/options/defaults.js
+++ b/packages/workbox-build/src/entry-points/options/defaults.js
@@ -16,7 +16,7 @@
 
 module.exports = {
   globFollow: true,
-  globIgnores: ['node_modules/**/*'],
+  globIgnores: ['**/node_modules/**/*'],
   globPatterns: ['**/*.{js,css,html}'],
   globStrict: true,
   // Use a different default for generateSWString.

--- a/packages/workbox-webpack-plugin/src/index.js
+++ b/packages/workbox-webpack-plugin/src/index.js
@@ -59,8 +59,7 @@ class WorkboxWebpackPlugin {
   }
 
   /**
-   * @param compilation
-   * @return {Promise.<void>}
+   * @param {Object} compilation The webpack compilation.
    * @private
    */
   async handleEmit(compilation) {

--- a/packages/workbox-webpack-plugin/src/lib/generate-or-copy-sw.js
+++ b/packages/workbox-webpack-plugin/src/lib/generate-or-copy-sw.js
@@ -31,8 +31,7 @@ function sanitizeConfig(config) {
   const propertiesToRemove = [
     'chunks',
     'excludeChunks',
-    'filename',
-    'manifestFilename',
+    'importWorkboxFrom',
   ];
 
   for (const property of propertiesToRemove) {

--- a/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-with-webpack.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-with-webpack.js
@@ -159,8 +159,8 @@ function getKnownHashesFromAssets(assetMetadata) {
  * @private
  */
 module.exports = (compilation, config) => {
-  const blacklistedChunkNames = config.excludeChunks || [];
-  const whitelistedChunkNames = config.chunks || [];
+  const blacklistedChunkNames = config.excludeChunks;
+  const whitelistedChunkNames = config.chunks;
   const {assets, chunks} = compilation;
   const {publicPath} = compilation.options.output;
 

--- a/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-with-webpack.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-with-webpack.js
@@ -53,47 +53,103 @@ function getEntry(knownHashes, url, revision) {
  *  but filter for [/\.map$/, /asset-manifest\.json$/] by default:
  *    https://github.com/GoogleChrome/workbox/pull/808#discussion_r140565156
  *
- * @param {Array<Object>} chunks webpack chunks.
+ * @param {Object<string, Object>} assetMetadata Metadata about the assets.
  * @param {Array<string>} [whitelist] Chunk names to include.
  * @param {Array<string>} [blacklist] Chunk names to exclude.
- * @return {Array<Object>} Filtered array of chunks.
+ * @return {Object<string, Object>} Filtered asset metadata.
  *
  * @private
  */
-function filterChunks(chunks, whitelist, blacklist) {
-  return chunks.filter((chunk) => {
-    return 'name' in chunk &&
-      (!whitelist || whitelist.includes(chunk.name)) &&
-      (!blacklist || !blacklist.includes(chunk.name));
-  });
+function filterAssets(assetMetadata, whitelist, blacklist) {
+  const filteredMapping = {};
+
+  for (const [file, metadata] of Object.entries(assetMetadata)) {
+    const chunkName = metadata.chunkName;
+    // This file is whitelisted if:
+    // - Trivially, if there is no whitelist defined.
+    // - There is a whitelist and our file is associated with a chunk whose name
+    // is listed.
+    const isWhitelisted = whitelist.length === 0 ||
+      whitelist.includes(chunkName);
+
+    // This file is blacklisted if our file is associated with a chunk whose
+    // name is listed.
+    const isBlacklisted = blacklist.includes(chunkName);
+
+    // Only include this entry in the filtered mapping if we're whitelisted and
+    // not blacklisted.
+    if (isWhitelisted && !isBlacklisted) {
+      filteredMapping[file] = metadata;
+    }
+  }
+
+  return filteredMapping;
 }
 
 /**
- * Takes in a list of webpack chunks, and returns a mapping of the path for each
- * file in the chunk to the associated hash for the entire chunk.
+ * Takes in compilation.assets and compilation.chunks, and assigns metadata
+ * to each file listed in assets:
  *
- * @param {Array<Object>} chunks The webpack chunks.
- * @return {Object<string, string>} Mapping of paths to hashes.
+ * - If the asset was created by a chunk, it assigns the existing chunk name and
+ * chunk hash.
+ * - If the asset was created outside of a chunk, it assigns a chunk name of ''
+ * and generates a hash of the asset.
+ *
+ * @param {Object} assets The compilation.assets
+ * @param {Array<Object>} chunks The compilation.chunks
+ * @return {Object<string, Object>} Mapping of asset paths to chunk name and
+ * hash metadata.
  *
  * @private
  */
-function mapChunksToChunkHashes(chunks) {
+function generateMetadataForAssets(assets, chunks) {
   const mapping = {};
+
+  // Start out by getting metadata for all the assets associated with a chunk.
   for (const chunk of chunks) {
     for (const file of chunk.files) {
-      mapping[file] = chunk.renderedHash;
+      mapping[file] = {
+        chunkName: chunk.name,
+        hash: chunk.renderedHash,
+      };
     }
   }
+
+  // Next, loop through the total list of assets and find anything that isn't
+  // associated with a chunk.
+  for (const [file, asset] of Object.entries(assets)) {
+    if (file in mapping) {
+      continue;
+    }
+
+    mapping[file] = {
+      // Just use an empty string to denote the lack of chunk association.
+      chunkName: '',
+      hash: getAssetHash(asset),
+    };
+  }
+
   return mapping;
 }
 
 /**
- * Generate an array of manifest entries using webpack's compilation data
+ * Given an assetMetadata mapping, returns a Set of all of the hashes that
+ * are associated with at least one asset.
  *
- * TODO:
- *   Rename variables so they are easier to understand:
- *      https://github.com/GoogleChrome/workbox/pull/808#discussion_r139605624
- *      https://github.com/GoogleChrome/workbox/pull/808#discussion_r139605973
+ * @param {Object<string, Object>} assetMetadata Mapping of asset paths to chunk
+ * name and hash metadata.
+ * @return {Set} The known hashes associated with an asset.
+ */
+function getKnownHashesFromAssets(assetMetadata) {
+  const knownHashes = new Set();
+  for (const metadata of Object.values(assetMetadata)) {
+    knownHashes.add(metadata.hash);
+  }
+  return knownHashes;
+}
+
+/**
+ * Generate an array of manifest entries using webpack's compilation data.
  *
  * @function getManifestEntriesWithWebpack
  * @param {Object} compilation webpack compilation
@@ -103,46 +159,25 @@ function mapChunksToChunkHashes(chunks) {
  * @private
  */
 module.exports = (compilation, config) => {
+  const blacklistedChunkNames = config.excludeChunks || [];
+  const whitelistedChunkNames = config.chunks || [];
+  const {assets, chunks} = compilation;
   const {publicPath} = compilation.options.output;
-  const whitelistedChunkNames = config.chunks;
-  const blacklistedChunkNames = config.excludeChunks;
-  let {
-    assets,
-    chunks,
-  } = compilation;
 
-  // If specified, only include chunks in config.chunks and exclude any chunks
-  // named in config.excludeChunks.
-  if (whitelistedChunkNames || blacklistedChunkNames) {
-    chunks = filterChunks(chunks, whitelistedChunkNames, blacklistedChunkNames);
-  }
+  const assetMetadata = generateMetadataForAssets(assets, chunks);
+  const filteredAssetMetadata = filterAssets(assetMetadata,
+    whitelistedChunkNames, blacklistedChunkNames);
 
-  // Map all of the paths from the named chunks to their associated hashes.
-  const pathsToHashes = mapChunksToChunkHashes(chunks);
-
-  // If we're not in whitelist mode, then also include the paths we can infer
-  // from compilation.assets in the final output.
-  if (!whitelistedChunkNames) {
-    for (const [filePath, asset] of Object.entries(assets)) {
-      // If we already have a hash because this filePath was part of a chunk's
-      // files, then we can skip calculating a hash.
-      if (!(filePath in pathsToHashes)) {
-        pathsToHashes[filePath] = getAssetHash(asset);
-      }
-    }
-  }
-
-  let knownHashes = [compilation.hash, compilation.fullHash];
-  for (const chunk of compilation.chunks) {
-    knownHashes.push(chunk.hash, chunk.renderedHash);
-  }
-  // Make sure we don't have any empty/undefined hashes.
-  knownHashes = knownHashes.filter((hash) => !!hash);
+  const knownHashes = [
+    compilation.hash,
+    compilation.fullHash,
+    ...getKnownHashesFromAssets(filteredAssetMetadata),
+  ].filter((hash) => !!hash);
 
   const manifestEntries = [];
-  for (const [filePath, hash] of Object.entries(pathsToHashes)) {
-    const publicUrl = resolveWebpackUrl(publicPath, filePath);
-    const manifestEntry = getEntry(knownHashes, publicUrl, hash);
+  for (const [file, metadata] of Object.entries(filteredAssetMetadata)) {
+    const publicUrl = resolveWebpackUrl(publicPath, file);
+    const manifestEntry = getEntry(knownHashes, publicUrl, metadata.hash);
     manifestEntries.push(manifestEntry);
   }
   return manifestEntries;

--- a/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-with-webpack.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-with-webpack.js
@@ -139,6 +139,8 @@ function generateMetadataForAssets(assets, chunks) {
  * @param {Object<string, Object>} assetMetadata Mapping of asset paths to chunk
  * name and hash metadata.
  * @return {Set} The known hashes associated with an asset.
+ *
+ * @private
  */
 function getKnownHashesFromAssets(assetMetadata) {
   const knownHashes = new Set();

--- a/test/workbox-build/node/entry-points/options/validate.js
+++ b/test/workbox-build/node/entry-points/options/validate.js
@@ -25,7 +25,7 @@ describe(`[workbox-build] entry-points/options/validate.js`, function() {
 
     expect(options).to.eql({
       globFollow: true,
-      globIgnores: ['node_modules/**/*'],
+      globIgnores: ['**/node_modules/**/*'],
       globPatterns: ['**/*.{js,css,html}'],
       globStrict: true,
       maximumFileSizeToCacheInBytes: 2097152,
@@ -38,7 +38,7 @@ describe(`[workbox-build] entry-points/options/validate.js`, function() {
 
     expect(options).to.eql({
       globFollow: true,
-      globIgnores: ['node_modules/**/*'],
+      globIgnores: ['**/node_modules/**/*'],
       globPatterns: ['**/*.{js,css,html}'],
       globStrict: true,
       maximumFileSizeToCacheInBytes,
@@ -52,7 +52,7 @@ describe(`[workbox-build] entry-points/options/validate.js`, function() {
     expect(options).to.eql({
       dontCacheBustUrlsMatching,
       globFollow: true,
-      globIgnores: ['node_modules/**/*'],
+      globIgnores: ['**/node_modules/**/*'],
       globPatterns: ['**/*.{js,css,html}'],
       globStrict: true,
       maximumFileSizeToCacheInBytes: 2097152,


### PR DESCRIPTION
R: @prateekbh @gauntface @goldhand 

This is another follow-up to #933, but doesn't close it yet, as there's still a TODO: to implement `importWorkboxFrom: 'local'`. This PR was large enough already so I wanted to break it up further.

I included a refactoring of a decent chunk of `get-manifest-entries-with-webpack.js` in this PR, because I discovered that it wasn't properly filtering out all assets based on the `chunks`/`excludeChunks` whitelist/blacklist. That became an issue since `importWorkboxFrom: <chunkname>` is supposed to implicitly add `<chunkname>` to the blacklist.

This also includes a few more relevant tests, both to ensure that `importWorkboxFrom: <chunkname>` works as expected, as well as ensure that whitelist/blacklist behavior works in general.

Finally, I discovered that errors which occurred in the previous codebase would lead to a promise being rejected within the plugin's execution, but that failure wouldn't be bubbled up as a webpack error. This refactors the error detection so that asynchronous failures will be properly reported via the webpack callback (and includes a test for that condition).