### PR TITLE
Fail Webpack build when `chunks` and `excludeChunks` are missing from compilation

### DIFF
--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -90,6 +90,88 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         }
       });
     });
+
+    it(`should throw when any of the specified chunks is missing from the compilation`, (done) => {
+      const outputDir = tempy.directory();
+      const config = {
+        entry: {
+          entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        },
+        output: {
+          filename: '[name]-[chunkhash].js',
+          path: outputDir,
+        },
+        plugins: [
+          new GenerateSW({
+            chunks: [
+              'chunkDoesNotExist',
+              'anotherMissingChunk',
+            ],
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run((webpackError, stats) => {
+        if (webpackError || stats.hasErrors()) {
+          if (stats.hasErrors()) {
+            const webpackStats = stats.toJson('minimal');
+            if (webpackStats.errors.reduce((builder, err) => {
+              return builder && /Specified chunks '.+' is missing from the compilation/.test(err);
+            }, true)) {
+              done();
+            } else {
+              done(new Error(`Expected all missing chunks errors to be thrown with the message but some are missing.`));
+            }
+          } else {
+            done(new Error(`An unexpected error was thrown: ${webpackError.message}`));
+          }
+        } else {
+          done(new Error('Unexpected success.'));
+        }
+      });
+    });
+
+    it(`should throw when any of the specified excludeChunks is missing from the compilation`, (done) => {
+      const outputDir = tempy.directory();
+      const config = {
+        entry: {
+          entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        },
+        output: {
+          filename: '[name]-[chunkhash].js',
+          path: outputDir,
+        },
+        plugins: [
+          new GenerateSW({
+            excludeChunks: [
+              'missingExcludeChunk',
+              'anotherMissingExcludeChunk',
+            ],
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run((webpackError, stats) => {
+        if (webpackError || stats.hasErrors()) {
+          if (stats.hasErrors()) {
+            const webpackStats = stats.toJson('minimal');
+            if (webpackStats.errors.reduce((builder, err) => {
+              return builder && /Specified excludeChunks '.+' is missing from the compilation/.test(err);
+            }, true)) {
+              done();
+            } else {
+              done(new Error(`Expected all missing excludeChunks errors to be thrown with the message but some are missing.`));
+            }
+          } else {
+            done(new Error(`An unexpected error was thrown: ${webpackError.message}`));
+          }
+        } else {
+          done(new Error('Unexpected success.'));
+        }
+      });
+    });
   });
 
   describe(`[workbox-webpack-plugin] Ensure only one precache-manifest is present on re-compile`, function() {


### PR DESCRIPTION
Explicit error messages thrown if any of the specified `chunks` or
`excludeChunks` is missing from the compilation. This is ensuring that
the workbox configuration is robust against any changes to the
compilation, resulting in confidence in precaching strategy.

R: @jeffposnick @addyosmani @gauntface

Fixes https://github.com/GoogleChrome/workbox/issues/1287

This PR adds robustness to the Workbox Webpack configuration as we can be confident of the specified `chunks` and `excludeChunks` will be captured in the precache-manifest. If that is not the case, we would add to the compilation errors detailing what was missing.
