### PR TITLE
Adding integration tests for remaining strategies

### DIFF
--- a/infra/testing/test-server.js
+++ b/infra/testing/test-server.js
@@ -50,7 +50,6 @@ app.get('/test/uniqueETag', (req, res) => {
 let uniqueValue = 0;
 app.get('/test/uniqueValue', (req, res) => {
   res.header('Cache-Control', 'no-cache');
-  res.header('ETag', uniqueValue++);
   res.send(uniqueValue.toString());
 });
 

--- a/infra/testing/test-server.js
+++ b/infra/testing/test-server.js
@@ -47,6 +47,13 @@ app.get('/test/uniqueETag', (req, res) => {
   res.send('ignored');
 });
 
+let uniqueValue = 0;
+app.get('/test/uniqueValue', (req, res) => {
+  res.header('Cache-Control', 'no-cache');
+  res.header('ETag', uniqueValue++);
+  res.send(uniqueValue.toString());
+});
+
 let server = null;
 let requestCounts = {};
 module.exports = {

--- a/infra/testing/test-server.js
+++ b/infra/testing/test-server.js
@@ -51,6 +51,7 @@ let uniqueValue = 0;
 app.get('/test/uniqueValue', (req, res) => {
   res.header('Cache-Control', 'no-cache');
   res.send(uniqueValue.toString());
+  uniqueValue++;
 });
 
 let server = null;

--- a/test/workbox-strategies/integration/test-networkFirst.js
+++ b/test/workbox-strategies/integration/test-networkFirst.js
@@ -1,0 +1,121 @@
+const expect = require('chai').expect;
+const seleniumAssistant = require('selenium-assistant');
+
+describe.only(`[workbox-strategies] NetworkFirst Requests`, function() {
+  let webdriver;
+  let testServerAddress = global.__workbox.server.getAddress();
+
+  beforeEach(async function() {
+    if (webdriver) {
+      await seleniumAssistant.killWebDriver(webdriver);
+      webdriver = null;
+    }
+
+    global.__workbox.server.reset();
+
+    // Allow async functions 10s to complete
+    webdriver = await global.__workbox.seleniumBrowser.getSeleniumDriver();
+    webdriver.manage().timeouts().setScriptTimeout(30 * 1000);
+  });
+
+  after(async function() {
+    if (webdriver) {
+      await seleniumAssistant.killWebDriver(webdriver);
+    }
+  });
+
+  const activateSW = async (swFile) => {
+    const error = await webdriver.executeAsyncScript((swFile, cb) => {
+      navigator.serviceWorker.register(swFile)
+      .then(() => {
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          if (navigator.serviceWorker.controller.scriptURL.endsWith(swFile)) {
+            cb();
+          }
+        });
+      })
+      .catch((err) => {
+        cb(err);
+      });
+    }, swFile);
+    if (error) {
+      throw error;
+    }
+  };
+
+  const getCachedRequest = (cacheName, url) => {
+    return webdriver.executeAsyncScript((cacheName, url, cb) => {
+      caches.open(cacheName)
+      .then((cache) => {
+        return cache.match(url);
+      })
+      .then((response) => response.text())
+      .then((response) => {
+        cb(response);
+      })
+      .catch((err) => cb());
+    }, cacheName, url);
+  };
+
+  const validateCacheEntry = (cacheName, url, validateCb) => {
+    let tries = 0;
+    const maxRetires = 20;
+    const intervalInMs = 1000;
+
+    return new Promise((resolve, reject) => {
+      const intervalId = setInterval(async () => {
+        tries++;
+
+        const response = await getCachedRequest(cacheName, url);
+        if (response) {
+          const isValid = validateCb(response);
+          if (isValid) {
+            clearInterval(intervalId);
+            resolve();
+          }
+        } else if (tries > maxRetires) {
+          clearInterval(intervalId);
+          reject(`Request not found in cache: ${url}`);
+        }
+      }, intervalInMs);
+    });
+  };
+
+  it(`should respond with a non-cached entry but stash request in a cache`, async function() {
+    const testingURl = `${testServerAddress}/test/workbox-strategies/static/network-first/`;
+    const SW_URL = `${testingURl}sw.js`;
+    const cacheName = 'network-first';
+
+    // Load the page and wait for the first service worker to register and activate.
+    await webdriver.get(testingURl);
+
+    // Register the first service worker.
+    await activateSW(SW_URL);
+
+    let response = await webdriver.executeAsyncScript((cb) => {
+      fetch(new URL(`/test/uniqueValue`, location).href)
+      .then((response) => response.text())
+      .then((responseBody) => cb(responseBody))
+      .catch((err) => cb(err.message));
+    });
+    const firstResponse = response.trim();
+    expect(firstResponse).to.not.equal('Cached');
+
+    await validateCacheEntry(cacheName, `${testServerAddress}/test/uniqueValue`, (value) => {
+      return value === firstResponse;
+    });
+
+    response = await webdriver.executeAsyncScript((cb) => {
+      fetch(new URL(`/test/uniqueValue`, location).href)
+      .then((response) => response.text())
+      .then((responseBody) => cb(responseBody))
+      .catch((err) => cb(err.message));
+    });
+    const secondResponse = response.trim();
+    expect(secondResponse).to.not.equal(firstResponse);
+
+    await validateCacheEntry(cacheName, `${testServerAddress}/test/uniqueValue`, (value) => {
+      return value === secondResponse;
+    });
+  });
+});

--- a/test/workbox-strategies/integration/test-networkOnly.js
+++ b/test/workbox-strategies/integration/test-networkOnly.js
@@ -1,0 +1,87 @@
+const expect = require('chai').expect;
+const seleniumAssistant = require('selenium-assistant');
+
+describe.only(`[workbox-strategies] NetworkOnly Requests`, function() {
+  let webdriver;
+  let testServerAddress = global.__workbox.server.getAddress();
+
+  beforeEach(async function() {
+    if (webdriver) {
+      await seleniumAssistant.killWebDriver(webdriver);
+      webdriver = null;
+    }
+
+    global.__workbox.server.reset();
+
+    // Allow async functions 10s to complete
+    webdriver = await global.__workbox.seleniumBrowser.getSeleniumDriver();
+    webdriver.manage().timeouts().setScriptTimeout(30 * 1000);
+  });
+
+  after(async function() {
+    if (webdriver) {
+      await seleniumAssistant.killWebDriver(webdriver);
+    }
+  });
+
+  const activateSW = async (swFile) => {
+    const error = await webdriver.executeAsyncScript((swFile, cb) => {
+      navigator.serviceWorker.register(swFile)
+      .then(() => {
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          if (navigator.serviceWorker.controller.scriptURL.endsWith(swFile)) {
+            cb();
+          }
+        });
+      })
+      .catch((err) => {
+        cb(err);
+      });
+    }, swFile);
+    if (error) {
+      throw error;
+    }
+  };
+
+  it(`should respond with a non-cached entry`, async function() {
+    const testingURl = `${testServerAddress}/test/workbox-strategies/static/network-only/`;
+    const SW_URL = `${testingURl}sw.js`;
+
+    // Load the page and wait for the first service worker to register and activate.
+    await webdriver.get(testingURl);
+
+    // Register the first service worker.
+    await activateSW(SW_URL);
+
+    let response = await webdriver.executeAsyncScript((cb) => {
+      fetch(new URL(`/test/uniqueValue`, location).href)
+      .then((response) => response.text())
+      .then((responseBody) => cb(responseBody))
+      .catch((err) => cb(err.message));
+    });
+    const firstResponse = response.trim();
+    expect(firstResponse).to.not.equal('Cached');
+
+    await webdriver.executeAsyncScript((cb) => {
+      caches.delete('network-only')
+      .then(cb)
+      .catch((err) => cb());
+    });
+
+    response = await webdriver.executeAsyncScript((cb) => {
+      fetch(new URL(`/test/uniqueValue`, location).href)
+      .then((response) => response.text())
+      .then((responseBody) => cb(responseBody))
+      .catch((err) => cb(err.message));
+    });
+    const secondResponse = response.trim();
+    expect(secondResponse).to.not.equal(firstResponse);
+
+    const cacheNames = await webdriver.executeAsyncScript((cb) => {
+      caches.keys()
+      .then(cb)
+      .catch((err) => cb());
+    });
+    expect(cacheNames.length).to.equal(0);
+  });
+});

