### PR TITLE
Don't copy the same workbox-sw.js(.map) files twice

### DIFF
--- a/packages/workbox-build/src/lib/copy-workbox-libraries.js
+++ b/packages/workbox-build/src/lib/copy-workbox-libraries.js
@@ -65,6 +65,13 @@ module.exports = async (destDirectory) => {
     const defaultPathToLibrary = require.resolve(`${library}/${pkg.main}`);
 
     for (const buildType of BUILD_TYPES) {
+      // Special-case logic for workbox-sw, which only has a single build type.
+      // This prevents a race condition with two identical copy promises;
+      // see https://github.com/GoogleChrome/workbox/issues/1180
+      if (library === 'workbox-sw' && buildType === BUILD_TYPES[0]) {
+        continue;
+      }
+
       const srcPath = useBuildType(defaultPathToLibrary, buildType);
       const destPath = path.join(workboxDirectoryPath,
         path.basename(srcPath));

--- a/test/workbox-build/node/lib/copy-workbox-libraries.js
+++ b/test/workbox-build/node/lib/copy-workbox-libraries.js
@@ -45,9 +45,9 @@ describe(`[workbox-build] lib/copy-workbox-libraries.js`, function() {
       expect(expectedPath).to.eql(ensureDirStub.args[0][0]);
 
       // This reflects the number of library files that were copied over:
-      // - both prod and dev builds
+      // - both prod and dev builds (except for workbox-sw.js, which is a single build)
       // - source maps for each
-      expect(copyStub.callCount).to.eql(40);
+      expect(copyStub.callCount).to.eql(38);
     });
   }
 });


### PR DESCRIPTION
R: @addyosmani @gauntface
CC: @jgw96

Fixes #1180