### PR TITLE
Make workbox sw chunk prefix with public path

### DIFF
--- a/packages/workbox-webpack-plugin/src/lib/get-workbox-sw-imports.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-workbox-sw-imports.js
@@ -61,7 +61,9 @@ async function getWorkboxSWImport(compilation, config) {
         // Make sure that we actually have a chunk with the appropriate name.
         if (chunk.name === config.importWorkboxFrom) {
           config.excludeChunks.push(chunk.name);
-          return chunk.files;
+          return chunk.files.map((file) => {
+            return (compilation.options.output.publicPath || '') + file;
+          });
         }
       }
 


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

Fixes https://github.com/GoogleChrome/workbox/issues/1261

*Description of what's changed/fixed.*
This fix is intended for the following two configurations:
- Webpack plugin InjectManifest is used
- Webpack compiler is configured with `output.publicPath`
- `importWorkboxFrom` plugin option is set to a string, which points to a valid Webpack chunk name.

The fix is to ensure the generated `importScripts` statement will prefix the Webpack workbox chunk with `output.publicPath`
