### PR TITLE
BroadcastCacheUpdate.Plugin integration test

### DIFF
--- a/infra/testing/test-server.js
+++ b/infra/testing/test-server.js
@@ -40,6 +40,13 @@ app.get(/\/__WORKBOX\/buildFile\/(workbox-[A-z|-]*)(\.(?:dev|prod)\.(.*))*/, (re
   res.sendFile(path.join(libraryPath, libraryFileName));
 });
 
+let eTagCounter = 0;
+app.get('/test/uniqueETag', (req, res) => {
+  res.header('Cache-Control', 'no-cache');
+  res.header('ETag', eTagCounter++);
+  res.send('ignored');
+});
+
 let server = null;
 let requestCounts = {};
 module.exports = {

--- a/packages/workbox-broadcast-cache-update/Plugin.mjs
+++ b/packages/workbox-broadcast-cache-update/Plugin.mjs
@@ -51,31 +51,36 @@ class Plugin {
    * @param {string} input.cacheName Name of the cache the responses belong to.
    * @param {Response} [input.oldResponse] The previous cached value, if any.
    * @param {Response} input.newResponse The new value in the cache.
-   * @param {string} input.url The cache key URL.
    */
-  cacheDidUpdate({cacheName, oldResponse, newResponse, url}) {
+  cacheDidUpdate({cacheName, oldResponse, newResponse, request}) {
     if (process.env.NODE_ENV !== 'production') {
       assert.isType(cacheName, 'string', {
         moduleName: 'workbox-broadcast-cache-update',
         className: 'Plugin',
-        funcName: 'constructor',
+        funcName: 'cacheDidUpdate',
         paramName: 'cacheName',
       });
       assert.isInstance(newResponse, Response, {
         moduleName: 'workbox-broadcast-cache-update',
         className: 'Plugin',
-        funcName: 'constructor',
+        funcName: 'cacheDidUpdate',
         paramName: 'newResponse',
+      });
+      assert.isInstance(request, Request, {
+        moduleName: 'workbox-broadcast-cache-update',
+        className: 'Plugin',
+        funcName: 'cacheDidUpdate',
+        paramName: 'request',
       });
     }
 
     if (!oldResponse) {
-      // Without a two responses there is nothing to comapre
+      // Without a two responses there is nothing to compare.
       return;
     }
 
     this._broadcastUpdate
-      .notifyIfUpdated(oldResponse, newResponse, cacheName, url);
+      .notifyIfUpdated(oldResponse, newResponse, request.url, cacheName);
   }
 }
 

--- a/packages/workbox-broadcast-cache-update/broadcastUpdate.mjs
+++ b/packages/workbox-broadcast-cache-update/broadcastUpdate.mjs
@@ -59,26 +59,26 @@ const broadcastUpdate = (channel, cacheName, url, source) => {
     assert.isInstance(channel, BroadcastChannel, {
       moduleName: 'workbox-broadcast-cache-update',
       className: '~',
-      funcName: 'broadcaseUpdate',
+      funcName: 'broadcastUpdate',
       paramName: 'channel',
     });
     assert.isType(cacheName, 'string', {
       moduleName: 'workbox-broadcast-cache-update',
       className: '~',
-      funcName: 'broadcaseUpdate',
+      funcName: 'broadcastUpdate',
       paramName: 'cacheName',
-    });
-    assert.isType(source, 'string', {
-      moduleName: 'workbox-broadcast-cache-update',
-      className: '~',
-      funcName: 'broadcaseUpdate',
-      paramName: 'source',
     });
     assert.isType(url, 'string', {
       moduleName: 'workbox-broadcast-cache-update',
       className: '~',
-      funcName: 'broadcaseUpdate',
+      funcName: 'broadcastUpdate',
       paramName: 'url',
+    });
+    assert.isType(source, 'string', {
+      moduleName: 'workbox-broadcast-cache-update',
+      className: '~',
+      funcName: 'broadcastUpdate',
+      paramName: 'source',
     });
   }
 

--- a/test/workbox-broadcast-cache-update/integration/broadcast-cache-update-plugin.js
+++ b/test/workbox-broadcast-cache-update/integration/broadcast-cache-update-plugin.js
@@ -1,0 +1,79 @@
+const expect = require('chai').expect;
+const seleniumAssistant = require('selenium-assistant');
+
+describe(`broadcastCacheUpdate.Plugin`, function() {
+  let webdriver;
+  let testServerAddress = global.__workbox.server.getAddress();
+
+  beforeEach(async function() {
+    if (webdriver) {
+      await seleniumAssistant.killWebDriver(webdriver);
+      webdriver = null;
+    }
+
+    global.__workbox.server.reset();
+
+    // Allow async functions 10s to complete
+    webdriver = await global.__workbox.seleniumBrowser.getSeleniumDriver();
+    webdriver.manage().timeouts().setScriptTimeout(10 * 1000);
+  });
+
+  after(async function() {
+    if (webdriver) {
+      await seleniumAssistant.killWebDriver(webdriver);
+    }
+  });
+
+  const activateSW = async (swFile) => {
+    const error = await webdriver.executeAsyncScript((swFile, cb) => {
+      navigator.serviceWorker.register(swFile)
+      .then(() => {
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          if (navigator.serviceWorker.controller.scriptURL.endsWith(swFile)) {
+            cb();
+          }
+        });
+      })
+      .catch((err) => {
+        cb(err.message);
+      });
+    }, swFile);
+
+    if (error) {
+      throw error;
+    }
+  };
+
+  it(`should broadcast a message on the expected channel when there's a cache update`, async function() {
+    const testPageUrl = `${testServerAddress}/test/workbox-broadcast-cache-update/static/`;
+    const swUrl = `${testPageUrl}sw.js`;
+    const apiUrl = `${testServerAddress}/test/uniqueETag`;
+
+    await webdriver.get(testPageUrl);
+    await activateSW(swUrl);
+
+    await webdriver.executeAsyncScript((apiUrl, cb) => {
+      // Call fetch(apiUrl) twice. Each response will include a different ETag,
+      // which will trigger the BCU plugin's behavior.
+      fetch(apiUrl)
+        .then(() => fetch(apiUrl))
+        .then(() => cb())
+        .catch((err) => cb(err.message));
+    }, apiUrl);
+
+    const updateMessageEventData = await webdriver.executeAsyncScript((cb) => {
+      // updateReceivedPromise is defined on the test page, and resolves when
+      // the initial Broadcast Channel API Message event fires.
+      updateReceivedPromise.then(cb);
+    });
+
+    expect(updateMessageEventData).to.deep.equal({
+      meta: 'workbox-broadcast-cache-update',
+      payload: {
+        cacheName: 'bcu-integration-test',
+        updatedUrl: apiUrl,
+      },
+      type: 'CACHE_UPDATED',
+    });
+  });
+});

