### PR TITLE
Ignore '.map' when suggesting extensions to precache.

### DIFF
--- a/packages/workbox-cli/src/lib/constants.js
+++ b/packages/workbox-cli/src/lib/constants.js
@@ -19,4 +19,7 @@ module.exports = {
   ignoredDirectories: [
     'node_modules',
   ],
+  ignoredFileExtensions: [
+    'map',
+  ],
 };

--- a/packages/workbox-cli/src/lib/questions/ask-extensions-to-cache.js
+++ b/packages/workbox-cli/src/lib/questions/ask-extensions-to-cache.js
@@ -54,7 +54,6 @@ async function getAllFileExtensions(globDirectory) {
   const extensions = new Set();
   for (const file of files) {
     const extension = path.extname(file);
-    // We skip a few extensions that never make sense to precache.
     if (extension) {
       // Get rid of the leading . character.
       extensions.add(extension.replace(/^\./, ''));

--- a/packages/workbox-cli/src/lib/questions/ask-extensions-to-cache.js
+++ b/packages/workbox-cli/src/lib/questions/ask-extensions-to-cache.js
@@ -21,7 +21,7 @@ const ora = require('ora');
 const path = require('path');
 
 const errors = require('../errors');
-const {ignoredDirectories} = require('../constants');
+const {ignoredDirectories, ignoredFileExtensions} = require('../constants');
 
 // The key used for the question/answer.
 const name = 'globPatterns';
@@ -38,7 +38,10 @@ async function getAllFileExtensions(globDirectory) {
     glob('**/*.*', {
       cwd: globDirectory,
       nodir: true,
-      ignore: ignoredDirectories.map((directory) => `**/${directory}/**`),
+      ignore: [
+        ...ignoredDirectories.map((directory) => `**/${directory}/**`),
+        ...ignoredFileExtensions.map((extension) => `**/*.${extension}`),
+      ],
     }, (error, files) => {
       if (error) {
         reject(error);
@@ -51,6 +54,7 @@ async function getAllFileExtensions(globDirectory) {
   const extensions = new Set();
   for (const file of files) {
     const extension = path.extname(file);
+    // We skip a few extensions that never make sense to precache.
     if (extension) {
       // Get rid of the leading . character.
       extensions.add(extension.replace(/^\./, ''));

--- a/test/workbox-cli/node/lib/questions/ask-extensions-to-cache.js
+++ b/test/workbox-cli/node/lib/questions/ask-extensions-to-cache.js
@@ -100,5 +100,26 @@ describe(`[workbox-cli] lib/questions/ask-extensions-to-cache.js`, function() {
     const answer = await askExtensionsToCache(GLOB_DIRECTORY);
     expect(answer).to.eql([`**/*.{${MULTIPLE_EXTENSIONS.join(',')}}`]);
   });
+
+  it(`should ignore the expected directories and extensions`, async function() {
+    const askExtensionsToCache = proxyquire(MODULE_PATH, {
+      glob: (pattern, config, callback) => {
+        expect(config.ignore).to.eql(['**/node_modules/**', '**/*.map']);
+        callback(null, MULTIPLE_EXTENSIONS.map((extension) => `file.${extension}`));
+      },
+      inquirer: {
+        prompt: () => Promise.resolve({[QUESTION_NAME]: MULTIPLE_EXTENSIONS}),
+      },
+      ora: () => {
+        return {
+          start: () => {
+            return {stop: () => {}};
+          },
+        };
+      },
+    });
+
+    await askExtensionsToCache(GLOB_DIRECTORY);
+  });
 });
 


### PR DESCRIPTION
R: @gauntface

Fixes #1239 