### PR TITLE
babelHelpers.asyncToGenerator minification, take two.

### DIFF
--- a/gulp-tasks/utils/external-helpers.js
+++ b/gulp-tasks/utils/external-helpers.js
@@ -2,35 +2,36 @@
 // This is extracted from the Babel runtime (original source: https://github.com/babel/babel/blob/9e0f5235b1ca5167c368a576ad7c5af62d20b0e3/packages/babel-helpers/src/helpers.js#L240).
 // As part of the Rollup bundling process, it's injected once into workbox-core
 // and reused throughout all of the other modules, avoiding code duplication.
+// It's exposed as self.Z as a brute-force minification technique, and rollup
+// replaces references to babelHelpers.asyncToGenerator with self.Z as part of
+// the bundling process.
 // See https://github.com/GoogleChrome/workbox/pull/1048#issuecomment-344698046
 // for further background.
-self.babelHelpers = {
-  asyncToGenerator: function(fn) {
-    return function() {
-      var gen = fn.apply(this, arguments);
-      return new Promise(function(resolve, reject) {
-        function step(key, arg) {
-          try {
-            var info = gen[key](arg);
-            var value = info.value;
-          } catch (error) {
-            reject(error);
-            return;
-          }
-
-          if (info.done) {
-            resolve(value);
-          } else {
-            return Promise.resolve(value).then(function(value) {
-              step('next', value);
-            }, function(err) {
-              step('throw', err);
-            });
-          }
+self.Z = function(fn) {
+  return function() {
+    var gen = fn.apply(this, arguments);
+    return new Promise(function(resolve, reject) {
+      function step(key, arg) {
+        try {
+          var info = gen[key](arg);
+          var value = info.value;
+        } catch (error) {
+          reject(error);
+          return;
         }
 
-        return step('next');
-      });
-    };
-  },
+        if (info.done) {
+          resolve(value);
+        } else {
+          return Promise.resolve(value).then(function(value) {
+            step('next', value);
+          }, function(err) {
+            step('throw', err);
+          });
+        }
+      }
+
+      return step('next');
+    });
+  };
 };

--- a/gulp-tasks/utils/rollup-helper.js
+++ b/gulp-tasks/utils/rollup-helper.js
@@ -32,6 +32,16 @@ module.exports = {
     };
     plugins.push(babel(babelConfig));
 
+    // This is a brute-force approach to minifying the babel-helpers code.
+    // self.Z is defined in our external-helper.js file and is used as the
+    // exposed interface for alias for babelHelpers.asyncToGenerator.
+    // See https://github.com/GoogleChrome/workbox/issues/1061
+    plugins.push(
+      replace({
+        'babelHelpers.asyncToGenerator': 'self.Z',
+      }),
+    );
+
     let minifyBuild = buildType === constants.BUILD_TYPES.prod;
     if (minifyBuild) {
       const uglifyOptions = {


### PR DESCRIPTION
R: @philipwalton @addyosmani @gauntface

Fixes #1061 

This is an alternative to #1183 that might be less finicky.

Instead of relying on UglifyJS to rename things for us, this brute-forces exposing the `babelHelpers.asyncToGenerator` helper as `self.Z` (an arbitrary 1 character property name) and then imposes a string replacement in the rollup bundling process to convert `babelHelpers.asyncToGenerator` to `self.Z`.