### PR TITLE
Safari groups

### DIFF
--- a/infra/testing/sw-env.js
+++ b/infra/testing/sw-env.js
@@ -63,6 +63,9 @@ global.SyncEvent = SyncEvent;
 global.URLSearchParams = URLSearchParams;
 global.BroadcastChannel = BroadcastChannel;
 
+global.navigator = global.navigator || {};
+global.navigator.userAgent = global.navigator.userAgent || 'Workbox User Agent';
+
 // TODO: Remove when fixed in service-worker-mock:
 // https://github.com/pinterest/service-workers/issues/71
 const origMatch = caches.match;

--- a/packages/workbox-core/_private/logger.mjs
+++ b/packages/workbox-core/_private/logger.mjs
@@ -18,6 +18,7 @@ import LOG_LEVELS from '../models/LogLevels.mjs';
 import '../_version.mjs';
 
 // Safari doesn't print all console.groupCollapsed() arguments.
+// Related bug: https://bugs.webkit.org/show_bug.cgi?id=182754
 const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
 const GREY = `#7f8c8d`;

--- a/packages/workbox-core/_private/logger.mjs
+++ b/packages/workbox-core/_private/logger.mjs
@@ -17,6 +17,9 @@
 import LOG_LEVELS from '../models/LogLevels.mjs';
 import '../_version.mjs';
 
+// Safari doesn't print all console.groupCollapsed() arguments.
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
 const GREY = `#7f8c8d`;
 const GREEN = `#2ecc71`;
 const YELLOW = `#f39c12`;
@@ -41,7 +44,7 @@ const _print = function(keyName, logArgs, levelColor) {
     return;
   }
 
-  if (!levelColor) {
+  if (!levelColor || (keyName === 'groupCollapsed' && isSafari)) {
     console[keyName](...logArgs);
     return;
   }


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

Fixes #1296

On Safari, don't log the `Workbox` prefix in logs as it silences the rest of the arguments. I checked the code and we only ever use a single string in group titles, so it's only the prefix that is the issue.
