### PR TITLE
Add in asset filename filtering via {test, include, exclude}

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7181,6 +7181,12 @@
         }
       }
     },
+    "generate-asset-webpack-plugin": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/generate-asset-webpack-plugin/-/generate-asset-webpack-plugin-0.3.0.tgz",
+      "integrity": "sha1-ZmLvgDP21DMMeImBZGHOJWgxMxg=",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -16473,19 +16479,6 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
-    },
-    "shelving-mock-event": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/shelving-mock-event/-/shelving-mock-event-1.0.12.tgz",
-      "integrity": "sha512-2F+IZ010rwV3sA/Kd2hnC1vGNycsxeBJmjkXR8+4IOlv5e+Wvj+xH+A8Cv8/Z0lUyCut/HcxSpeDccYTVtnuaQ==",
-      "dev": true
-    },
-    "shelving-mock-indexeddb": {
-      "version": "github:philipwalton/shelving-mock-indexeddb#594ec7fa09a910019fd6e5fa22128d02a0e14a55",
-      "dev": true,
-      "requires": {
-        "shelving-mock-event": "1.0.12"
-      }
     },
     "sigmund": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "firebase-tools": "^3.13.1",
     "fs-extra": "^4.0.1",
     "geckodriver": "^1.8.1",
+    "generate-asset-webpack-plugin": "^0.3.0",
     "github": "^12.0.1",
     "glob": "^7.1.2",
     "gulp": "github:gulpjs/gulp#4.0",

--- a/packages/workbox-webpack-plugin/package.json
+++ b/packages/workbox-webpack-plugin/package.json
@@ -31,6 +31,9 @@
     "json-stable-stringify": "^1.0.1",
     "workbox-build": "^3.0.0-alpha.3"
   },
+  "peerDependencies": {
+    "webpack": "^2.0.0 || ^3.0.0"
+  },
   "author": "Will Farley <a.will.farley@gmail.com> (http://www.willfarley.org/)",
   "license": "Apache-2.0",
   "repository": "googlechrome/workbox",

