### PR TITLE
Expiration integration

### DIFF
--- a/infra/testing/test-server.js
+++ b/infra/testing/test-server.js
@@ -8,7 +8,7 @@ const logHelper = require('../utils/log-helper');
 
 const app = express();
 
-app.get(/\/__WORKBOX\/buildFile\/(workbox-[A-z]*)(\.(?:dev|prod)\.(.*))*/, (req, res) => {
+app.get(/\/__WORKBOX\/buildFile\/(workbox-[A-z|-]*)(\.(?:dev|prod)\.(.*))*/, (req, res) => {
   res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
   res.header('Expires', '-1');
   res.header('Pragma', 'no-cache');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10263,7 +10263,7 @@
     },
     "jsdoc-baseline": {
       "version": "https://github.com/hegemonic/baseline/tarball/master",
-      "integrity": "sha1-7H4toBglK8wP8qNDU/RAJFvHE3k=",
+      "integrity": "sha512-jJdjBcQabPfctcgYLHp4aHFPZXTZWJkkvI1cuvC0C59zJXvT27HccUN8omZ59CLekrSlKAO7F9fCeZe4Bm2p+w==",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",

--- a/test/workbox-cache-expiration/integration/expiration-plugin.js
+++ b/test/workbox-cache-expiration/integration/expiration-plugin.js
@@ -1,0 +1,183 @@
+const expect = require('chai').expect;
+const seleniumAssistant = require('selenium-assistant');
+
+describe(`expiration.Plugin`, function() {
+  let webdriver;
+  let testServerAddress = global.__workbox.server.getAddress();
+
+  beforeEach(async function() {
+    if (webdriver) {
+      await seleniumAssistant.killWebDriver(webdriver);
+      webdriver = null;
+    }
+
+    global.__workbox.server.reset();
+
+    // Allow async functions 10s to complete
+    webdriver = await global.__workbox.seleniumBrowser.getSeleniumDriver();
+    webdriver.manage().timeouts().setScriptTimeout(10 * 1000);
+  });
+
+  after(async function() {
+    if (webdriver) {
+      await seleniumAssistant.killWebDriver(webdriver);
+    }
+  });
+
+  const activateSW = async (swFile) => {
+    const error = await webdriver.executeAsyncScript((swFile, cb) => {
+      navigator.serviceWorker.register(swFile)
+      .then(() => {
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          if (navigator.serviceWorker.controller.scriptURL.endsWith(swFile)) {
+            cb();
+          }
+        });
+      })
+      .catch((err) => {
+        cb(err.message);
+      });
+    }, swFile);
+    if (error) {
+      throw error;
+    }
+  };
+
+  const getCachedRequests = (cacheName) => {
+    return webdriver.executeAsyncScript((cacheName, cb) => {
+      caches.open(cacheName)
+      .then((cache) => {
+        return cache.keys();
+      })
+      .then((keys) => {
+        cb(
+          keys.map((request) => request.url).sort()
+        );
+      });
+    }, cacheName);
+  };
+
+  it(`should load a page with entries managed by maxEntries`, async function() {
+    const testingURl = `${testServerAddress}/test/workbox-cache-expiration/static/expiration-plugin/`;
+    const SW_URL = `${testingURl}sw-max-entries.js`;
+
+    // Load the page and wait for the first service worker to register and activate.
+    await webdriver.get(testingURl);
+
+    // Register the service worker.
+    await activateSW(SW_URL);
+
+    await webdriver.executeAsyncScript((testingURl, cb) => {
+      fetch(`${testingURl}example-1.txt`).then(() => cb()).catch((err) => cb(err.message));
+    }, testingURl);
+
+    // Caching is done async from returning a response, so we may need
+    // to wait before the cache has some content.
+    await webdriver.wait(async () => {
+      return await webdriver.executeAsyncScript((cb) => {
+        caches.keys().then((keys) => cb(keys.length > 0));
+      });
+    });
+
+    const keys = await webdriver.executeAsyncScript((cb) => {
+      caches.keys().then(cb);
+    });
+
+    expect(keys).to.deep.equal([
+      'expiration-plugin-max-entries',
+    ]);
+
+    let cachedRequests = await getCachedRequests(keys[0]);
+    expect(cachedRequests).to.deep.equal([
+      `${testingURl}example-1.txt`,
+    ]);
+
+    await webdriver.executeAsyncScript((testingURl, cb) => {
+      fetch(`${testingURl}example-2.txt`).then(() => cb()).catch((err) => cb(err.message));
+    }, testingURl);
+
+    // Caching is done async from returning a response, so we may need
+    // to wait before the cache has be cleaned up.
+    let waitForCleanup = true;
+    while (waitForCleanup) {
+      cachedRequests = await getCachedRequests(keys[0]);
+      if (cachedRequests.length !== 1) {
+        continue;
+      }
+
+      if (cachedRequests[0] !== `${testingURl}example-2.txt`) {
+        continue;
+      }
+
+      waitForCleanup = false;
+    }
+
+    // If the code path reaches here - the clean up from expiration was
+    // successful
+  });
+
+  it(`should load a page with entries managed by maxAgeSeconds`, async function() {
+    const testingURl = `${testServerAddress}/test/workbox-cache-expiration/static/expiration-plugin/`;
+    const SW_URL = `${testingURl}sw-max-age-seconds.js`;
+
+    // Load the page and wait for the first service worker to register and activate.
+    await webdriver.get(testingURl);
+
+    // Register the service worker.
+    await activateSW(SW_URL);
+
+    await webdriver.executeAsyncScript((testingURl, cb) => {
+      fetch(`${testingURl}example-1.txt`).then(() => cb()).catch((err) => cb(err.message));
+    }, testingURl);
+
+    // Caching is done async from returning a response, so we may need
+    // to wait before the cache has some content.
+    await webdriver.wait(async () => {
+      return await webdriver.executeAsyncScript((cb) => {
+        caches.keys().then((keys) => cb(keys.length > 0));
+      });
+    });
+
+    const keys = await webdriver.executeAsyncScript((cb) => {
+      caches.keys().then(cb);
+    });
+
+    expect(keys).to.deep.equal([
+      'expiration-plugin-max-entries',
+    ]);
+
+    let cachedRequests = await getCachedRequests(keys[0]);
+    expect(cachedRequests).to.deep.equal([
+      `${testingURl}example-1.txt`,
+    ]);
+
+    // Wait 1.5 seconds to expire entry.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1500);
+    });
+
+    await webdriver.executeAsyncScript((testingURl, cb) => {
+      fetch(`${testingURl}example-2.txt`).then(() => cb()).catch((err) => cb(err.message));
+    }, testingURl);
+
+    // Caching is done async from returning a response, so we may need
+    // to wait before the cache has be cleaned up.
+    console.log(`Waiting for cache cleanup`);
+    let waitForCleanup = true;
+    while (waitForCleanup) {
+      cachedRequests = await getCachedRequests(keys[0]);
+      if (cachedRequests.length !== 1) {
+        continue;
+      }
+
+      if (cachedRequests[0] !== `${testingURl}example-2.txt`) {
+        continue;
+      }
+
+      waitForCleanup = false;
+    }
+
+    // If the code path reaches here - the clean up from expiration was
+    // successful
+  });
+});

