### PR TITLE
Gracefully no-op when BroadcastChannel doesn't exist

### DIFF
--- a/packages/workbox-background-sync/src/lib/background-sync-queue.js
+++ b/packages/workbox-background-sync/src/lib/background-sync-queue.js
@@ -68,7 +68,7 @@ class Queue {
       isType({maxRetentionTime}, 'number');
     }
 
-    if (broadcastChannel) {
+    if ('BroadcastChannel' in self && broadcastChannel) {
       isInstance({broadcastChannel}, BroadcastChannel);
     }
 

--- a/packages/workbox-background-sync/src/lib/broadcast-manager.js
+++ b/packages/workbox-background-sync/src/lib/broadcast-manager.js
@@ -12,7 +12,7 @@ import {isType, isInstance} from '../../../../lib/assert';
  * @private
  */
 function broadcastMessage({broadcastChannel, type, url}) {
-  if (!broadcastChannel) {
+  if (!('BroadcastChannel' in self) || !broadcastChannel) {
     return;
   }
 

--- a/packages/workbox-background-sync/test/browser/broadcast-manager.js
+++ b/packages/workbox-background-sync/test/browser/broadcast-manager.js
@@ -15,22 +15,24 @@
 
 import * as broadcastManager from '../../src/lib/broadcast-manager.js';
 
-describe(`broadcast manager`, function() {
-  it(`should broadcast message on given channel name`, function(done) {
-    this.timeout(100);
-    let msgRead = false;
-    const channelName = 'CHANNEL';
-    const testBroadcastChannel = new BroadcastChannel(channelName);
-    const testReceiverChannel = new BroadcastChannel(channelName);
-    testReceiverChannel.onmessage = function() {
-      msgRead = true;
-      expect(msgRead).to.be.true;
-      done();
-    };
-    broadcastManager.broadcastMessage({
-      broadcastChannel: testBroadcastChannel,
-      type: 'SUCCESS',
-      url: 'http://google.com',
+if ('BroadcastChannel' in self) {
+  describe(`broadcast manager`, function() {
+    it(`should broadcast message on given channel name`, function(done) {
+      this.timeout(100);
+      let msgRead = false;
+      const channelName = 'CHANNEL';
+      const testBroadcastChannel = new BroadcastChannel(channelName);
+      const testReceiverChannel = new BroadcastChannel(channelName);
+      testReceiverChannel.onmessage = function() {
+        msgRead = true;
+        expect(msgRead).to.be.true;
+        done();
+      };
+      broadcastManager.broadcastMessage({
+        broadcastChannel: testBroadcastChannel,
+        type: 'SUCCESS',
+        url: 'http://google.com',
+      });
     });
   });
-});
+}

--- a/packages/workbox-broadcast-cache-update/src/lib/broadcast-cache-update.js
+++ b/packages/workbox-broadcast-cache-update/src/lib/broadcast-cache-update.js
@@ -103,7 +103,13 @@ class BroadcastCacheUpdate {
    */
   get channel() {
     if (!this._channel) {
-      this._channel = new BroadcastChannel(this.channelName);
+      if ('BroadcastChannel' in self) {
+        this._channel = new BroadcastChannel(this.channelName);
+      } else {
+        this._channel = {
+          postMessage: () => {},
+        };
+      }
     }
     return this._channel;
   }

--- a/packages/workbox-broadcast-cache-update/src/lib/broadcast-update.js
+++ b/packages/workbox-broadcast-cache-update/src/lib/broadcast-update.js
@@ -63,7 +63,12 @@ import {cacheUpdatedMessageType} from './constants';
  *        of the update message.
  */
 function broadcastUpdate({channel, cacheName, url, source} = {}) {
+  if (!('BroadcastChannel' in self)) {
+    return;
+  }
+
   isInstance({channel}, BroadcastChannel);
+
   isType({cacheName}, 'string');
   isType({source}, 'string');
   isType({url}, 'string');

--- a/packages/workbox-broadcast-cache-update/test/sw/broadcast-cache-update.js
+++ b/packages/workbox-broadcast-cache-update/test/sw/broadcast-cache-update.js
@@ -53,14 +53,16 @@ describe(`Test of the BroadcastCacheUpdate class`, function() {
     expect(bcu.source).to.not.be.empty;
   });
 
-  it(`should create and reuse a BroadcastChannel based on channelName`, function() {
-    const bcu = new BroadcastCacheUpdate({channelName});
-    const broadcastChannel = bcu.channel;
-    expect(broadcastChannel).to.be.instanceof(BroadcastChannel);
-    // bcu.channel is a getter that create a BroadcastChannel the first
-    // time it's called, and this test confirms that it returns the same
-    // BroadcastChannel object when called twice.
-    expect(broadcastChannel).to.eql(bcu.channel);
-    expect(broadcastChannel.name).to.equal(channelName);
-  });
+  if ('BroadcastChannel' in self) {
+    it(`should create and reuse a BroadcastChannel based on channelName`, function() {
+      const bcu = new BroadcastCacheUpdate({channelName});
+      const broadcastChannel = bcu.channel;
+      expect(broadcastChannel).to.be.instanceof(BroadcastChannel);
+      // bcu.channel is a getter that create a BroadcastChannel the first
+      // time it's called, and this test confirms that it returns the same
+      // BroadcastChannel object when called twice.
+      expect(broadcastChannel).to.eql(bcu.channel);
+      expect(broadcastChannel.name).to.equal(channelName);
+    });
+  }
 });

--- a/packages/workbox-broadcast-cache-update/test/sw/broadcast-update.js
+++ b/packages/workbox-broadcast-cache-update/test/sw/broadcast-update.js
@@ -18,32 +18,35 @@
 import {cacheUpdatedMessageType} from '../../src/lib/constants.js';
 import broadcastUpdate from '../../src/lib/broadcast-update.js';
 
-describe(`Test of the broadcastUpdate function`, function() {
-  const channelName = 'test-channel';
-  const channel = new BroadcastChannel(channelName);
-  const cacheName = 'test-cache';
-  const url = 'https://example.com';
-  const source = 'test-source';
+if ('BroadcastChannel' in self) {
+  describe(`Test of the broadcastUpdate function`, function() {
+    const channelName = 'test-channel';
+    const channel = new BroadcastChannel(channelName);
+    const cacheName = 'test-cache';
+    const url = 'https://example.com';
+    const source = 'test-source';
 
-  it(`should throw when broadcastUpdate() is called without any parameters`, function() {
-    expect(() => {
-      broadcastUpdate();
-    }).to.throw().with.property('name', 'assertion-failed');
-  });
-
-  it(`should trigger the appropriate message event on a BroadcastChannel with the same channel name`, function(done) {
-    const secondChannel = new BroadcastChannel(channelName);
-    secondChannel.addEventListener('message', (event) => {
-      expect(event.data).to.eql({
-        type: cacheUpdatedMessageType,
-        meta: source,
-        payload: {
-          cacheName,
-          updatedUrl: url,
-        },
-      });
-      done();
+    it(`should throw when broadcastUpdate() is called without any parameters`, function() {
+      expect(() => {
+        broadcastUpdate();
+      }).to.throw().with.property('name', 'assertion-failed');
     });
-    broadcastUpdate({channel, cacheName, source, url});
+
+
+    it(`should trigger the appropriate message event on a BroadcastChannel with the same channel name`, function(done) {
+      const secondChannel = new BroadcastChannel(channelName);
+      secondChannel.addEventListener('message', (event) => {
+        expect(event.data).to.eql({
+          type: cacheUpdatedMessageType,
+          meta: source,
+          payload: {
+            cacheName,
+            updatedUrl: url,
+          },
+        });
+        done();
+      });
+      broadcastUpdate({channel, cacheName, source, url});
+    });
   });
-});
+}


### PR DESCRIPTION
R: @gauntface @addyosmani 

Needed for Safari compatibility.

Checking for `'BroadcastChannel' in self` and effectively no-op'ing if it wasn't defined seems preferable to doing something more forceful, like throwing an error.

I'm wrapping the tests that assume `BroadcastChannel` in a similar conditional, but if there's a preferred way of conditionally skipping them, let me know.