### PR TITLE
Prevent multiple precache manifest in webpack development

### DIFF
--- a/packages/workbox-webpack-plugin/src/generate-sw.js
+++ b/packages/workbox-webpack-plugin/src/generate-sw.js
@@ -66,26 +66,26 @@ class GenerateSW {
     const workboxSWImports = await getWorkboxSWImports(
       compilation, this.config);
     const entries = getManifestEntriesFromCompilation(compilation, this.config);
+    const importScriptsArray = [].concat(this.config.importScripts);
 
     const manifestString = stringifyManifest(entries);
     const manifestAsset = convertStringToAsset(manifestString);
     const manifestHash = getAssetHash(manifestAsset);
     const manifestFilename = `precache-manifest.${manifestHash}.js`;
     compilation.assets[manifestFilename] = manifestAsset;
-    this.config.importScripts.push(
+    importScriptsArray.push(
       (compilation.options.output.publicPath || '') + manifestFilename);
 
     // workboxSWImports might be null if importWorkboxFrom is 'disabled'.
     if (workboxSWImports) {
-      // workboxSWImport is an array, so use concat() rather than push().
-      this.config.importScripts = this.config.importScripts.concat(
-        workboxSWImports);
+      importScriptsArray.push(...workboxSWImports);
     }
 
     const sanitizedConfig = sanitizeConfig.forGenerateSWString(this.config);
     // If globPatterns isn't explicitly set, then default to [], instead of
     // the workbox-build.generateSWString() default.
     sanitizedConfig.globPatterns = sanitizedConfig.globPatterns || [];
+    sanitizedConfig.importScripts = importScriptsArray;
     const serviceWorker = await generateSWString(sanitizedConfig);
     compilation.assets[this.config.swDest] =
       convertStringToAsset(serviceWorker);

--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -80,6 +80,7 @@ class InjectManifest {
     const workboxSWImports = await getWorkboxSWImports(
       compilation, this.config);
     let entries = getManifestEntriesFromCompilation(compilation, this.config);
+    const importScriptsArray = [].concat(this.config.importScripts);
 
     const sanitizedConfig = sanitizeConfig.forGetManifest(this.config);
     // If there are any "extra" config options remaining after we remove the
@@ -98,19 +99,17 @@ class InjectManifest {
     const manifestHash = getAssetHash(manifestAsset);
     const manifestFilename = `precache-manifest.${manifestHash}.js`;
     compilation.assets[manifestFilename] = manifestAsset;
-    this.config.importScripts.push(
+    importScriptsArray.push(
       (compilation.options.output.publicPath || '') + manifestFilename);
 
     // workboxSWImports might be null if importWorkboxFrom is 'disabled'.
     if (workboxSWImports) {
-      // workboxSWImport is an array, so use concat() rather than push().
-      this.config.importScripts = this.config.importScripts.concat(
-        workboxSWImports);
+      Array.prototype.push.apply(importScriptsArray, workboxSWImports);
     }
 
     const originalSWString = await readFileWrapper(readFile, this.config.swSrc);
 
-    const importScriptsString = this.config.importScripts
+    const importScriptsString = importScriptsArray
       .map(JSON.stringify)
       .join(', ');
 

--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -104,7 +104,7 @@ class InjectManifest {
 
     // workboxSWImports might be null if importWorkboxFrom is 'disabled'.
     if (workboxSWImports) {
-      Array.prototype.push.apply(importScriptsArray, workboxSWImports);
+      importScriptsArray.push(...workboxSWImports);
     }
 
     const originalSWString = await readFileWrapper(readFile, this.config.swSrc);

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -89,6 +89,74 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
   });
 
+  describe(`[workbox-webpack-plugin] Ensure only one precache-manifest is present on re-compile`, function() {
+    it(`should only have one reference to precache-manifest file in 'importScripts'`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.b6f6b1b151c4f027ee1e1aa3061eeaf7.js';
+      const outputDir = tempy.directory();
+      const config = {
+        entry: {
+          entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+          entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        },
+        output: {
+          filename: '[name]-[chunkhash].js',
+          path: outputDir,
+        },
+        plugins: [
+          new GenerateSW(),
+        ],
+      };
+      let emitCount = 0;
+
+      const compiler = webpack(config);
+      const watching = compiler.watch({
+      }, async (err, stats) => {
+        emitCount += 1;
+
+        if (err) {
+          done(err);
+          return;
+        }
+
+        const swFile = path.join(outputDir, 'service-worker.js');
+
+        try {
+          // First, validate that the generated service-worker.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [[
+              FILE_MANIFEST_NAME,
+              WORKBOX_SW_FILE_NAME,
+            ]],
+            suppressWarnings: [[]],
+            precacheAndRoute: [[[], {}]],
+          }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            url: 'entry2-17c2a1b5c94290899539.js',
+          }, {
+            url: 'entry1-d7f4e7088b64a9896b23.js',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          if (emitCount == 2) {
+            watching.close(done);
+          } else {
+            watching.invalidate(); // triggers second compilation
+          }
+        } catch (error) {
+          watching.close();
+          done(error);
+        }
+      });
+    });
+  });
+
   describe(`[workbox-webpack-plugin] multiple chunks`, function() {
     it(`should work when called without any parameters`, function(done) {
       const FILE_MANIFEST_NAME = 'precache-manifest.b6f6b1b151c4f027ee1e1aa3061eeaf7.js';


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

Fixes https://github.com/GoogleChrome/workbox/issues/1267

*Description of what's changed/fixed.*
When in Webpack development mode where, regardless of using Webpack dev server, if Webpack watches the source change and re-compiles accordingly, the bug manifests itself as:

- precache-mainfest.js & workbox-sw path will be included multiple times, within `importScripts` from the generated service worker script.
- It appears in both `InjectManifest` and `GenerateSW`

### How to reproduce the bug
By `git checkout` the fixes on the latest `v3`, and run it against the tests.