### PR TITLE
Update gulp patterns

### DIFF
--- a/gulp-tasks/analyze-properties.js
+++ b/gulp-tasks/analyze-properties.js
@@ -1,14 +1,24 @@
 const gulp = require('gulp');
 
+const build = require('./build');
+
 const AnalyseBuildForProperties = require('./utils/analyse-properties');
 
-gulp.task('analyze-properties:run', async () => {
+const runAnalyzeProperties = async () => {
   const analysisTool = new AnalyseBuildForProperties();
   const results = await analysisTool.run();
   results.forEach((entry) => {
     analysisTool.printDetails(entry);
   });
-});
+};
+runAnalyzeProperties.displayName = 'analyze-properties:run';
+// GULP: Is this exposed to the CLI?
+gulp.task(runAnalyzeProperties);
 
-gulp.task('analyze-properties',
-  gulp.series(['build', 'analyze-properties:run']));
+const analyzeProperties = gulp.series(
+  build,
+  runAnalyzeProperties,
+);
+analyzeProperties.displayName = 'analyze-properties';
+
+module.exports = analyzeProperties;

--- a/gulp-tasks/analyze-properties.js
+++ b/gulp-tasks/analyze-properties.js
@@ -12,8 +12,6 @@ const runAnalyzeProperties = async () => {
   });
 };
 runAnalyzeProperties.displayName = 'analyze-properties:run';
-// GULP: Is this exposed to the CLI?
-gulp.task(runAnalyzeProperties);
 
 const analyzeProperties = gulp.series(
   build,

--- a/gulp-tasks/build-browser-packages.js
+++ b/gulp-tasks/build-browser-packages.js
@@ -14,8 +14,6 @@ const browserBundle = gulp.series(
   ))
 );
 browserBundle.displayName = 'build-browser-packages:browser-bundle';
