### PR TITLE
adding bg-sync tag name check

### DIFF
--- a/packages/workbox-background-sync/Queue.mjs
+++ b/packages/workbox-background-sync/Queue.mjs
@@ -94,8 +94,10 @@ class Queue {
     await this._runCallback('requestWillEnqueue', storableRequest);
     await this._queueStore.addEntry(storableRequest);
     await this._registerSync();
-    logger.log(`Request for '${request.url}' has been added to
-        background sync queue '${this._name}'.`);
+    if (process.env.NODE_ENV !== 'production') {
+      logger.log(`Request for '${request.url}' has been added to
+          background sync queue '${this._name}'.`);
+    }
   }
 
   /**
@@ -171,10 +173,17 @@ class Queue {
     if ('sync' in registration) {
       self.addEventListener('sync', (event) => {
         if (event.tag === `${TAG_PREFIX}:${this._name}`) {
+          if (process.env.NODE_ENV !== 'production') {
+            logger.log(`Background sync for tag '${event.tag}'
+                has been received, starting replay now`);
+          }
           event.waitUntil(this.replayRequests());
         }
       });
     } else {
+      if (process.env.NODE_ENV !== 'production') {
+        logger.log(`Background sync replaying without background sync event`);
+      }
       // If the browser doesn't support background sync, retry
       // every time the service worker starts up as a fallback.
       this.replayRequests();

--- a/packages/workbox-background-sync/Queue.mjs
+++ b/packages/workbox-background-sync/Queue.mjs
@@ -94,6 +94,8 @@ class Queue {
     await this._runCallback('requestWillEnqueue', storableRequest);
     await this._queueStore.addEntry(storableRequest);
     await this._registerSync();
+    logger.log(`Request for '${request.url}' has been added to
+        background sync queue '${this._name}'.`);
   }
 
   /**
@@ -168,7 +170,9 @@ class Queue {
   _addSyncListener() {
     if ('sync' in registration) {
       self.addEventListener('sync', (event) => {
-        event.waitUntil(this.replayRequests());
+        if (event.tag === `${TAG_PREFIX}:${this._name}`) {
+          event.waitUntil(this.replayRequests());
+        }
       });
     } else {
       // If the browser doesn't support background sync, retry

--- a/test/workbox-background-sync/node/test-Queue.mjs
+++ b/test/workbox-background-sync/node/test-Queue.mjs
@@ -79,6 +79,11 @@ describe(`[workbox-background-sync] Queue`, function() {
         tag: 'workbox-background-sync:foo',
       }));
 
+      // replayRequests should not be called for this due to incorrect tag name
+      self.dispatchEvent(new SyncEvent('sync', {
+        tag: 'workbox-background-sync:bar',
+      }));
+
       expect(Queue.prototype.replayRequests.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

Adds a check for tag name before replaying the requests in background sync queue.