### PR TITLE
Refactor the way CLI parameters are processed by app.js.

### DIFF
--- a/packages/workbox-cli/src/bin.js
+++ b/packages/workbox-cli/src/bin.js
@@ -29,11 +29,7 @@ const logger = require('./lib/logger');
   updateNotifier({pkg: params.pkg}).notify();
 
   try {
-    if (params.input.length > 0) {
-      await app(...params.input, params.flags);
-    } else {
-      params.showHelp();
-    }
+    await app(params);
   } catch (error) {
     // Show the full error and stack trace if we're run with --debug.
     if (params.flags.debug) {

--- a/packages/workbox-cli/src/lib/errors.js
+++ b/packages/workbox-cli/src/lib/errors.js
@@ -17,7 +17,7 @@
 const ol = require('common-tags').oneLine;
 
 module.exports = {
-  'missing-command-param': `Please provide a command.`,
+  'missing-input': `params.input value was not set properly.`,
   'missing-dest-dir-param': ol`Please provide the path to a directory in which
     the libraries will be copied.`,
   'invalid-common-js-module': ol`Please pass in a valid CommonJS module that

--- a/test/workbox-broadcast-cache-update/integration/broadcast-cache-update-plugin.js
+++ b/test/workbox-broadcast-cache-update/integration/broadcast-cache-update-plugin.js
@@ -52,7 +52,7 @@ describe(`broadcastCacheUpdate.Plugin`, function() {
     await webdriver.get(testPageUrl);
     await activateSW(swUrl);
 
-    await webdriver.executeAsyncScript((apiUrl, cb) => {
+    const err = await webdriver.executeAsyncScript((apiUrl, cb) => {
       // Call fetch(apiUrl) twice. Each response will include a different ETag,
       // which will trigger the BCU plugin's behavior.
       fetch(apiUrl)
@@ -60,6 +60,8 @@ describe(`broadcastCacheUpdate.Plugin`, function() {
         .then(() => cb())
         .catch((err) => cb(err.message));
     }, apiUrl);
+
+    expect(err).to.not.exist;
 
     const updateMessageEventData = await webdriver.executeAsyncScript((cb) => {
       // updateReceivedPromise is defined on the test page, and resolves when

--- a/test/workbox-cli/node/app.js
+++ b/test/workbox-cli/node/app.js
@@ -31,22 +31,13 @@ describe(`[workbox-cli] app.js`, function() {
         await app();
         throw new Error('Unexpected success.');
       } catch (error) {
-        expect(error.message).to.have.string(errors['missing-command-param']);
-      }
-    });
-
-    it(`should reject when the command parameter is missing and options is present`, async function() {
-      try {
-        await app(undefined, PROXIED_CONFIG_FILE);
-        throw new Error('Unexpected success.');
-      } catch (error) {
-        expect(error.message).to.have.string(errors['missing-command-param']);
+        expect(error.message).to.have.string(errors['missing-input']);
       }
     });
 
     it(`should reject when the command is unknown and options is present`, async function() {
       try {
-        await app(UNKNOWN_COMMAND, PROXIED_CONFIG_FILE);
+        await app({input: [UNKNOWN_COMMAND, PROXIED_CONFIG_FILE]});
         throw new Error('Unexpected success.');
       } catch (error) {
         expect(error.message).to.have.string(errors['unknown-command']);
@@ -56,7 +47,7 @@ describe(`[workbox-cli] app.js`, function() {
 
     it(`should reject when the command parameter is copyLibraries and options is missing`, async function() {
       try {
-        await app('copyLibraries');
+        await app({input: ['copyLibraries']});
         throw new Error('Unexpected success.');
       } catch (error) {
         expect(error.message).to.have.string(errors['missing-dest-dir-param']);
@@ -73,7 +64,7 @@ describe(`[workbox-cli] app.js`, function() {
         });
 
         try {
-          await appWithStub(command, INVALID_CONFIG_FILE);
+          await appWithStub({input: [command, INVALID_CONFIG_FILE]});
           throw new Error('Unexpected success.');
         } catch (error) {
           expect(loggerErrorStub.calledOnce).to.be.true;
@@ -109,7 +100,7 @@ describe(`[workbox-cli] app.js`, function() {
           });
 
           try {
-            await app(command, PROXIED_CONFIG_FILE);
+            await app({input: [command, PROXIED_CONFIG_FILE]});
             throw new Error('Unexpected success.');
           } catch (error) {
             expect(error.message).to.have.string(errors['config-validation-failed']);
@@ -137,7 +128,7 @@ describe(`[workbox-cli] app.js`, function() {
         });
 
         try {
-          await app(command, PROXIED_CONFIG_FILE);
+          await app({input: [command, PROXIED_CONFIG_FILE]});
           throw new Error('Unexpected success.');
         } catch (error) {
           expect(loggerErrorStub.calledOnce).to.be.true;
@@ -169,7 +160,7 @@ describe(`[workbox-cli] app.js`, function() {
           },
         });
 
-        await app(command, PROXIED_CONFIG_FILE);
+        await app({input: [command, PROXIED_CONFIG_FILE]});
         expect(loggerLogStub.calledTwice).to.be.true;
       });
 
@@ -191,7 +182,7 @@ describe(`[workbox-cli] app.js`, function() {
           },
         });
 
-        await app(command);
+        await app({input: [command]});
         expect(loggerLogStub.calledTwice).to.be.true;
       });
     }
@@ -210,8 +201,32 @@ describe(`[workbox-cli] app.js`, function() {
         },
       });
 
-      await app('copyLibraries', PROXIED_DEST_DIR);
+      await app({input: ['copyLibraries', PROXIED_DEST_DIR]});
       expect(loggerLogStub.calledOnce).to.be.true;
+    });
+
+    it(`should call params.showHelp() when passed 'help'`, async function() {
+      const app = require(MODULE_PATH);
+
+      const params = {
+        input: ['help'],
+        showHelp: sinon.stub(),
+      };
+
+      await app(params);
+      expect(params.showHelp.calledOnce).to.be.true;
+    });
+
+    it(`should call params.showHelp() when not passed any command`, async function() {
+      const app = require(MODULE_PATH);
+
+      const params = {
+        input: [],
+        showHelp: sinon.stub(),
+      };
+
+      await app(params);
+      expect(params.showHelp.calledOnce).to.be.true;
     });
   });
 });


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #1238

The parameters got messed up when I started passed in `params.flags` from `bin.js` to `app.js`, so I took a step back and refactored how those are passed through.

I'm happier with this approach as it keeps the CLI position parameters separate from the CLI flags.