--- a/test/workbox-strategies/integration/test-staleWhileRevalidate.js
+++ b/test/workbox-strategies/integration/test-staleWhileRevalidate.js
@@ -1,0 +1,123 @@
+const expect = require('chai').expect;
+const seleniumAssistant = require('selenium-assistant');
+
+describe(`[workbox-strategies] StaleWhileRevalidate Requests`, function() {
+  let webdriver;
+  let testServerAddress = global.__workbox.server.getAddress();
+
+  beforeEach(async function() {
+    if (webdriver) {
+      await seleniumAssistant.killWebDriver(webdriver);
+      webdriver = null;
+    }
+
+    global.__workbox.server.reset();
+
+    // Allow async functions 10s to complete
+    webdriver = await global.__workbox.seleniumBrowser.getSeleniumDriver();
+    webdriver.manage().timeouts().setScriptTimeout(30 * 1000);
+  });
+
+  after(async function() {
+    if (webdriver) {
+      await seleniumAssistant.killWebDriver(webdriver);
+    }
+  });
+
+  const activateSW = async (swFile) => {
+    const error = await webdriver.executeAsyncScript((swFile, cb) => {
+      navigator.serviceWorker.register(swFile)
+      .then(() => {
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          if (navigator.serviceWorker.controller.scriptURL.endsWith(swFile)) {
+            cb();
+          }
+        });
+      })
+      .catch((err) => {
+        cb(err);
+      });
+    }, swFile);
+    if (error) {
+      throw error;
+    }
+  };
+
+  const getCachedRequest = (cacheName, url) => {
+    return webdriver.executeAsyncScript((cacheName, url, cb) => {
+      caches.open(cacheName)
+      .then((cache) => {
+        return cache.match(url);
+      })
+      .then((response) => response.text())
+      .then((response) => {
+        cb(response);
+      })
+      .catch((err) => cb());
+    }, cacheName, url);
+  };
+
+  const validateCacheEntry = (cacheName, url, validateCb) => {
+    let tries = 0;
+    const maxRetires = 20;
+    const intervalInMs = 1000;
+
+    return new Promise((resolve, reject) => {
+      const intervalId = setInterval(async () => {
+        tries++;
+
+        const response = await getCachedRequest(cacheName, url);
+        if (response) {
+          const isValid = validateCb(response);
+          if (isValid) {
+            clearInterval(intervalId);
+            resolve();
+          }
+        } else if (tries > maxRetires) {
+          clearInterval(intervalId);
+          reject(`Request not found in cache: ${url}`);
+        }
+      }, intervalInMs);
+    });
+  };
+
+  it(`should respond with cached entry and update it`, async function() {
+    const testingURl = `${testServerAddress}/test/workbox-strategies/static/stale-while-revalidate/`;
+    const SW_URL = `${testingURl}sw.js`;
+    const cacheName = 'stale-while-revalidate';
+
+    // Load the page and wait for the first service worker to register and activate.
+    await webdriver.get(testingURl);
+
+    // Register the first service worker.
+    await activateSW(SW_URL);
+
+    let response = await webdriver.executeAsyncScript((cb) => {
+      fetch(new URL(`/test/uniqueValue`, location).href)
+      .then((response) => response.text())
+      .then((responseBody) => cb(responseBody))
+      .catch((err) => cb(err.message));
+    });
+    const firstResponse = response.trim();
+
+    // The first response should be cached.
+    await validateCacheEntry(cacheName, `${testServerAddress}/test/uniqueValue`, (value) => {
+      return value === firstResponse;
+    });
+
+    // This request should come from cache and not the server
+    response = await webdriver.executeAsyncScript((cb) => {
+      fetch(new URL(`/test/uniqueValue`, location).href)
+      .then((response) => response.text())
+      .then((responseBody) => cb(responseBody))
+      .catch((err) => cb(err.message));
+    });
+    const secondResponse = response.trim();
+    expect(secondResponse).to.equal(firstResponse);
+
+    // The entry should be updated after the response is returned
+    await validateCacheEntry(cacheName, `${testServerAddress}/test/uniqueValue`, (value) => {
+      return value !== secondResponse;
+    });
+  });
+});

