### PR TITLE
Improve the RegExp object validation failure message

### DIFF
--- a/packages/workbox-build/src/entry-points/options/base-schema.js
+++ b/packages/workbox-build/src/entry-points/options/base-schema.js
@@ -17,10 +17,11 @@
 const joi = require('joi');
 
 const defaults = require('./defaults');
+const regExpObject = require('./reg-exp-object');
 
 // Define some common constrains used by all methods.
 module.exports = joi.object().keys({
-  dontCacheBustUrlsMatching: joi.object().type(RegExp),
+  dontCacheBustUrlsMatching: regExpObject,
   globFollow: joi.boolean().default(defaults.globFollow),
   globIgnores: joi.array().items(joi.string()).default(defaults.globIgnores),
   globPatterns: joi.array().items(joi.string()).default(defaults.globPatterns),

--- a/packages/workbox-build/src/entry-points/options/common-generate-schema.js
+++ b/packages/workbox-build/src/entry-points/options/common-generate-schema.js
@@ -18,18 +18,19 @@ const joi = require('joi');
 
 const baseSchema = require('./base-schema');
 const defaults = require('./defaults');
+const regExpObject = require('./reg-exp-object');
 
 // Add some constraints that apply to both generateSW and generateSWString.
 module.exports = baseSchema.keys({
   cacheId: joi.string(),
   clientsClaim: joi.boolean().default(defaults.clientsClaim),
   directoryIndex: joi.string(),
-  ignoreUrlParametersMatching: joi.array().items(joi.object().type(RegExp)),
+  ignoreUrlParametersMatching: joi.array().items(regExpObject),
   navigateFallback: joi.string().default(defaults.navigateFallback),
-  navigateFallbackBlacklist: joi.array().items(joi.object().type(RegExp)),
-  navigateFallbackWhitelist: joi.array().items(joi.object().type(RegExp)),
+  navigateFallbackBlacklist: joi.array().items(regExpObject),
+  navigateFallbackWhitelist: joi.array().items(regExpObject),
   runtimeCaching: joi.array().items(joi.object().keys({
-    urlPattern: [joi.object().type(RegExp), joi.string()],
+    urlPattern: [regExpObject, joi.string()],
     handler: [joi.func(), joi.string().valid(
       'cacheFirst',
       'cacheOnly',

--- a/packages/workbox-build/src/entry-points/options/reg-exp-object.js
+++ b/packages/workbox-build/src/entry-points/options/reg-exp-object.js
@@ -16,13 +16,5 @@
 
 const joi = require('joi');
 
-const baseSchema = require('./base-schema');
-const defaults = require('./defaults');
-const regExpObject = require('./reg-exp-object');
-
-module.exports = baseSchema.keys({
-  globDirectory: joi.string().required(),
-  injectionPointRegexp: regExpObject.default(defaults.injectionPointRegexp),
-  swSrc: joi.string().required(),
-  swDest: joi.string().required(),
-});
+module.exports = joi.object().type(RegExp)
+  .error(() => 'the value must be a RegExp');


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #1262 

This leads to error messages like:

```
child "dontCacheBustUrlsMatching" fails because [the value must be a RegExp]
```