-// GULP: Is this exposed to the CLI?
-gulp.task(browserBundle);
 
 const version = gulp.series(
   Object.keys(constants.BUILD_TYPES).map((buildKey) => packageRunnner(
@@ -26,8 +24,6 @@ const version = gulp.series(
   ))
 );
 version.displayName = 'build-browser-packages:version-module';
-// GULP: Is this exposed to the CLI?
-gulp.task(version);
 
 const buildPackages = gulp.series(
   version,

--- a/gulp-tasks/build-browser-packages.js
+++ b/gulp-tasks/build-browser-packages.js
@@ -5,25 +5,34 @@ const versionModule = require('./utils/version-module');
 const constants = require('./utils/constants');
 const packageRunnner = require('./utils/package-runner');
 
-gulp.task('build-browser-packages:browser-bundle', gulp.series(
+const browserBundle = gulp.series(
   Object.keys(constants.BUILD_TYPES).map((buildKey) => packageRunnner(
     'build-browser-packages:browser-bundle',
     'browser',
     buildBrowserBundle,
     constants.BUILD_TYPES[buildKey],
   ))
-));
+);
+browserBundle.displayName = 'build-browser-packages:browser-bundle';
+// GULP: Is this exposed to the CLI?
+gulp.task(browserBundle);
 
-gulp.task('build-browser-packages:version-module', gulp.series(
+const version = gulp.series(
   Object.keys(constants.BUILD_TYPES).map((buildKey) => packageRunnner(
     'build-browser-packages:version-module',
     'browser',
     versionModule,
     constants.BUILD_TYPES[buildKey],
   ))
-));
+);
+version.displayName = 'build-browser-packages:version-module';
+// GULP: Is this exposed to the CLI?
+gulp.task(version);
 
-gulp.task('build-browser-packages', gulp.series(
-  'build-browser-packages:version-module',
-  'build-browser-packages:browser-bundle',
-));
+const buildPackages = gulp.series(
+  version,
+  browserBundle,
+);
+buildPackages.displayName = 'build-browser-packages';
+
+module.exports = buildPackages;

--- a/gulp-tasks/build-node-packages.js
+++ b/gulp-tasks/build-node-packages.js
@@ -3,10 +3,14 @@ const gulp = require('gulp');
 const buildNodePackage = require('./utils/build-node-package');
 const packageRunnner = require('./utils/package-runner');
 
-gulp.task('build-node-packages', gulp.series(
+// GULP: why is this using gulp.series?
+const buildPackages = gulp.series(
   packageRunnner(
     'build-node-packages',
     'node',
     buildNodePackage
   )
-));
+);
+buildPackages.displayName = 'build-node-packages';
+
+module.exports = buildPackages;

--- a/gulp-tasks/build-packages.js
+++ b/gulp-tasks/build-packages.js
@@ -2,6 +2,9 @@ const fse = require('fs-extra');
 const gulp = require('gulp');
 const path = require('path');
 
+const buildNodePackages = require('./build-node-packages');
+const buildBrowserPackages = require('./build-browser-packages');
+
 const constants = require('./utils/constants');
 const packageRunnner = require('./utils/package-runner');
 
@@ -11,20 +14,30 @@ const cleanPackage = (packagePath) => {
   return fse.remove(outputDirectory);
 };
 
-gulp.task('build-packages:clean', gulp.series(
+// GULP: Why is this using gulp.series?
+const clean = gulp.series(
     packageRunnner(
       'build-packages:clean',
       'all',
       cleanPackage
     )
-));
+);
+clean.displayName = 'build-packages:clean';
+// GULP: Is this exposed to the CLI?
+gulp.task(clean);
 
-gulp.task('build-packages:build', gulp.parallel(
-  'build-node-packages',
-  'build-browser-packages'
-));
+const build = gulp.parallel(
+  buildNodePackages,
+  buildBrowserPackages
+);
+build.displayName = 'build-packages:build';
+// GULP: Is this exposed to the CLI?
+gulp.task(build);
 
-gulp.task('build-packages', gulp.series(
-  'build-packages:clean',
-  'build-packages:build'
-));
+const buildPackages = gulp.series(
+  clean,
+  build
+);
+buildPackages.displayName = 'build-packages';
+
+module.exports = buildPackages;

--- a/gulp-tasks/build-packages.js
+++ b/gulp-tasks/build-packages.js
@@ -23,16 +23,12 @@ const clean = gulp.series(
     )
 );
 clean.displayName = 'build-packages:clean';
-// GULP: Is this exposed to the CLI?
-gulp.task(clean);
 
 const build = gulp.parallel(
   buildNodePackages,
   buildBrowserPackages
 );
 build.displayName = 'build-packages:build';
-// GULP: Is this exposed to the CLI?
-gulp.task(build);
 
 const buildPackages = gulp.series(
   clean,

--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -3,7 +3,7 @@ const lernaWrapper = require('./utils/lerna-wrapper');
 const fs = require('fs-extra');
 const path = require('path');
 
-gulp.task('lerna-bootstrap', () => {
+const lernaBootstrap = () => {
   // If it's a star, build all projects (I.e. bootstrap everything.)
   if (global.packageOrStar === '*') {
     return lernaWrapper.bootstrap();
@@ -14,12 +14,15 @@ gulp.task('lerna-bootstrap', () => {
     '--include-filtered-dependencies',
     '--scope', global.packageOrStar
   );
-});
+};
+lernaBootstrap.displayName = 'lerna-bootstrap';
+// GULP: Is this exposed to the CLI?
+gulp.task(lernaBootstrap);
 
 // This is needed for workbox-build but is also used by the rollup-helper
 // to add CDN details to workbox-sw.
 // Make sure this runs **before** lerna-bootstrap.
-gulp.task('build:update-cdn-details', async function() {
+const updateCdnDetails = async () => {
   const cdnDetails = await fs.readJSON(path.join(
     __dirname, '..', 'cdn-details.json'
   ));
@@ -37,9 +40,15 @@ gulp.task('build:update-cdn-details', async function() {
   await fs.writeJson(workboxBuildPath, cdnDetails, {
     spaces: 2,
   });
-});
+};
+updateCdnDetails.displayName = 'build:update-cdn-details';
+// GULP: Is this exposed to the CLI?
+gulp.task(updateCdnDetails);
 
-gulp.task('build', gulp.series(
-  'build:update-cdn-details',
-  'lerna-bootstrap',
-));
+const build = gulp.series(
+  updateCdnDetails,
+  lernaBootstrap,
+);
+build.displayName = 'build';
+
+module.exports = build;

--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -16,8 +16,6 @@ const lernaBootstrap = () => {
   );
 };
 lernaBootstrap.displayName = 'lerna-bootstrap';
-// GULP: Is this exposed to the CLI?
-gulp.task(lernaBootstrap);
 
 // This is needed for workbox-build but is also used by the rollup-helper
 // to add CDN details to workbox-sw.
@@ -42,8 +40,6 @@ const updateCdnDetails = async () => {
   });
 };
 updateCdnDetails.displayName = 'build:update-cdn-details';
-// GULP: Is this exposed to the CLI?
-gulp.task(updateCdnDetails);
 
 const build = gulp.series(
   updateCdnDetails,

--- a/gulp-tasks/demos.js
+++ b/gulp-tasks/demos.js
@@ -7,7 +7,7 @@ const constants = require('./utils/constants');
 const getNpmCmd = require('./utils/get-npm-cmd');
 const spawn = require('./utils/spawn-promise-wrapper');
 
-gulp.task('demos:groupBuildFiles', async () => {
+const groupBuildFiles = async () => {
   const pattern = path.posix.join(
     __dirname, '..', 'packages', '**',
     constants.PACKAGE_BUILD_DIRNAME, '*.{js,map}');
@@ -26,36 +26,60 @@ gulp.task('demos:groupBuildFiles', async () => {
       path.join(localBuildPath, path.basename(fileToInclude)),
     );
   }
-});
+};
+groupBuildFiles.displayName = 'demos:groupBuildFiles';
+// GULP: Is this exposed to the CLI?
+gulp.task(groupBuildFiles);
 
-gulp.task('demos:firebaseServe:local', () => {
+const firebaseServeLocal = () => {
   process.env.WORKBOX_DEMO_ENV = 'local';
   return spawn(getNpmCmd(), [
     'run', 'demos-serve',
   ]);
-});
+};
+firebaseServeLocal.displayName = 'demos:firebaseServe:local';
+// GULP: Is this exposed to the CLI?
+gulp.task(firebaseServeLocal);
 
-gulp.task('demos:firebaseServe:cdn', () => {
+const firebaseServeCdn = () => {
   process.env.WORKBOX_DEMO_ENV = 'cdn';
   return spawn(getNpmCmd(), [
     'run', 'demos-serve',
   ]);
-});
+};
+firebaseServeCdn.displayName = 'demos:firebaseServe:cdn';
+// GULP: Is this exposed to the CLI?
+gulp.task(firebaseServeCdn);
 
-gulp.task('demos:serve:local', gulp.series([
-  'demos:groupBuildFiles',
-  'demos:firebaseServe:local',
-]));
+const serveLocal = gulp.series(
+  groupBuildFiles,
+  firebaseServeLocal,
+);
+serveLocal.displayName = 'demos:serve:local';
+// GULP: Is this exposed to the CLI?
+gulp.task(serveLocal);
 
-gulp.task('demos:serve:cdn', gulp.series([
-  'demos:groupBuildFiles',
-  'demos:firebaseServe:cdn',
-]));
+const serveCdn = gulp.series(
+  groupBuildFiles,
+  firebaseServeCdn,
+);
+serveCdn.displayName = 'demos:serve:cdn';
+// GULP: Is this exposed to the CLI?
+gulp.task(serveCdn);
 
-gulp.task('demos:cdn', gulp.series([
-  'demos:serve:local',
-]));
+// GULP: Why is series used here?
+const demosCdn = gulp.series(
+  // GULP: Why is this serveLocal?
+  serveLocal,
+);
+demosCdn.displayName = 'demos:cdn';
+// GULP: Is this exposed to the CLI?
+gulp.task(demosCdn);
 
-gulp.task('demos', gulp.series([
-  'demos:serve:local',
-]));
+// GULP: Why is series used here?
+const demos = gulp.series(
+  serveLocal
+);
+demos.displayName = 'demos';
+
+module.exports = demos;

--- a/gulp-tasks/demos.js
+++ b/gulp-tasks/demos.js
@@ -28,8 +28,6 @@ const groupBuildFiles = async () => {
   }
 };
 groupBuildFiles.displayName = 'demos:groupBuildFiles';
-// GULP: Is this exposed to the CLI?
-gulp.task(groupBuildFiles);
 
 const firebaseServeLocal = () => {
   process.env.WORKBOX_DEMO_ENV = 'local';
@@ -38,8 +36,6 @@ const firebaseServeLocal = () => {
   ]);
 };
 firebaseServeLocal.displayName = 'demos:firebaseServe:local';
-// GULP: Is this exposed to the CLI?
-gulp.task(firebaseServeLocal);
 
 const firebaseServeCdn = () => {
   process.env.WORKBOX_DEMO_ENV = 'cdn';
@@ -48,33 +44,27 @@ const firebaseServeCdn = () => {
   ]);
 };
 firebaseServeCdn.displayName = 'demos:firebaseServe:cdn';
-// GULP: Is this exposed to the CLI?
-gulp.task(firebaseServeCdn);
 
 const serveLocal = gulp.series(
   groupBuildFiles,
   firebaseServeLocal,
 );
 serveLocal.displayName = 'demos:serve:local';
-// GULP: Is this exposed to the CLI?
-gulp.task(serveLocal);
 
+// GULP: This is never used?
 const serveCdn = gulp.series(
   groupBuildFiles,
   firebaseServeCdn,
 );
 serveCdn.displayName = 'demos:serve:cdn';
-// GULP: Is this exposed to the CLI?
-gulp.task(serveCdn);
 
 // GULP: Why is series used here?
+// GULP: This is never used?
 const demosCdn = gulp.series(
   // GULP: Why is this serveLocal?
   serveLocal,
 );
 demosCdn.displayName = 'demos:cdn';
-// GULP: Is this exposed to the CLI?
-gulp.task(demosCdn);
 
 // GULP: Why is series used here?
 const demos = gulp.series(

--- a/gulp-tasks/docs.js
+++ b/gulp-tasks/docs.js
@@ -9,9 +9,12 @@ const logHelper = require('../infra/utils/log-helper');
 
 const DOCS_DIRECTORY = path.join(__dirname, '..', 'docs');
 
-gulp.task('docs:clean', () => {
+const clean = () => {
   return fs.remove(DOCS_DIRECTORY);
-});
+};
+clean.displayName = 'docs:clean';
+// GULP: Is this exposed to the CLI?
+gulp.task(clean);
 
 const getJSDocFunc = (debug) => {
   return () => {
@@ -65,33 +68,48 @@ You can view a friendlier UI by running
   };
 };
 
-gulp.task('docs:build-debug', gulp.series([
-  'docs:clean',
+const buildDebug = gulp.series(
+  clean,
   getJSDocFunc(true),
-]));
+);
+buildDebug.displayName = 'docs:build-debug';
+// GULP: Is this exposed to the CLI?
+gulp.task(buildDebug);
 
-gulp.task('docs:build', gulp.series([
-  'docs:clean',
+const build = gulp.series(
+  clean,
   getJSDocFunc(false),
-]));
+);
+build.displayName = 'docs:build';
+// GULP: Is this exposed to the CLI?
+gulp.task(build);
 
-gulp.task('docs:watch', () => {
+const watch = () => {
   const watcher = gulp.watch('packages/**/*',
     gulp.series(['docs:build']));
   watcher.on('error', (err) => {
     logHelper.error(`Docs failed to build: `, err);
   });
-});
+};
+watch.displayName = 'docs:watch';
+// GULP: Is this exposed to the CLI?
+gulp.task(watch);
 
-gulp.task('docs:serve', () => {
+const serve = () => {
   browserSync.init({
     server: {
         baseDir: DOCS_DIRECTORY,
     },
   });
-});
+};
+serve.displayName = 'docs:serve';
+// GULP: Is this exposed to the CLI?
+gulp.task(serve);
 
-gulp.task('docs', gulp.series([
-  'docs:build',
-  gulp.parallel(['docs:serve', 'docs:watch']),
-]));
+const docs = gulp.series(
+  build,
+  gulp.parallel(serve, watch),
+);
+docs.displayName = 'docs';
+
+module.exports = docs;

--- a/gulp-tasks/docs.js
+++ b/gulp-tasks/docs.js
@@ -13,8 +13,6 @@ const clean = () => {
   return fs.remove(DOCS_DIRECTORY);
 };
 clean.displayName = 'docs:clean';
-// GULP: Is this exposed to the CLI?
-gulp.task(clean);
 
 const getJSDocFunc = (debug) => {
   return () => {
@@ -68,21 +66,18 @@ You can view a friendlier UI by running
   };
 };
 
+// GULP: This is never used?
 const buildDebug = gulp.series(
   clean,
   getJSDocFunc(true),
 );
 buildDebug.displayName = 'docs:build-debug';
-// GULP: Is this exposed to the CLI?
-gulp.task(buildDebug);
 
 const build = gulp.series(
   clean,
   getJSDocFunc(false),
 );
 build.displayName = 'docs:build';
-// GULP: Is this exposed to the CLI?
-gulp.task(build);
 
 const watch = () => {
   const watcher = gulp.watch('packages/**/*',
@@ -92,8 +87,6 @@ const watch = () => {
   });
 };
 watch.displayName = 'docs:watch';
-// GULP: Is this exposed to the CLI?
-gulp.task(watch);
 
 const serve = () => {
   browserSync.init({
@@ -103,8 +96,6 @@ const serve = () => {
   });
 };
 serve.displayName = 'docs:serve';
-// GULP: Is this exposed to the CLI?
-gulp.task(serve);
 
 const docs = gulp.series(
   build,

--- a/gulp-tasks/lint.js
+++ b/gulp-tasks/lint.js
@@ -1,13 +1,15 @@
-const gulp = require('gulp');
 const spawn = require('./utils/spawn-promise-wrapper');
 const getNpmCmd = require('./utils/get-npm-cmd');
 const logHelper = require('../infra/utils/log-helper');
 
 // Use npm run lint to ensure we are using local eslint
-gulp.task('lint', () => {
+const lint = () => {
   return spawn(getNpmCmd(), ['run', 'lint'])
   .catch((err) => {
     logHelper.error(err);
     throw new Error(`[Workbox Error Msg] 'gulp lint' discovered errors.`);
   });
-});
+};
+lint.displayName = 'lint';
+
+module.exports = lint;

--- a/gulp-tasks/publish-cdn.js
+++ b/gulp-tasks/publish-cdn.js
@@ -65,8 +65,6 @@ const generateFromTags = async () => {
   }
 };
 generateFromTags.displayName = 'publish-cdn:generate-from-tags';
-// GULP: Is this exposed to the CLI?
-gulp.task(generateFromTags);
 
 // GULP: Why is this using gulp.series?
 const publishCdn = gulp.series(

--- a/gulp-tasks/publish-cdn.js
+++ b/gulp-tasks/publish-cdn.js
@@ -49,7 +49,7 @@ const handleCDNUpload = async (tagName, gitBranch) => {
   });
 };
 
-gulp.task('publish-cdn:generate-from-tags', async () => {
+const generateFromTags = async () => {
   // Get all of the tags in the repo.
   const tags = await githubHelper.getTags();
   const missingTags = await findMissingCDNTags(tags);
@@ -63,8 +63,15 @@ gulp.task('publish-cdn:generate-from-tags', async () => {
     // using a tagged release.
     await handleCDNUpload(tagData.name, tagData.name);
   }
-});
+};
+generateFromTags.displayName = 'publish-cdn:generate-from-tags';
+// GULP: Is this exposed to the CLI?
+gulp.task(generateFromTags);
 
-gulp.task('publish-cdn', gulp.series(
-  'publish-cdn:generate-from-tags',
-));
+// GULP: Why is this using gulp.series?
+const publishCdn = gulp.series(
+  generateFromTags
+);
+publishCdn.displayName = 'publish-cdn';
+
+module.exports = publishCdn;

--- a/gulp-tasks/publish-demos.js
+++ b/gulp-tasks/publish-demos.js
@@ -20,8 +20,6 @@ const updateCDNDetails = () => {
   return fs.writeJSON(filePath, details);
 };
 updateCDNDetails.displayName = 'publish-demos:updateCDNDetails';
-// GULP: Is this exposed to the CLI?
-gulp.task(updateCDNDetails);
 
 const deploy = () => {
   return spawn(getNpmCmd(), ['run', 'demos-deploy'], {
@@ -29,8 +27,6 @@ const deploy = () => {
   });
 };
 deploy.displayName = 'publish-demos:deploy';
-// GULP: Is this exposed to the CLI?
-gulp.task(deploy);
 
 const clean = () => {
   return fs.remove(
@@ -38,8 +34,6 @@ const clean = () => {
   );
 };
 clean.displayName = 'publish-demos:clean';
-// GULP: Is this exposed to the CLI?
-gulp.task(clean);
 
 const publishDemos = gulp.series(
   clean,

--- a/gulp-tasks/publish-demos.js
+++ b/gulp-tasks/publish-demos.js
@@ -10,7 +10,7 @@ const constants = require('./utils/constants');
 // TODO: This should publish based on git tags, similar to Github and CDN
 // releases
 
-gulp.task('publish-demos:updateCDNDetails', () => {
+const updateCDNDetails = () => {
   const details = {
     latestUrl: getVersionsCDNUrl(),
   };
@@ -18,22 +18,34 @@ gulp.task('publish-demos:updateCDNDetails', () => {
     'functions', 'cdn-details.json');
 
   return fs.writeJSON(filePath, details);
-});
+};
+updateCDNDetails.displayName = 'publish-demos:updateCDNDetails';
+// GULP: Is this exposed to the CLI?
+gulp.task(updateCDNDetails);
 
-gulp.task('publish-demos:deploy', () => {
+const deploy = () => {
   return spawn(getNpmCmd(), ['run', 'demos-deploy'], {
     cwd: path.join(__dirname, '..'),
   });
-});
+};
+deploy.displayName = 'publish-demos:deploy';
+// GULP: Is this exposed to the CLI?
+gulp.task(deploy);
 
-gulp.task('publish-demos:clean', () => {
+const clean = () => {
   return fs.remove(
     path.join(__dirname, '..', 'demos', 'public', constants.LOCAL_BUILDS_DIR)
   );
-});
+};
+clean.displayName = 'publish-demos:clean';
+// GULP: Is this exposed to the CLI?
+gulp.task(clean);
 
-gulp.task('publish-demos', gulp.series([
-  'publish-demos:clean',
-  'publish-demos:updateCDNDetails',
-  'publish-demos:deploy',
-]));
+const publishDemos = gulp.series(
+  clean,
+  updateCDNDetails,
+  deploy,
+);
+publishDemos.displayName = 'publish-demos';
+
+module.exports = publishDemos;

--- a/gulp-tasks/publish-github.js
+++ b/gulp-tasks/publish-github.js
@@ -74,8 +74,6 @@ const generateFromTags = async () => {
   }
 };
 generateFromTags.displayName = 'publish-github:generate-from-tags';
-// GULP: Is this exposed to the CLI?
-gulp.task(generateFromTags);
 
 const publishGithub = gulp.series(
   generateFromTags,

--- a/gulp-tasks/publish-github.js
+++ b/gulp-tasks/publish-github.js
@@ -56,7 +56,7 @@ const filterTagsWithReleaseBundles = (allTags, taggedReleases) => {
   });
 };
 
-gulp.task('publish-github:generate-from-tags', async () => {
+const generateFromTags = async () => {
   // Get all of the tags in the repo.
   const allTags = await githubHelper.getTags();
   const taggedReleases = await githubHelper.getTaggedReleases();
@@ -72,8 +72,14 @@ gulp.task('publish-github:generate-from-tags', async () => {
     await handleGithubRelease(
       tagInfo.name, tagInfo.name, taggedReleases[tagInfo.name]);
   }
-});
+};
+generateFromTags.displayName = 'publish-github:generate-from-tags';
+// GULP: Is this exposed to the CLI?
+gulp.task(generateFromTags);
 
-gulp.task('publish-github', gulp.series(
-  'publish-github:generate-from-tags',
-));
+const publishGithub = gulp.series(
+  generateFromTags,
+);
+publishGithub.displayName = 'publish-github';
+
+module.exports = publishGithub;

--- a/gulp-tasks/publish-lerna.js
+++ b/gulp-tasks/publish-lerna.js
@@ -1,9 +1,8 @@
-const gulp = require('gulp');
-
 const getNpmCmd = require('./utils/get-npm-cmd');
+// GULP: We handle async completion on child processes
 const spawn = require('./utils/spawn-promise-wrapper');
 
-gulp.task('publish-lerna', () => {
+const publishLerna = () => {
   return spawn(getNpmCmd(), [
     'run', 'local-lerna',
     '--',
@@ -15,4 +14,7 @@ gulp.task('publish-lerna', () => {
     '--cd-version=prerelease', '--preid=alpha',
     '--npm-tag', 'alpha',
   ]);
-});
+};
+publishLerna.displayName = 'publish-lerna';
+
+module.exports = publishLerna;

--- a/gulp-tasks/publish.js
+++ b/gulp-tasks/publish.js
@@ -18,8 +18,6 @@ const publishClean = () => {
     constants.GENERATED_RELEASE_FILES_DIRNAME));
 };
 publishClean.displayName = 'publish:clean';
-// GULP: Is this exposed to the CLI?
-gulp.task(publishClean);
 
 const publishCdnGit = gulp.series(
   publishClean,
@@ -27,8 +25,6 @@ const publishCdnGit = gulp.series(
   publishCdn,
 );
 publishCdnGit.displayName = 'publish:cdn+git';
-// GULP: Is this exposed to the CLI?
-gulp.task(publishCdnGit);
 
 const publishSignin = async () => {
   try {
@@ -45,8 +41,6 @@ const publishSignin = async () => {
   }
 };
 publishSignin.displayName = 'publish:signin';
-// GULP: Is this exposed to the CLI?
-gulp.task(publishSignin);
 
 const publish = gulp.series(
   publishSignin,

--- a/gulp-tasks/test-integration.js
+++ b/gulp-tasks/test-integration.js
@@ -1,4 +1,3 @@
-const gulp = require('gulp');
 const oneLine = require('common-tags').oneLine;
 const glob = require('glob');
 const seleniumAssistant = require('selenium-assistant');
@@ -85,7 +84,7 @@ const runIntegrationForBrowser = async (browser) => {
   }
 };
 
-gulp.task('test-integration', async () => {
+const testIntegration = async () => {
   if (process.platform === 'win32') {
     logHelper.warn(`Skipping integration tests on Windows.`);
     return;
@@ -121,4 +120,7 @@ gulp.task('test-integration', async () => {
 
   // TODO Saucelabs browsers for latest - 1 browser
   // TODO Saucelabs browsers for latest - 2 browser
-});
+};
+testIntegration.displayName = 'test-integration';
+
+module.exports = testIntegration;

--- a/gulp-tasks/test-node.js
+++ b/gulp-tasks/test-node.js
@@ -53,23 +53,35 @@ const runNodeTestsWithEnv = async (testGroup, nodeEnv) => {
   }
 };
 
-gulp.task('test-node:prod', gulp.series(
+const testNodeProd = gulp.series(
   () => runNodeTestsWithEnv(global.packageOrStar, constants.BUILD_TYPES.prod),
-));
+);
+testNodeProd.displayName = 'test-node:prod';
+// GULP: Is this exposed to the CLI?
+gulp.task(testNodeProd);
 
-gulp.task('test-node:dev', gulp.series(
+const testNodeDev = gulp.series(
   () => runNodeTestsWithEnv(global.packageOrStar, constants.BUILD_TYPES.dev),
-));
+);
+testNodeDev.displayName = 'test-node:dev';
+// GULP: Is this exposed to the CLI?
+gulp.task(testNodeDev);
 
-gulp.task('test-node:all', gulp.series(
+const testNodeAll = gulp.series(
   () => runNodeTestsWithEnv('all', constants.BUILD_TYPES.prod),
-));
+);
+testNodeAll.displayName = 'test-node:all';
+// GULP: Is this exposed to the CLI?
+gulp.task(testNodeAll);
 
-gulp.task('test-node:clean', () => {
+const testNodeClean = () => {
   return fse.remove(path.join(__dirname, '..', '.nyc_output'));
-});
+};
+testNodeClean.displayName = 'test-node:clean';
+// GULP: Is this exposed to the CLI?
+gulp.task(testNodeClean);
 
-gulp.task('test-node:coverage', () => {
+const testNodeCoverage = () => {
   const runOptions = ['run', 'coverage-report'];
   if (global.packageOrStar !== '*') {
     runOptions.push('--');
@@ -79,12 +91,18 @@ gulp.task('test-node:coverage', () => {
     );
   }
   return spawn(getNpmCmd(), runOptions);
-});
+};
+testNodeCoverage.displayName = 'test-node:coverage';
+// GULP: Is this exposed to the CLI?
+gulp.task(testNodeCoverage);
 
-gulp.task('test-node', gulp.series(
-  'test-node:clean',
-  'test-node:dev',
-  'test-node:prod',
-  'test-node:all',
-  'test-node:coverage',
-));
+const testNode = gulp.series(
+  testNodeClean,
+  testNodeDev,
+  testNodeProd,
+  testNodeAll,
+  testNodeCoverage,
+);
+testNode.displayName = 'test-node';
+
+module.exports = testNode;

--- a/gulp-tasks/test-node.js
+++ b/gulp-tasks/test-node.js
@@ -57,29 +57,21 @@ const testNodeProd = gulp.series(
   () => runNodeTestsWithEnv(global.packageOrStar, constants.BUILD_TYPES.prod),
 );
 testNodeProd.displayName = 'test-node:prod';
-// GULP: Is this exposed to the CLI?
-gulp.task(testNodeProd);
 
 const testNodeDev = gulp.series(
   () => runNodeTestsWithEnv(global.packageOrStar, constants.BUILD_TYPES.dev),
 );
 testNodeDev.displayName = 'test-node:dev';
-// GULP: Is this exposed to the CLI?
-gulp.task(testNodeDev);
 
 const testNodeAll = gulp.series(
   () => runNodeTestsWithEnv('all', constants.BUILD_TYPES.prod),
 );
 testNodeAll.displayName = 'test-node:all';
-// GULP: Is this exposed to the CLI?
-gulp.task(testNodeAll);
 
 const testNodeClean = () => {
   return fse.remove(path.join(__dirname, '..', '.nyc_output'));
 };
 testNodeClean.displayName = 'test-node:clean';
-// GULP: Is this exposed to the CLI?
-gulp.task(testNodeClean);
 
 const testNodeCoverage = () => {
   const runOptions = ['run', 'coverage-report'];
@@ -93,8 +85,6 @@ const testNodeCoverage = () => {
   return spawn(getNpmCmd(), runOptions);
 };
 testNodeCoverage.displayName = 'test-node:coverage';
-// GULP: Is this exposed to the CLI?
-gulp.task(testNodeCoverage);
 
 const testNode = gulp.series(
   testNodeClean,

--- a/gulp-tasks/test-server.js
+++ b/gulp-tasks/test-server.js
@@ -23,12 +23,18 @@ const startServer = () => {
   return testServer.start();
 };
 
-gulp.task('test-server:prod', () => {
+const testServerProd = () => {
   process.env.NODE_ENV = constants.BUILD_TYPES.prod;
   startServer();
-});
+};
+// GULP: Is this exposed to the CLI?
+// GULP: This should probably be a CLI flag like `--prod`
+gulp.task('test-server:prod', testServerProd);
 
-gulp.task('test-server', () => {
+const testServerDev = () => {
   process.env.NODE_ENV = constants.BUILD_TYPES.dev;
   startServer();
-});
+};
+testServerDev.displayName = 'test-server';
+
+module.exports = testServerDev;

--- a/gulp-tasks/test-server.js
+++ b/gulp-tasks/test-server.js
@@ -1,5 +1,3 @@
-const gulp = require('gulp');
-
 const constants = require('./utils/constants');
 const testServer = require('../infra/testing/test-server');
 
@@ -23,13 +21,13 @@ const startServer = () => {
   return testServer.start();
 };
 
+// GULP: This is not used?
+// GULP: This should probably be a CLI flag like `--prod`
 const testServerProd = () => {
   process.env.NODE_ENV = constants.BUILD_TYPES.prod;
   startServer();
 };
-// GULP: Is this exposed to the CLI?
-// GULP: This should probably be a CLI flag like `--prod`
-gulp.task('test-server:prod', testServerProd);
+testServerProd.displayName = 'test-server:prod';
 
 const testServerDev = () => {
   process.env.NODE_ENV = constants.BUILD_TYPES.dev;

--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -1,8 +1,16 @@
 const gulp = require('gulp');
 
-gulp.task('test', gulp.series(
-  'build',
-  'test-node',
-  'test-integration',
-  'lint',
-));
+const lint = require('./lint');
+const build = require('./build');
+const testNode = require('./test-node');
+const testIntegration = require('./test-integration');
+
+const test = gulp.series(
+  build,
+  testNode,
+  testIntegration,
+  lint,
+);
+test.displayName = 'test';
+
+module.exports = test;

--- a/gulp-tasks/utils/package-runner.js
+++ b/gulp-tasks/utils/package-runner.js
@@ -113,6 +113,7 @@ module.exports = (displayName, packageType, func, ...args) => {
   // We need to return a single no-op rather than an empty array, or else gulp
   // will throw 'One or more tasks should be combined using series or parallel'.
   if (packagePaths.length === 0) {
+    // TODO: should gulp handle this differently?
     const noOp = (done) => done();
     noOp.displayName = displayName;
     return [noOp];

--- a/gulp-tasks/watch.js
+++ b/gulp-tasks/watch.js
@@ -1,9 +1,11 @@
 const gulp = require('gulp');
 
+const build = require('./build');
+
 const logHelper = require('../infra/utils/log-helper');
 
-gulp.task('watch', gulp.series(
-  'build',
+const watch = gulp.series(
+  build,
   () => {
     gulp.watch(
       [
@@ -11,11 +13,15 @@ gulp.task('watch', gulp.series(
         '!packages/**/_version.mjs',
         '!packages/**/build/**/*',
         '!packages/**/node_modules/**/*',
-      ], gulp.series('build'),
+      ], build,
     )
+    // GULP: why is this here?
     .on('error', () => {})
     .on('change', function(path, stats) {
       logHelper.log(`gulp.watch() is running due to a change in '${path}'`);
     });
   }
-));
+);
+watch.displayName = 'watch';
+
+module.exports = watch;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,9 @@ global.cliOptions = options;
 
 // Forward referencing means the order of gulp-task
 // requires is important
-const gulpTaskFiles = [
+const exportedTasks = [
+  // GULP: If you use function everywhere instead of strings,
+  // this order doesn't matter
   'build-node-packages',
   'build-browser-packages',
   'build-packages',
@@ -57,7 +59,7 @@ const gulpTaskFiles = [
   'demos',
 ];
 
-gulpTaskFiles.forEach((gulpTaskFile) => {
+exportedTasks.forEach((taskName) => {
   // Requiring will be enough to register the tasks with gulp.
-  require(path.join(__dirname, 'gulp-tasks', gulpTaskFile));
+  exports[taskName] = require(path.join(__dirname, 'gulp-tasks', taskName));
 });

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -39,7 +39,7 @@
   },
   "main": "build/index.js",
   "scripts": {
-    "build": "gulp build:update-cdn-details && gulp build-packages --package workbox-build",
+    "build": "gulp build-packages --package workbox-build",
     "version": "npm run build",
     "prepare": "npm run build"
   },


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

Hey all! I just wanted to say that the gulpfile & tasks were super informative for me to look through in this project.

As with all Google's usage of gulp, we love to have them be best-in-class and a place to point people for learning.  So I wanted to update this to use our recommended patterns with gulp 4 -  namely, functions instead of strings for composition, `.displayName` property (I'd love to update with `.flags` and `.description`), and exported tasks instead of using `gulp.task`.

There were a bunch of methods registered with `gulp.task` because of string referencing so I wasn't sure if they should even be exposed (composing functions allows for "private" tasks that can still be used within `series`/`parallel`).

I also added some inline comments/questions labeled with `// GULP:` - I'd appreciate any feedback.

Cheers,
-Blaine
