### PR TITLE
Switching to a db name instead of just a store name

### DIFF
--- a/gulp-tasks/test-node.js
+++ b/gulp-tasks/test-node.js
@@ -71,6 +71,7 @@ gulp.task('test-node:clean', () => {
 
 gulp.task('test-node:coverage', () => {
   const runOptions = ['run', 'coverage-report'];
+  console.log(global.packageOrStar);
   if (global.packageOrStar !== '*') {
     runOptions.push('--');
     runOptions.push('--include');
@@ -78,6 +79,7 @@ gulp.task('test-node:coverage', () => {
       path.posix.join('packages', global.packageOrStar, '**', '*')
     );
   }
+  console.log(runOptions);
   return spawn(getNpmCmd(), runOptions);
 });
 

--- a/gulp-tasks/test-node.js
+++ b/gulp-tasks/test-node.js
@@ -71,7 +71,6 @@ gulp.task('test-node:clean', () => {
 
 gulp.task('test-node:coverage', () => {
   const runOptions = ['run', 'coverage-report'];
-  console.log(global.packageOrStar);
   if (global.packageOrStar !== '*') {
     runOptions.push('--');
     runOptions.push('--include');
@@ -79,7 +78,6 @@ gulp.task('test-node:coverage', () => {
       path.posix.join('packages', global.packageOrStar, '**', '*')
     );
   }
-  console.log(runOptions);
   return spawn(getNpmCmd(), runOptions);
 });
 

--- a/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
+++ b/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
@@ -43,6 +43,13 @@ class CacheTimestampsModel {
     });
   }
 
+  /**
+   * Should perform an upgrade of indexedDB.
+   *
+   * @param {Event} evt
+   *
+   * @private
+   */
   _handleUpgrade(evt) {
     const db = evt.target.result;
     if (evt.oldVersion < 2) {

--- a/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
+++ b/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
@@ -38,11 +38,23 @@ class CacheTimestampsModel {
     this._cacheName = cacheName;
     this._storeName = cacheName;
 
-    this._db = new DBWrapper(this._cacheName, 1, {
-      onupgradeneeded: (evt) => evt.target.result
-          .createObjectStore(this._storeName, {keyPath: URL_KEY})
-          .createIndex(TIMESTAMP_KEY, TIMESTAMP_KEY, {unique: false}),
+    this._db = new DBWrapper(this._cacheName, 2, {
+      onupgradeneeded: (evt) => this._handleUpgrade(evt),
     });
+  }
+
+  _handleUpgrade(evt) {
+    const db = evt.target.result;
+    if (evt.oldVersion < 2) {
+      // Remove old databases.
+      if (db.objectStoreNames.contains('workbox-cache-expiration')) {
+        db.deleteObjectStore('workbox-cache-expiration');
+      }
+    }
+
+    db
+    .createObjectStore(this._storeName, {keyPath: URL_KEY})
+    .createIndex(TIMESTAMP_KEY, TIMESTAMP_KEY, {unique: false});
   }
 
   /**

--- a/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
+++ b/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
@@ -38,7 +38,7 @@ class CacheTimestampsModel {
     this._cacheName = cacheName;
     this._storeName = cacheName;
 
-    this._db = new DBWrapper('workbox-cache-expiration', 1, {
+    this._db = new DBWrapper(this._cacheName, 1, {
       onupgradeneeded: (evt) => evt.target.result
           .createObjectStore(this._storeName, {keyPath: URL_KEY})
           .createIndex(TIMESTAMP_KEY, TIMESTAMP_KEY, {unique: false}),

--- a/test/workbox-cache-expiration/node/test-CacheTimestampsModel.mjs
+++ b/test/workbox-cache-expiration/node/test-CacheTimestampsModel.mjs
@@ -1,15 +1,20 @@
 import {expect} from 'chai';
 import {reset as iDBReset} from 'shelving-mock-indexeddb';
+import * as sinon from 'sinon';
 
 import CacheTimestampsModel from '../../../packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs';
 import {DBWrapper} from '../../../packages/workbox-core/_private/DBWrapper.mjs';
 
 describe(`[workbox-cache-expiration] CacheTimestampsModel`, function() {
+  const sandbox = sinon.sandbox.create();
+
   beforeEach(function() {
+    sandbox.restore();
     iDBReset();
   });
 
   after(function() {
+    sandbox.restore();
     iDBReset();
   });
 
@@ -28,7 +33,7 @@ describe(`[workbox-cache-expiration] CacheTimestampsModel`, function() {
       await model.setTimestamp('/', timestamp);
 
       const timestamps =
-          await new DBWrapper('test-cache', 1).getAll('test-cache');
+          await new DBWrapper('test-cache', 2).getAll('test-cache');
 
       expect(timestamps).to.deep.equal([{
         url: 'https://example.com/',
@@ -110,6 +115,62 @@ describe(`[workbox-cache-expiration] CacheTimestampsModel`, function() {
           timestamp: timestamp,
         },
       ]);
+    });
+  });
+
+  describe('_handleUpgrade', function() {
+    it('should handle upgrade 0 (Doesnt exist)', () => {
+      const objectStoreNames = [];
+      const fakeDB = {
+        objectStoreNames: {
+          contains: (name) => objectStoreNames.indexOf(name) !== -1,
+        },
+        createIndex: sandbox.spy(),
+        deleteObjectStore: sandbox.spy(),
+        createObjectStore: sandbox.stub().callsFake(() => fakeDB)
+      };
+
+      const DB_NAME = 'test';
+      const model = new CacheTimestampsModel(DB_NAME);
+      model._handleUpgrade({
+        target: {
+          result: fakeDB,
+        },
+      });
+
+      // Assert only create called
+      expect(fakeDB.createObjectStore.callCount).to.equal(1);
+      expect(fakeDB.createObjectStore.args[0][0]).to.equal(DB_NAME);
+
+     expect(fakeDB.deleteObjectStore.callCount).to.equal(0);
+    });
+
+    it('should handle upgrade 1 > 2', () => {
+      const objectStoreNames = ['workbox-cache-expiration'];
+      const fakeDB = {
+        objectStoreNames: {
+          contains: (name) => objectStoreNames.indexOf(name) !== -1,
+        },
+        createIndex: sandbox.spy(),
+        deleteObjectStore: sandbox.spy(),
+        createObjectStore: sandbox.stub().callsFake(() => fakeDB),
+      };
+
+      const DB_NAME = 'test';
+      const model = new CacheTimestampsModel(DB_NAME);
+      model._handleUpgrade({
+        oldVersion: 1,
+        target: {
+          result: fakeDB,
+        },
+      });
+
+      // Assert only create called
+      expect(fakeDB.createObjectStore.callCount).to.equal(1);
+      expect(fakeDB.createObjectStore.args[0][0]).to.equal(DB_NAME);
+
+     expect(fakeDB.deleteObjectStore.callCount).to.equal(1);
+     expect(fakeDB.deleteObjectStore.args[0][0]).to.equal('workbox-cache-expiration');
     });
   });
 });

--- a/test/workbox-cache-expiration/node/test-CacheTimestampsModel.mjs
+++ b/test/workbox-cache-expiration/node/test-CacheTimestampsModel.mjs
@@ -127,7 +127,7 @@ describe(`[workbox-cache-expiration] CacheTimestampsModel`, function() {
         },
         createIndex: sandbox.spy(),
         deleteObjectStore: sandbox.spy(),
-        createObjectStore: sandbox.stub().callsFake(() => fakeDB)
+        createObjectStore: sandbox.stub().callsFake(() => fakeDB),
       };
 
       const DB_NAME = 'test';

--- a/test/workbox-cache-expiration/node/test-CacheTimestampsModel.mjs
+++ b/test/workbox-cache-expiration/node/test-CacheTimestampsModel.mjs
@@ -28,7 +28,7 @@ describe(`[workbox-cache-expiration] CacheTimestampsModel`, function() {
       await model.setTimestamp('/', timestamp);
 
       const timestamps =
-          await new DBWrapper(`workbox-cache-expiration`, 1).getAll('test-cache');
+          await new DBWrapper('test-cache', 1).getAll('test-cache');
 
       expect(timestamps).to.deep.equal([{
         url: 'https://example.com/',


### PR DESCRIPTION
R: @jeffposnick @philipwalton 

Previously I was using a single database name with multiple store names for the cache expiration timestamps,. This doesn't work / make sense given that you need to know the store names up front which for multiple instances of the class - will not be the case.

This change moves to using a name for the database and store name to ensure uniqueness.

Fixes #1175
