### PR TITLE
Throwing error instead of re registering sync on failure

### DIFF
--- a/packages/workbox-core/models/messages/messages.mjs
+++ b/packages/workbox-core/models/messages/messages.mjs
@@ -128,6 +128,10 @@ export default {
       `registered.`;
   },
 
+  'queue-replay-failed': ({name, count}) => {
+    return `${count} requests failed, while trying to replay Queue: ${name}.`;
+  },
+
   'duplicate-queue-name': ({name}) => {
     return `The Queue name '${name}' is already being used. ` +
         `All instances of backgroundSync.Queue must be given unique names.`;

--- a/test/workbox-background-sync/node/lib/test-Queue.mjs
+++ b/test/workbox-background-sync/node/lib/test-Queue.mjs
@@ -23,6 +23,7 @@ import {DB_NAME, OBJECT_STORE_NAME} from
 import {DBWrapper} from '../../../../packages/workbox-core/_private/DBWrapper.mjs';
 import {resetEventListeners} from
     '../../../../infra/testing/sw-env-mocks/event-listeners.js';
+import {WorkboxError} from '../../../../packages/workbox-core/_private/WorkboxError.mjs';
 
 const getObjectStoreEntries = async () => {
   return await new DBWrapper(DB_NAME, 1).getAll(OBJECT_STORE_NAME);
@@ -304,10 +305,10 @@ describe(`[workbox-background-sync] Queue`, function() {
         return;
       }
 
-      return Promise.reject('should have exit from catch');
+      throw new Error('should have exit from catch');
     });
 
-    it(`should reject replayRequests promise if re-fetching fails`,
+    it(`should throw WorkboxError if re-fetching fails`,
         async function() {
       sandbox.stub(self, 'fetch')
           .onCall(1).rejects(new Error())
@@ -324,12 +325,11 @@ describe(`[workbox-background-sync] Queue`, function() {
       try {
         await queue.replayRequests(); // The second request should fail.
       } catch (error) {
-        expect(error.length).to.be.equal(1);
-        expect(error[0].url).to.be.equal(failureURL);
+        expect(error).to.be.instanceof(WorkboxError);
         return;
       }
 
-      return Promise.reject('should have exit from catch');
+      throw new Error('should have exit from catch');
     });
 
     it(`should invoke all replay callbacks`, async function() {


### PR DESCRIPTION
R:  @philipwalton 
CC: @jeffposnick @addyosmani @gauntface

Fixes #1145

Currently, on any failures in queue replay it results in re-registering of sync queue tag.
This causes infinite loop in case of `offline` from devtools + IIRC will not re-play the failed requests as this will re-register the same tag and also resolve the promise inside `event.waitUntil` of `sync` event. Hence telling the browser that we've successfully done everything related to this tag.

Instead to indicate any failure it is require that the promise passed to `event.waitUntil` should be rejected. ref: https://github.com/WICG/BackgroundSync/blob/master/explainer.md#the-api

> The promise passed to waitUntil is a signal to the user agent that the sync event is ongoing and that it should keep the service worker alive if possible. Rejection of the event signals to the user agent that the sync failed. Upon rejection the user agent should reschedule (likely with a user agent determined backoff).
