### PR TITLE
Set credentials: 'same-origin' on the precaching requests.

### DIFF
--- a/infra/testing/sw-env-mocks/Request.js
+++ b/infra/testing/sw-env-mocks/Request.js
@@ -33,6 +33,9 @@ class Request {
     this.url = url;
     this.method = options.method || 'GET';
     this.mode = options.mode || 'cors';
+    // See https://fetch.spec.whatwg.org/#concept-request-credentials-mode
+    this.credentials = options.credentials || (this.mode === 'navigate' ?
+      'include' : 'omit');
     this.headers = new Headers(options.headers);
 
     this._body = new Blob('body' in options ? [options.body] : []);

--- a/packages/workbox-precaching/models/PrecacheEntry.mjs
+++ b/packages/workbox-precaching/models/PrecacheEntry.mjs
@@ -36,7 +36,7 @@ export default class PrecacheEntry {
     this._originalInput = originalInput;
     this._entryId = url;
     this._revision = revision;
-    const requestAsCacheKey = new Request(url);
+    const requestAsCacheKey = new Request(url, {credentials: 'same-origin'});
     this._cacheRequest = requestAsCacheKey;
     this._networkRequest = shouldCacheBust ?
       this._cacheBustRequest(requestAsCacheKey) : requestAsCacheKey;
@@ -53,7 +53,9 @@ export default class PrecacheEntry {
    */
   _cacheBustRequest(request) {
     let url = request.url;
-    const requestOptions = {};
+    const requestOptions = {
+      credentials: 'same-origin',
+    };
     if ('cache' in Request.prototype) {
       // Make use of the Request cache mode where we can.
       // Reload skips the HTTP cache for outgoing requests and updates

--- a/test/workbox-background-sync/node/test-Queue.mjs
+++ b/test/workbox-background-sync/node/test-Queue.mjs
@@ -128,6 +128,7 @@ describe(`[workbox-background-sync] Queue`, function() {
         'body',
         'headers',
         'mode',
+        'credentials',
       ]);
     });
 

--- a/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
@@ -408,6 +408,21 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       expect(fetchWrapper.fetch.args[0][2]).to.equal(testPlugins);
       expect(cacheWrapper.put.args[0][3]).to.equal(testPlugins);
     });
+
+    it(`it should set credentials: 'same-origin' on the precaching requests`, async function() {
+      sandbox.spy(fetchWrapper, 'fetch');
+
+      const precacheController = new PrecacheController();
+      const cacheList = [
+        '/index.1234.html',
+      ];
+      precacheController.addToCacheList(cacheList);
+
+      await precacheController.install();
+
+      const request = fetchWrapper.fetch.args[0][0];
+      expect(request.credentials).to.eql('same-origin');
+    });
   });
 
   describe(`cleanup()`, function() {


### PR DESCRIPTION
R: @addyosmani @gauntface
CC: @mnquintana

Fixes #1288

Rather than passing in `{credentials: 'same-origin'}` when calling `fetch()`, it seemed a bit more self-contained to explicitly set the `credentials` property on the underlying `Request` object that the precaching code uses.