### PR TITLE
Analytics fixes

### DIFF
--- a/packages/workbox-background-sync/Queue.mjs
+++ b/packages/workbox-background-sync/Queue.mjs
@@ -124,6 +124,10 @@ class Queue {
 
     let storableRequest;
     while (storableRequest = await this._queueStore.getAndRemoveOldestEntry()) {
+      // Make a copy so the unmodified request can be stored]
+      // in the event of a replay failure.
+      const storableRequestClone = storableRequest.clone();
+
       // Ignore requests older than maxRetentionTime.
       const maxRetentionTimeInMs = this._maxRetentionTime * 60 * 1000;
       if (now - storableRequest.timestamp > maxRetentionTimeInMs) {
@@ -139,7 +143,7 @@ class Queue {
         replay.response = await fetch(replay.request.clone());
       } catch (err) {
         replay.error = err;
-        failedRequests.push(storableRequest);
+        failedRequests.push(storableRequestClone);
       }
 
       replayedRequests.push(replay);

--- a/packages/workbox-background-sync/Queue.mjs
+++ b/packages/workbox-background-sync/Queue.mjs
@@ -124,7 +124,7 @@ class Queue {
 
     let storableRequest;
     while (storableRequest = await this._queueStore.getAndRemoveOldestEntry()) {
-      // Make a copy so the unmodified request can be stored]
+      // Make a copy so the unmodified request can be stored
       // in the event of a replay failure.
       const storableRequestClone = storableRequest.clone();
 

--- a/packages/workbox-background-sync/models/StorableRequest.mjs
+++ b/packages/workbox-background-sync/models/StorableRequest.mjs
@@ -127,4 +127,25 @@ export default class StorableRequest {
   toRequest() {
     return new Request(this.url, this.requestInit);
   }
+
+  /**
+   * Creates and returns a deep clone of the instance.
+   *
+   * @return {StorableRequest}
+   *
+   * @private
+   */
+  clone() {
+    const requestInit = Object.assign({}, this.requestInit);
+    requestInit.headers = Object.assign({}, this.requestInit.headers);
+    if (this.requestInit.body) {
+      requestInit.body = this.requestInit.body.slice();
+    }
+
+    return new StorableRequest({
+      url: this.url,
+      timestamp: this.timestamp,
+      requestInit,
+    });
+  }
 }

--- a/packages/workbox-google-analytics/_default.mjs
+++ b/packages/workbox-google-analytics/_default.mjs
@@ -62,21 +62,28 @@ const getTextFromBlob = async (blob) => {
  * @private
  */
 const createRequestWillReplayCallback = (config) => {
-  return async ({url, timestamp, requestInit}) => {
+  return async (storableRequest) => {
+    let {url, requestInit, timestamp} = storableRequest;
     url = new URL(url);
 
     // Measurement protocol requests can set their payload parameters in either
     // the URL query string (for GET requests) or the POST body.
     let params;
     if (requestInit.body) {
-      const payload = await getTextFromBlob(requestInit.body);
+      const payload = requestInit.body instanceof Blob ?
+          await getTextFromBlob(requestInit.body) : requestInit.body;
+
       params = new URLSearchParams(payload);
     } else {
       params = url.searchParams;
     }
 
-    // Set the qt param prior to apply the hitFilter or parameterOverrides.
-    const queueTime = Date.now() - timestamp;
+    // Calculate the qt param, accounting for the fact that an existing
+    // qt param may be present and should be updated rather than replaced.
+    const originalHitTime = timestamp - (params.get('qt') || 0)
+    const queueTime = Date.now() - originalHitTime;
+
+    // Set the qt param prior to applying the hitFilter or parameterOverrides.
     params.set('qt', queueTime);
 
     if (config.parameterOverrides) {
@@ -94,10 +101,10 @@ const createRequestWillReplayCallback = (config) => {
     requestInit.method = 'POST';
     requestInit.mode = 'cors';
     requestInit.credentials = 'omit';
-    requestInit.headers = '[["Content-Type", "text/plain"]]';
+    requestInit.headers = {'Content-Type': 'text/plain'};
 
-    // Ignore URL search params as they're in the post body.
-    requestInit.url = `${url.origin}${url.pathname}`;
+    // Ignore URL search params as they're now in the post body.
+    storableRequest.url = `${url.origin}${url.pathname}`;
   };
 };
 

--- a/packages/workbox-google-analytics/_default.mjs
+++ b/packages/workbox-google-analytics/_default.mjs
@@ -80,7 +80,7 @@ const createRequestWillReplayCallback = (config) => {
 
     // Calculate the qt param, accounting for the fact that an existing
     // qt param may be present and should be updated rather than replaced.
-    const originalHitTime = timestamp - (params.get('qt') || 0)
+    const originalHitTime = timestamp - (params.get('qt') || 0);
     const queueTime = Date.now() - originalHitTime;
 
     // Set the qt param prior to applying the hitFilter or parameterOverrides.

--- a/test/workbox-background-sync/node/lib/test-StorableRequest.mjs
+++ b/test/workbox-background-sync/node/lib/test-StorableRequest.mjs
@@ -141,4 +141,32 @@ describe(`[workbox-background-sync] StorableRequest`, function() {
       expect(request.headers.get('x-qux')).to.equal('baz');
     });
   });
+
+  describe(`clone`, function() {
+    it(`creates a new instance with the same values`, async function() {
+      const original = new StorableRequest({
+        timestamp: 123456,
+        url: '/foo',
+        requestInit: {
+          body: new Blob(['it worked!']),
+          method: 'POST',
+          mode: 'no-cors',
+          headers: {
+            'x-foo': 'bar',
+            'x-qux': 'baz',
+          },
+        }
+      });
+      const clone = original.clone();
+
+      expect(original.url).to.equal(clone.url);
+      expect(original.timestamp).to.equal(clone.timestamp);
+      expect(original.requestInit).to.deep.equal(clone.requestInit);
+
+      // Ensure clone was not shallow.
+      expect(original.requestInit.body).to.not.equal(clone.requestInit.body);
+      expect(original.requestInit.headers).to.not.equal(
+          clone.requestInit.headers);
+    });
+  });
 });

--- a/test/workbox-background-sync/node/lib/test-StorableRequest.mjs
+++ b/test/workbox-background-sync/node/lib/test-StorableRequest.mjs
@@ -155,7 +155,7 @@ describe(`[workbox-background-sync] StorableRequest`, function() {
             'x-foo': 'bar',
             'x-qux': 'baz',
           },
-        }
+        },
       });
       const clone = original.clone();
 

--- a/test/workbox-google-analytics/node/test-index.mjs
+++ b/test/workbox-google-analytics/node/test-index.mjs
@@ -22,7 +22,6 @@ import {cacheNames} from '../../../packages/workbox-core/_private/cacheNames.mjs
 import {NetworkFirst, NetworkOnly} from '../../../packages/workbox-strategies/index.mjs';
 import * as googleAnalytics from '../../../packages/workbox-google-analytics/index.mjs';
 import {
-  MAX_RETENTION_TIME,
   GOOGLE_ANALYTICS_HOST,
   GTM_HOST,
   ANALYTICS_JS_PATH,
@@ -351,7 +350,6 @@ describe(`[workbox-google-analytics] initialize`, function() {
     const replay2 = self.fetch.secondCall.args[0];
     const replayParams1 = new URLSearchParams(await replay1.text());
     const replayParams2 = new URLSearchParams(await replay2.text());
-    const payloadParams = new URLSearchParams(PAYLOAD);
 
     expect(parseInt(replayParams1.get('qt'))).to.equal(1200);
     expect(parseInt(replayParams2.get('qt'))).to.equal(3100);

--- a/test/workbox-google-analytics/node/test-index.mjs
+++ b/test/workbox-google-analytics/node/test-index.mjs
@@ -259,18 +259,22 @@ describe(`[workbox-google-analytics] initialize`, function() {
   it(`should add the qt param to replayed hits`, async function() {
     sandbox.stub(self, 'fetch').rejects();
     sandbox.spy(Queue.prototype, 'addRequest');
+    const clock = sandbox.useFakeTimers({toFake: ['Date']});
 
     googleAnalytics.initialize();
 
     self.dispatchEvent(new FetchEvent('fetch', {
       request: new Request(`https://${GOOGLE_ANALYTICS_HOST}` +
-          `/collect?${PAYLOAD}&`, {
+          `/collect?${PAYLOAD}`, {
         method: 'GET',
       }),
     }));
 
+    await eventsDoneWaiting();
+    clock.tick(100);
+
     self.dispatchEvent(new FetchEvent('fetch', {
-      request: new Request(`https://${GOOGLE_ANALYTICS_HOST}/collect`, {
+      request: new Request(`https://${GOOGLE_ANALYTICS_HOST}/r/collect`, {
         method: 'POST',
         body: PAYLOAD,
       }),
@@ -281,28 +285,76 @@ describe(`[workbox-google-analytics] initialize`, function() {
     self.fetch.restore();
     sandbox.stub(self, 'fetch').resolves(new Response('', {status: 200}));
 
-    const [queuePlugin] = Queue.prototype.addRequest.thisValues;
-    await queuePlugin.replayRequests();
+    const [queue] = Queue.prototype.addRequest.thisValues;
+
+    clock.tick(100);
+
+    await queue.replayRequests();
 
     expect(self.fetch.callCount).to.equal(2);
 
     const replay1 = self.fetch.firstCall.args[0];
     const replay2 = self.fetch.secondCall.args[0];
-
+    expect(replay1.url).to.equal(`https://${GOOGLE_ANALYTICS_HOST}/collect`);
+    expect(replay2.url).to.equal(`https://${GOOGLE_ANALYTICS_HOST}/r/collect`);
 
     const replayParams1 = new URLSearchParams(await replay1.text());
     const replayParams2 = new URLSearchParams(await replay2.text());
     const payloadParams = new URLSearchParams(PAYLOAD);
 
-    expect(parseInt(replayParams1.get('qt'))).to.be.above(0);
-    expect(parseInt(replayParams1.get('qt'))).to.be.below(MAX_RETENTION_TIME);
-    expect(parseInt(replayParams2.get('qt'))).to.be.above(0);
-    expect(parseInt(replayParams2.get('qt'))).to.be.below(MAX_RETENTION_TIME);
+    expect(parseInt(replayParams1.get('qt'))).to.equal(200);
+    expect(parseInt(replayParams2.get('qt'))).to.equal(100);
 
     for (const [key, value] of payloadParams.entries()) {
       expect(replayParams1.get(key)).to.equal(value);
       expect(replayParams2.get(key)).to.equal(value);
     }
+  });
+
+  it(`should update an existing qt param`, async function() {
+    sandbox.stub(self, 'fetch').rejects();
+    sandbox.spy(Queue.prototype, 'addRequest');
+    const clock = sandbox.useFakeTimers({toFake: ['Date']});
+
+    googleAnalytics.initialize();
+
+    self.dispatchEvent(new FetchEvent('fetch', {
+      request: new Request(`https://${GOOGLE_ANALYTICS_HOST}` +
+          `/collect?${PAYLOAD}&qt=1000`, {
+        method: 'GET',
+      }),
+    }));
+
+    await eventsDoneWaiting();
+    clock.tick(100);
+
+    self.dispatchEvent(new FetchEvent('fetch', {
+      request: new Request(`https://${GOOGLE_ANALYTICS_HOST}/r/collect`, {
+        method: 'POST',
+        body: `${PAYLOAD}&qt=3000`,
+      }),
+    }));
+
+    await eventsDoneWaiting();
+
+    self.fetch.restore();
+    sandbox.stub(self, 'fetch').resolves(new Response('', {status: 200}));
+
+    const [queue] = Queue.prototype.addRequest.thisValues;
+
+    clock.tick(100);
+    await queue.replayRequests();
+
+    expect(self.fetch.callCount).to.equal(2);
+
+    const replay1 = self.fetch.firstCall.args[0];
+    const replay2 = self.fetch.secondCall.args[0];
+    const replayParams1 = new URLSearchParams(await replay1.text());
+    const replayParams2 = new URLSearchParams(await replay2.text());
+    const payloadParams = new URLSearchParams(PAYLOAD);
+
+    expect(parseInt(replayParams1.get('qt'))).to.equal(1200);
+    expect(parseInt(replayParams2.get('qt'))).to.equal(3100);
   });
 
   it(`should add parameterOverrides to replayed hits`, async function() {


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

Fixes #1309 

This PR fixes the error in #1309, which was resulting from `workbox-google-analytics` setting the replayed request headers as the string ` '[["Content-Type", "text/plain"]]'` instead of the object.

This likely means none of the replays were working, something that ideally should have been caught by an integration test. I'll put together another PR to make sure an integration test exists that ensures the entire process works. (Note, the node tests didn't catch this because we use header mock that didn't error here when they should have. Not sure if anything should be done about that though.)

In the process of manually testing it, I noticed a few other issues that I fixed as well.

- Failed `workbox-background-sync` requests that were modified were storing the modified versions, I updated it to store the original.
- `workbox-google-analytics` requests that already included a `qt` param were having that param overridden when the correct behavior should be to update it instead.

/cc: @DavidScales