--- a/packages/workbox-webpack-plugin/src/generate-sw.js
+++ b/packages/workbox-webpack-plugin/src/generate-sw.js
@@ -45,6 +45,12 @@ class GenerateSW {
   constructor(config = {}) {
     this.config = Object.assign({}, {
       chunks: [],
+      exclude: [
+        // Exclude source maps.
+        /\.map$/,
+        // Exclude anything starting with manifest and ending .js or .json.
+        /^manifest.*\.js(?:on)?$/,
+      ],
       excludeChunks: [],
       importScripts: [],
       importWorkboxFrom: 'cdn',

--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -52,6 +52,12 @@ class InjectManifest {
 
     this.config = Object.assign({}, {
       chunks: [],
+      exclude: [
+        // Exclude source maps.
+        /\.map$/,
+        // Exclude anything starting with manifest and ending .js or .json.
+        /^manifest.*\.js(?:on)?$/,
+      ],
       excludeChunks: [],
       importScripts: [],
       importWorkboxFrom: 'cdn',

--- a/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-from-compilation.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-from-compilation.js
@@ -14,6 +14,8 @@
   limitations under the License.
 */
 
+const ModuleFilenameHelpers = require('webpack/lib/ModuleFilenameHelpers');
+
 const getAssetHash = require('./get-asset-hash');
 const resolveWebpackUrl = require('./resolve-webpack-url');
 
@@ -177,6 +179,13 @@ function getManifestEntriesFromCompilation(compilation, config) {
 
   const manifestEntries = [];
   for (const [file, metadata] of Object.entries(filteredAssetMetadata)) {
+    // Filter based on test/include/exclude options set in the webpack config.
+    // See https://github.com/GoogleChrome/workbox/issues/935#issue-267021143 and
+    // https://github.com/webpack-contrib/uglifyjs-webpack-plugin/blob/025262284c86196d0a4c4fe71e186132579629ec/src/index.js
+    if (!ModuleFilenameHelpers.matchObject(config, file)) {
+      continue;
+    }
+
     const publicUrl = resolveWebpackUrl(publicPath, file);
     const manifestEntry = getEntry(knownHashes, publicUrl, metadata.hash);
     manifestEntries.push(manifestEntry);

--- a/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-from-compilation.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-from-compilation.js
@@ -179,9 +179,9 @@ function getManifestEntriesFromCompilation(compilation, config) {
 
   const manifestEntries = [];
   for (const [file, metadata] of Object.entries(filteredAssetMetadata)) {
-    // Filter based on test/include/exclude options set in the webpack config.
-    // See https://github.com/GoogleChrome/workbox/issues/935#issue-267021143 and
-    // https://github.com/webpack-contrib/uglifyjs-webpack-plugin/blob/025262284c86196d0a4c4fe71e186132579629ec/src/index.js
+    // Filter based on test/include/exclude options set in the config,
+    // following webpack's conventions.
+    // This matches the behavior of, e.g., UglifyJS's webpack plugin.
     if (!ModuleFilenameHelpers.matchObject(config, file)) {
       continue;
     }

--- a/packages/workbox-webpack-plugin/src/lib/sanitize-config.js
+++ b/packages/workbox-webpack-plugin/src/lib/sanitize-config.js
@@ -25,11 +25,14 @@
 function forGetManifest(originalConfig) {
   const propertiesToRemove = [
     'chunks',
+    'exclude',
     'excludeChunks',
     'importScripts',
     'importWorkboxFrom',
+    'include',
     'swDest',
     'swSrc',
+    'test',
   ];
 
   return sanitizeConfig(originalConfig, propertiesToRemove);
@@ -46,9 +49,12 @@ function forGetManifest(originalConfig) {
 function forGenerateSWString(originalConfig) {
   const propertiesToRemove = [
     'chunks',
+    'exclude',
     'excludeChunks',
     'importWorkboxFrom',
+    'include',
     'swDest',
+    'test',
   ];
 
   return sanitizeConfig(originalConfig, propertiesToRemove);

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -1,4 +1,5 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const GenerateAssetPlugin = require('generate-asset-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const expect = require('chai').expect;
 const fse = require('fs-extra');
@@ -639,6 +640,258 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           }, {
             revision: '452b0a9f3978190f4c77997ab23473db',
             url: 'images/example-jpeg.jpg',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+  });
+
+  describe(`[workbox-webpack-plugin] Filtering via test/include/exclude`, function() {
+    const TEST_ASSET_CB = (compilation, callback) => callback(null, 'test');
+
+    it(`should exclude .map and manifest.js(on) files by default`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.43591bdf46c7ac47eb8d7b2bcd41f13e.js';
+      const outputDir = tempy.directory();
+      const config = {
+        entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        output: {
+          filename: WEBPACK_ENTRY_FILENAME,
+          path: outputDir,
+        },
+        devtool: 'source-map',
+        plugins: [
+          new GenerateAssetPlugin({
+            filename: 'manifest.js',
+            fn: TEST_ASSET_CB,
+          }),
+          new GenerateAssetPlugin({
+            filename: 'manifest.json',
+            fn: TEST_ASSET_CB,
+          }),
+          new InjectManifest({
+            swSrc: SW_SRC,
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError) => {
+        if (webpackError) {
+          return done(webpackError);
+        }
+
+        const swFile = path.join(outputDir, path.basename(SW_SRC));
+        try {
+          // First, validate that the generated service-worker.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [[
+              FILE_MANIFEST_NAME,
+              WORKBOX_SW_FILE_NAME,
+            ]],
+            suppressWarnings: [[]],
+            precacheAndRoute: [[[], {}]],
+          }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            revision: '8e8e9f093f036bd18dfa',
+            url: 'webpackEntry.js',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+
+    it(`should allow developers to override the default exclude filter`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.b87ef85173e527290f94979b09e72d12.js';
+      const outputDir = tempy.directory();
+      const config = {
+        entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        output: {
+          filename: WEBPACK_ENTRY_FILENAME,
+          path: outputDir,
+        },
+        devtool: 'source-map',
+        plugins: [
+          new InjectManifest({
+            exclude: [],
+            swSrc: SW_SRC,
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError) => {
+        if (webpackError) {
+          return done(webpackError);
+        }
+
+        const swFile = path.join(outputDir, path.basename(SW_SRC));
+        try {
+          // First, validate that the generated service-worker.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [[
+              FILE_MANIFEST_NAME,
+              WORKBOX_SW_FILE_NAME,
+            ]],
+            suppressWarnings: [[]],
+            precacheAndRoute: [[[], {}]],
+          }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            revision: '8e8e9f093f036bd18dfa',
+            url: 'webpackEntry.js.map',
+          }, {
+            revision: '8e8e9f093f036bd18dfa',
+            url: 'webpackEntry.js',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+
+    it(`should allow developers to whitelist via include`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.1242f9e007897f035a52e56690ff17a6.js';
+      const outputDir = tempy.directory();
+      const config = {
+        entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        output: {
+          filename: WEBPACK_ENTRY_FILENAME,
+          path: outputDir,
+        },
+        devtool: 'source-map',
+        plugins: [
+          new CopyWebpackPlugin([{
+            from: SRC_DIR,
+            to: outputDir,
+          }]),
+          new InjectManifest({
+            include: [/.html$/],
+            swSrc: SW_SRC,
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError) => {
+        if (webpackError) {
+          return done(webpackError);
+        }
+
+        const swFile = path.join(outputDir, path.basename(SW_SRC));
+        try {
+          // First, validate that the generated service-worker.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [[
+              FILE_MANIFEST_NAME,
+              WORKBOX_SW_FILE_NAME,
+            ]],
+            suppressWarnings: [[]],
+            precacheAndRoute: [[[], {}]],
+          }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+            url: 'page-2.html',
+          }, {
+            revision: '544658ab25ee8762dc241e8b1c5ed96d',
+            url: 'page-1.html',
+          }, {
+            revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+            url: 'index.html',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+
+    it(`should allow developers to combine the test and exclude filters`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.83df65831eb442f8ad5fbeb8edecc558.js';
+      const outputDir = tempy.directory();
+      const config = {
+        entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        output: {
+          filename: WEBPACK_ENTRY_FILENAME,
+          path: outputDir,
+        },
+        devtool: 'source-map',
+        plugins: [
+          new CopyWebpackPlugin([{
+            from: SRC_DIR,
+            to: outputDir,
+          }]),
+          new InjectManifest({
+            swSrc: SW_SRC,
+            test: [/.html$/],
+            exclude: [/index/],
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError) => {
+        if (webpackError) {
+          return done(webpackError);
+        }
+
+        const swFile = path.join(outputDir, path.basename(SW_SRC));
+        try {
+          // First, validate that the generated service-worker.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [[
+              FILE_MANIFEST_NAME,
+              WORKBOX_SW_FILE_NAME,
+            ]],
+            suppressWarnings: [[]],
+            precacheAndRoute: [[[], {}]],
+          }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+            url: 'page-2.html',
+          }, {
+            revision: '544658ab25ee8762dc241e8b1c5ed96d',
+            url: 'page-1.html',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface
CC: @anilanar

Fixes #935

As mentioned in the comments/the original issue, this takes advantage of a pattern native to webpack and used in other plugins (like UglifyJS) for filtering the precache manifest of webpack assets based on an object with `test`, `include`, and `exclude` properties.

It defaults to using RegExps for `exclude` that will match `.map` files and `manifest*.js(on)` files. While webpack gives developers flexibility to name their sourcemaps and asset manifest files whatever they'd like, those seem like the most common naming schemes (and they can be overridden).

The drawback of this PR is that it makes filtering more complicated: prior to this PR we implemented filtering based on chunk name white/blacklists, and now this introduces filtering based on asset name white/blacklists. (The chunk filtering is run first, then asset filtering.) There seems to be developer demand for supporting both, but this is another thing to try to explain clearly in the docs update (https://github.com/google/WebFundamentals/issues/5567).