--- a/test/workbox-strategies/static/network-first/index.html
+++ b/test/workbox-strategies/static/network-first/index.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <p>You need to manually register sw.js</p>
+  </body>
+</html>

--- a/test/workbox-strategies/static/network-first/sw.js
+++ b/test/workbox-strategies/static/network-first/sw.js
@@ -1,0 +1,17 @@
+importScripts('/__WORKBOX/buildFile/workbox-sw');
+
+/* globals workbox */
+
+workbox.routing.registerRoute(
+  new RegExp('/test/uniqueValue'),
+  new workbox.strategies.NetworkFirst({
+    cacheName: 'network-first',
+  }),
+);
+
+self.addEventListener('install', (event) => event.waitUntil(
+  caches.open('network-first')
+  .then((cache) => cache.put('/test/uniqueValue', new Response('Cached')))
+  .then(() => self.skipWaiting()))
+);
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));

--- a/test/workbox-strategies/static/network-only/index.html
+++ b/test/workbox-strategies/static/network-only/index.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <p>You need to manually register sw.js</p>
+  </body>
+  </html>

--- a/test/workbox-strategies/static/network-only/sw.js
+++ b/test/workbox-strategies/static/network-only/sw.js
@@ -1,0 +1,17 @@
+importScripts('/__WORKBOX/buildFile/workbox-sw');
+
+/* globals workbox */
+
+workbox.routing.registerRoute(
+  new RegExp('/test/uniqueValue'),
+  new workbox.strategies.NetworkOnly({
+    cacheName: 'network-only',
+  }),
+);
+
+self.addEventListener('install', (event) => event.waitUntil(
+  caches.open('network-only')
+  .then((cache) => cache.put('/test/uniqueValue', new Response('Cached')))
+  .then(() => self.skipWaiting()))
+);
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));

--- a/test/workbox-strategies/static/stale-while-revalidate/index.html
+++ b/test/workbox-strategies/static/stale-while-revalidate/index.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <p>You need to manually register sw.js</p>
+  </body>
+  </html>

--- a/test/workbox-strategies/static/stale-while-revalidate/sw.js
+++ b/test/workbox-strategies/static/stale-while-revalidate/sw.js
@@ -1,0 +1,15 @@
+importScripts('/__WORKBOX/buildFile/workbox-sw');
+
+/* globals workbox */
+
+workbox.routing.registerRoute(
+  new RegExp('/test/uniqueValue'),
+  new workbox.strategies.StaleWhileRevalidate(
+    {
+      cacheName: 'stale-while-revalidate',
+    }
+  ),
+);
+
+self.addEventListener('install', (event) => event.waitUntil(self.skipWaiting()));
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));


### PR DESCRIPTION
R: @jeffposnick 

Fixes #1196

Integration tests for networkonly networkfirst and stalewhilerevalidate.