### PR TITLE
Remove some BCU integration flakiness by pre-populating the cache in the SW

### DIFF
--- a/test/workbox-broadcast-cache-update/integration/broadcast-cache-update-plugin.js
+++ b/test/workbox-broadcast-cache-update/integration/broadcast-cache-update-plugin.js
@@ -53,10 +53,9 @@ describe(`broadcastCacheUpdate.Plugin`, function() {
     await activateSW(swUrl);
 
     const err = await webdriver.executeAsyncScript((apiUrl, cb) => {
-      // Call fetch(apiUrl) twice. Each response will include a different ETag,
-      // which will trigger the BCU plugin's behavior.
+      // There's already a cached entry for apiUrl created by the
+      // service worker's install handler.
       fetch(apiUrl)
-        .then(() => fetch(apiUrl))
         .then(() => cb())
         .catch((err) => cb(err.message));
     }, apiUrl);

--- a/test/workbox-broadcast-cache-update/static/sw.js
+++ b/test/workbox-broadcast-cache-update/static/sw.js
@@ -3,15 +3,22 @@ importScripts('/__WORKBOX/buildFile/workbox-broadcast-cache-update');
 importScripts('/__WORKBOX/buildFile/workbox-routing');
 importScripts('/__WORKBOX/buildFile/workbox-strategies');
 
+const cacheName = 'bcu-integration-test';
+
 workbox.routing.registerRoute(
   new RegExp('/test/uniqueETag$'),
   workbox.strategies.staleWhileRevalidate({
-    cacheName: 'bcu-integration-test',
+    cacheName,
     plugins: [
       new workbox.broadcastUpdate.Plugin('bcu-integration-test'),
     ],
   })
 );
 
-self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('install', (event) => {
+  // Pre-populate the cache.
+  event.waitUntil(caches.open(cacheName)
+    .then((cache) => cache.add('/test/uniqueETag')));
+  self.skipWaiting();
+});
 self.addEventListener('activate', () => self.clients.claim());


### PR DESCRIPTION
R: @gauntface

Fixes #1272 

There were a couple of tests in v2 that relied on the old `RequestWrapper'`s `waitOnCache` config option to ensure that the async cache writes were done before moving on to the next step of the test. Since that's no longer a thing in v3, doing two sequential `fetch()`es might be a bit flakey.