--- a/test/workbox-broadcast-cache-update/integration/broadcast-cache-update-plugin.js
+++ b/test/workbox-broadcast-cache-update/integration/broadcast-cache-update-plugin.js
@@ -64,7 +64,7 @@ describe(`broadcastCacheUpdate.Plugin`, function() {
     const updateMessageEventData = await webdriver.executeAsyncScript((cb) => {
       // updateReceivedPromise is defined on the test page, and resolves when
       // the initial Broadcast Channel API Message event fires.
-      updateReceivedPromise.then(cb);
+      window.updateReceivedPromise.then(cb);
     });
 
     expect(updateMessageEventData).to.deep.equal({

--- a/test/workbox-broadcast-cache-update/node/test-Plugin.mjs
+++ b/test/workbox-broadcast-cache-update/node/test-Plugin.mjs
@@ -26,9 +26,10 @@ describe(`[workbox-broadcast-cache-udpate] Plugin`, function() {
     it(`should not throw when called with valid parameters`, function() {
       const bcuPlugin = new Plugin('channel-name');
       const cacheName = 'cache-name';
+      const request = new Request('/');
       const oldResponse = new Response();
       const newResponse = new Response();
-      bcuPlugin.cacheDidUpdate({cacheName, oldResponse, newResponse});
+      bcuPlugin.cacheDidUpdate({cacheName, oldResponse, newResponse, request});
     });
   });
 });

--- a/test/workbox-broadcast-cache-update/static/index.html
+++ b/test/workbox-broadcast-cache-update/static/index.html
@@ -6,9 +6,9 @@
     <script>
       window.__test = {};
 
-      const updateReceivedPromise = new Promise((resolve) => {
+      window.updateReceivedPromise = new Promise((resolve) => {
         const updatesChannel = new BroadcastChannel('bcu-integration-test');
-        updatesChannel.addEventListener('message', async (event) => {
+        updatesChannel.addEventListener('message', (event) => {
           resolve(event.data);
         });
       });

--- a/test/workbox-broadcast-cache-update/static/index.html
+++ b/test/workbox-broadcast-cache-update/static/index.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <p>You need to manually register sw.js</p>
+    <script>
+      window.__test = {};
+
+      const updateReceivedPromise = new Promise((resolve) => {
+        const updatesChannel = new BroadcastChannel('bcu-integration-test');
+        updatesChannel.addEventListener('message', async (event) => {
+          resolve(event.data);
+        });
+      });
+    </script>
+  </body>
+  </html>

--- a/test/workbox-broadcast-cache-update/static/sw.js
+++ b/test/workbox-broadcast-cache-update/static/sw.js
@@ -1,0 +1,17 @@
+importScripts('/__WORKBOX/buildFile/workbox-core');
+importScripts('/__WORKBOX/buildFile/workbox-broadcast-cache-update');
+importScripts('/__WORKBOX/buildFile/workbox-routing');
+importScripts('/__WORKBOX/buildFile/workbox-strategies');
+
+workbox.routing.registerRoute(
+  new RegExp('/test/uniqueETag$'),
+  workbox.strategies.staleWhileRevalidate({
+    cacheName: 'bcu-integration-test',
+    plugins: [
+      new workbox.broadcastUpdate.Plugin('bcu-integration-test'),
+    ],
+  })
+);
+
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #1191 

In the course of writing this test I found two problems with the implementation, which this PR also fixes:

- The v3 `cacheDidUpdate` lifecycle callback no longer sets the `url` property on the parameter. It still sets the `request` property, and you can get the `url` from that, so I just switched over to getting it from there.
- The move from named properties for parameters to positional parameters led to an issue where `notifyIfUpdated()` was being called with the `url` and `cacheName` parameters transposed.

(I guess that's why we write integration tests!)