### PR TITLE
Support for the new webpack v4 plugin architecture.

### DIFF
--- a/packages/workbox-webpack-plugin/package.json
+++ b/packages/workbox-webpack-plugin/package.json
@@ -32,7 +32,7 @@
     "workbox-build": "^3.0.0-alpha.6"
   },
   "peerDependencies": {
-    "webpack": "^2.0.0 || ^3.0.0"
+    "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "author": "Will Farley <a.will.farley@gmail.com> (http://www.willfarley.org/)",
   "license": "Apache-2.0",

--- a/packages/workbox-webpack-plugin/src/generate-sw.js
+++ b/packages/workbox-webpack-plugin/src/generate-sw.js
@@ -97,11 +97,20 @@ class GenerateSW {
    * @private
    */
   apply(compiler) {
-    compiler.plugin('emit', (compilation, callback) => {
-      this.handleEmit(compilation)
-        .then(callback)
-        .catch(callback);
-    });
+    if ('hooks' in compiler) {
+      // We're in webpack 4+.
+      compiler.hooks.emit.tapPromise(
+        this.constructor.name,
+        (compilation) => this.handleEmit(compilation)
+      );
+    } else {
+      // We're in webpack 2 or 3.
+      compiler.plugin('emit', (compilation, callback) => {
+        this.handleEmit(compilation)
+          .then(callback)
+          .catch(callback);
+      });
+    }
   }
 }
 

--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -129,11 +129,21 @@ ${originalSWString}
    * @private
    */
   apply(compiler) {
-    compiler.plugin('emit', (compilation, callback) => {
-      this.handleEmit(compilation, compiler.inputFileSystem._readFile)
-        .then(callback)
-        .catch(callback);
-    });
+    if ('hooks' in compiler) {
+      // We're in webpack 4+.
+      compiler.hooks.emit.tapPromise(
+        this.constructor.name,
+        (compilation) => this.handleEmit(compilation,
+          compiler.inputFileSystem._readFile)
+      );
+    } else {
+      // We're in webpack 2 or 3.
+      compiler.plugin('emit', (compilation, callback) => {
+        this.handleEmit(compilation, compiler.inputFileSystem._readFile)
+          .then(callback)
+          .catch(callback);
+      });
+    }
   }
 }
 


### PR DESCRIPTION
R: @addyosmani @gauntface
CC: @goldhand @TheLarkInn

Fixes #1151 

I'd like to get this out there in the next release to at least ensure that folks who are early adopters of webpack v4 get a chance to try it out in real-world scenarios. It's a small change that should be backwards compatible with users still on webpack v3.

This has been a bit hard to test manually, since most of our webpack integration tests rely on other plugins that aren't yet webpack v4 compatible. I did some manual tests of basic compilations using the latest webpack v4 beta, and it seemed to work, though.

I'm also not sure how we could update our tests to work with both webpack v3 and v4, along with the corresponding versions of plugins that are compatible with each. The strategy moving forward might be just to keep our tests against webpack v3 for now, and migrate to testing against webpack v4 once that is fully released and gets some traction.
