### PR TITLE
Adding range request demo and making function - non-static

### DIFF
--- a/demos/functions/views/demo/workbox-range-requests.hbs
+++ b/demos/functions/views/demo/workbox-range-requests.hbs
@@ -1,0 +1,36 @@
+<section>
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-8 mx-auto">
+        <ol>
+          <li>Open DevTools</li>
+          <li>Go to the Console</li>
+          <li>Click this button to request range 1 - 4 of 'hello, world.':<br /><button class="make-range-request btn btn-outline-primary">Make Range Request</button></li>
+          <li>Checkout the logs for info on the range request that was handled.</li>
+        </ol>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  const makeRequestBtn = document.querySelector('.make-range-request');
+
+  caches.open('range-requests-demo')
+  .then((cache) => cache.put('/range-request-example', new Response('hello, world.')));
+
+  navigator.serviceWorker.register('/demo/workbox-range-requests/sw.js')
+  .then(() => {
+    makeRequestBtn.addEventListener('click', () => {
+      fetch(new Request('/range-request-example', {
+        headers: {
+          Range: `bytes=1-4`,
+        }
+      }))
+      .then((response) => response.text())
+      .then((responseText) => {
+        console.log(`Received response: '${responseText}'`);
+      });
+    });
+  });
+</script>

--- a/demos/functions/views/demo/workbox-range-requests/sw.hbs
+++ b/demos/functions/views/demo/workbox-range-requests/sw.hbs
@@ -1,0 +1,16 @@
+{{{WORKBOX_SW_IMPORT}}}
+
+console.log(new workbox.rangeRequests.Plugin());
+
+workbox.routing.registerRoute(
+  new RegExp('/range-request-example'),
+  workbox.strategies.cacheOnly({
+    cacheName: 'range-requests-demo',
+    plugins: [
+      new workbox.rangeRequests.Plugin(),
+    ],
+  })
+);
+
+workbox.skipWaiting();
+workbox.clientsClaim();

--- a/packages/workbox-range-requests/Plugin.mjs
+++ b/packages/workbox-range-requests/Plugin.mjs
@@ -36,7 +36,7 @@ class Plugin {
    *
    * @private
    */
-  static async cachedResponseWillBeUsed({request, cachedResponse} = {}) {
+  async cachedResponseWillBeUsed({request, cachedResponse} = {}) {
     // Only return a sliced response if there's a Range: header in the request.
     if (request.headers.has('range')) {
       return await createPartialResponse(request, cachedResponse);

--- a/test/workbox-range-requests/static/sw.js
+++ b/test/workbox-range-requests/static/sw.js
@@ -8,7 +8,7 @@ workbox.routing.registerRoute(
   workbox.strategies.cacheOnly({
     cacheName: 'range-requests-integration-test',
     plugins: [
-      workbox.rangeRequests.Plugin,
+      new workbox.rangeRequests.Plugin(),
     ],
   })
 );


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

Fixes #1200

I added the demo for range requests but made one change to the range request plugin.

At the moment we have a number of plugins exposed but they all require instantiating since they have their own constructor options. Range raquests has a single static method meaning it **doesn't** need instantiating like the others. This felt pretty weird so I've undone it in this PR.

Hopefully that's ok in the name of consistency.
