### PR TITLE
Call new on the corresponding Plugin class.

### DIFF
--- a/infra/testing/validator/service-worker-runtime.js
+++ b/infra/testing/validator/service-worker-runtime.js
@@ -6,16 +6,29 @@ const sinon = require('sinon');
 const vm = require('vm');
 
 function setupSpiesAndContext() {
+  const cacheableResponsePluginSpy = sinon.spy();
+  class CacheableResponsePlugin {
+    constructor(...args) {
+      cacheableResponsePluginSpy(...args);
+    }
+  }
+
+  const cacheExpirationPluginSpy = sinon.spy();
+  class CacheExpirationPlugin {
+    constructor(...args) {
+      cacheExpirationPluginSpy(...args);
+    }
+  }
+
   const importScripts = sinon.spy();
+
   const workbox = {
-    // To make testing easier, return the name of the plugin.
     cacheableResponse: {
-      Plugin: sinon.stub().returns('workbox.cacheableResponse.Plugin'),
+      Plugin: CacheableResponsePlugin,
     },
     clientsClaim: sinon.spy(),
-    // To make testing easier, return the name of the plugin.
     expiration: {
-      Plugin: sinon.stub().returns('workbox.expiration.Plugin'),
+      Plugin: CacheExpirationPlugin,
     },
     precaching: {
       precacheAndRoute: sinon.spy(),
@@ -44,8 +57,8 @@ function setupSpiesAndContext() {
 
   const methodsToSpies = {
     importScripts,
-    cacheableResponsePlugin: workbox.cacheableResponse.Plugin,
-    cacheExpirationPlugin: workbox.expiration.Plugin,
+    cacheableResponsePlugin: cacheableResponsePluginSpy,
+    cacheExpirationPlugin: cacheExpirationPluginSpy,
     cacheFirst: workbox.strategies.cacheFirst,
     clientsClaim: workbox.clientsClaim,
     networkFirst: workbox.strategies.networkFirst,

--- a/packages/workbox-build/src/lib/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/runtime-caching-converter.js
@@ -60,7 +60,7 @@ function getOptionsString(options = {}) {
       throw new Error(`${errors['bad-runtime-caching-config']} ${pluginName}`);
     }
 
-    plugins.push(`${pluginString}(${JSON.stringify(pluginConfig)})`);
+    plugins.push(`new ${pluginString}(${JSON.stringify(pluginConfig)})`);
   }
 
   if (networkTimeoutSeconds || cacheName || plugins.length > 0) {

--- a/test/workbox-build/node/entry-points/generate-sw-string.js
+++ b/test/workbox-build/node/entry-points/generate-sw-string.js
@@ -390,8 +390,7 @@ describe(`[workbox-build] entry-points/generate-sw-string.js (End to End)`, func
         [STRING_HANDLER]: [[{
           cacheName: runtimeCachingOptions.cacheName,
           plugins: runtimeCachingOptions.plugins.concat([
-            'workbox.expiration.Plugin',
-            'workbox.cacheableResponse.Plugin',
+            {}, {},
           ]),
         }]],
         cacheableResponsePlugin: [[runtimeCachingOptions.cacheableResponse]],
@@ -436,10 +435,10 @@ describe(`[workbox-build] entry-points/generate-sw-string.js (End to End)`, func
       await validateServiceWorkerRuntime({swCode, expectedMethodCalls: {
         [STRING_HANDLER]: [[{
           cacheName: firstRuntimeCachingOptions.cacheName,
-          plugins: ['workbox.expiration.Plugin'],
+          plugins: [{}],
         }], [{
           cacheName: secondRuntimeCachingOptions.cacheName,
-          plugins: ['workbox.cacheableResponse.Plugin'],
+          plugins: [{}],
         }]],
         cacheableResponsePlugin: [[secondRuntimeCachingOptions.cacheableResponse]],
         cacheExpirationPlugin: [[firstRuntimeCachingOptions.expiration]],

--- a/test/workbox-build/node/entry-points/generate-sw.js
+++ b/test/workbox-build/node/entry-points/generate-sw.js
@@ -587,10 +587,10 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [STRING_HANDLER]: [[{
           cacheName: firstRuntimeCachingOptions.cacheName,
-          plugins: ['workbox.expiration.Plugin'],
+          plugins: [{}],
         }], [{
           cacheName: secondRuntimeCachingOptions.cacheName,
-          plugins: ['workbox.cacheableResponse.Plugin'],
+          plugins: [{}],
         }]],
         cacheableResponsePlugin: [[secondRuntimeCachingOptions.cacheableResponse]],
         cacheExpirationPlugin: [[firstRuntimeCachingOptions.expiration]],


### PR DESCRIPTION
R: @addyosmani @gauntface
CC: @mischnic

Fixes #1215

The missing `new` was an oversight during the migration to using the `plugins: []` property for configuring all strategy classes.