--- a/test/workbox-cache-expiration/integration/expiration-plugin.js
+++ b/test/workbox-cache-expiration/integration/expiration-plugin.js
@@ -162,7 +162,6 @@ describe(`expiration.Plugin`, function() {
 
     // Caching is done async from returning a response, so we may need
     // to wait before the cache has be cleaned up.
-    console.log(`Waiting for cache cleanup`);
     let waitForCleanup = true;
     while (waitForCleanup) {
       cachedRequests = await getCachedRequests(keys[0]);

--- a/test/workbox-cache-expiration/static/expiration-plugin/example-1.txt
+++ b/test/workbox-cache-expiration/static/expiration-plugin/example-1.txt
@@ -1,0 +1,1 @@
+example-1.txt

--- a/test/workbox-cache-expiration/static/expiration-plugin/example-2.txt
+++ b/test/workbox-cache-expiration/static/expiration-plugin/example-2.txt
@@ -1,0 +1,1 @@
+example-2.txt

--- a/test/workbox-cache-expiration/static/expiration-plugin/index.html
+++ b/test/workbox-cache-expiration/static/expiration-plugin/index.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <p>You need to manually register sw.js</p>
+    <script src="/node_modules/sinon/pkg/sinon.js"></script>
+    <script>
+      window.__test = {};
+    </script>
+  </body>
+  </html>

--- a/test/workbox-cache-expiration/static/expiration-plugin/sw-max-age-seconds.js
+++ b/test/workbox-cache-expiration/static/expiration-plugin/sw-max-age-seconds.js
@@ -1,0 +1,21 @@
+importScripts('/__WORKBOX/buildFile/workbox-core');
+importScripts('/__WORKBOX/buildFile/workbox-cache-expiration');
+importScripts('/__WORKBOX/buildFile/workbox-routing');
+importScripts('/__WORKBOX/buildFile/workbox-strategies');
+
+/* globals workbox */
+
+workbox.routing.registerRoute(
+  /.*.txt/,
+  workbox.strategies.cacheFirst({
+    cacheName: 'expiration-plugin-max-entries',
+    plugins: [
+      new workbox.expiration.Plugin({
+        maxAgeSeconds: 1,
+      }),
+    ],
+  })
+);
+
+self.addEventListener('install', (event) => event.waitUntil(self.skipWaiting()));
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));

--- a/test/workbox-cache-expiration/static/expiration-plugin/sw-max-entries.js
+++ b/test/workbox-cache-expiration/static/expiration-plugin/sw-max-entries.js
@@ -1,0 +1,21 @@
+importScripts('/__WORKBOX/buildFile/workbox-core');
+importScripts('/__WORKBOX/buildFile/workbox-cache-expiration');
+importScripts('/__WORKBOX/buildFile/workbox-routing');
+importScripts('/__WORKBOX/buildFile/workbox-strategies');
+
+/* globals workbox */
+
+workbox.routing.registerRoute(
+  /.*.txt/,
+  workbox.strategies.cacheFirst({
+    cacheName: 'expiration-plugin-max-entries',
+    plugins: [
+      new workbox.expiration.Plugin({
+        maxEntries: 1,
+      }),
+    ],
+  })
+);
+
+self.addEventListener('install', (event) => event.waitUntil(self.skipWaiting()));
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));


### PR DESCRIPTION
R: @jeffposnick

This adds integration tests to the cache expiration plugin - this should guarantee everything stays working.

Major downside is I couldn't thing of a sure fire way to test the timed expiration. The sinon fake timers would need to be setup in the service worker env, which *could* get terminated and brought back up between commands, so for now I just wait a second before testing the expiration flow.
