### PR TITLE
Consistently use broadcastUpdate instead of broadcastCacheUpdate

### DIFF
--- a/packages/workbox-build/src/entry-points/options/common-generate-schema.js
+++ b/packages/workbox-build/src/entry-points/options/common-generate-schema.js
@@ -43,7 +43,7 @@ module.exports = baseSchema.keys({
         name: joi.string().required(),
         options: joi.object(),
       }),
-      broadcastCacheUpdate: joi.object().keys({
+      broadcastUpdate: joi.object().keys({
         channelName: joi.string().required(),
         options: joi.object(),
       }),

--- a/packages/workbox-build/src/lib/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/runtime-caching-converter.js
@@ -44,7 +44,7 @@ function getOptionsString(options = {}) {
 
   const pluginsMapping = {
     backgroundSync: 'workbox.backgroundSync.Plugin',
-    broadcastCacheUpdate: 'workbox.broadcastCacheUpdate.Plugin',
+    broadcastUpdate: 'workbox.broadcastUpdate.Plugin',
     expiration: 'workbox.expiration.Plugin',
     cacheableResponse: 'workbox.cacheableResponse.Plugin',
   };

--- a/test/workbox-build/node/lib/runtime-caching-converter.js
+++ b/test/workbox-build/node/lib/runtime-caching-converter.js
@@ -22,6 +22,9 @@ function validate(runtimeCachingOptions, convertedOptions) {
       expiration: {
         Plugin: sinon.spy(),
       },
+      broadcastUpdate: {
+        Plugin: sinon.spy(),
+      },
       routing: {
         registerRoute: sinon.spy(),
       },
@@ -75,6 +78,10 @@ function validate(runtimeCachingOptions, convertedOptions) {
 
       if (options.cacheableResponse) {
         expect(globalScope.workbox.cacheableResponse.Plugin.calledWith(options.cacheableResponse)).to.be.true;
+      }
+
+      if (options.broadcastUpdate) {
+        expect(globalScope.workbox.broadcastUpdate.Plugin.calledWith(options.broadcastUpdate)).to.be.true;
       }
     }
   });
@@ -139,6 +146,9 @@ describe(`[workbox-build] src/lib/utils/runtime-caching-converter.js`, function(
         },
         cacheableResponse: {
           statuses: [0, 200],
+        },
+        broadcastUpdate: {
+          channelName: 'test',
         },
       },
     }];


### PR DESCRIPTION
R: @addyosmani @gauntface
CC: @mischnic

Fixes #1289

This is just normalizing the `runtimeCaching` option key to match the namespace that's exposed by `workbox-sw`.

~~I'll make a corresponding change to the docs.~~ The docs have the correct value already.