### PR TITLE
Adds support for changing the options used when calling fetch()

### DIFF
--- a/packages/workbox-strategies/CacheFirst.mjs
+++ b/packages/workbox-strategies/CacheFirst.mjs
@@ -42,10 +42,14 @@ class CacheFirst {
    * [workbox-core]{@link workbox.core.cacheNames}.
    * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
    * to use in conjunction with this caching strategy.
+   * @param {Object} options.fetchOptions Values passed along to the
+   * [`init`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)
+   * of all fetch() requests made by this strategy.
    */
   constructor(options = {}) {
     this._cacheName = cacheNames.getRuntimeName(options.cacheName);
     this._plugins = options.plugins || [];
+    this._fetchOptions = options.fetchOptions || null;
   }
 
   /**
@@ -133,7 +137,7 @@ class CacheFirst {
   async _getFromNetwork(event) {
     const response = await fetchWrapper.fetch(
       event.request,
-      null,
+      this._fetchOptions,
       this._plugins
     );
 

--- a/packages/workbox-strategies/NetworkFirst.mjs
+++ b/packages/workbox-strategies/NetworkFirst.mjs
@@ -46,6 +46,9 @@ class NetworkFirst {
    * [workbox-core]{@link workbox.core.cacheNames}.
    * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
    * to use in conjunction with this caching strategy.
+   * @param {Object} options.fetchOptions Values passed along to the
+   * [`init`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)
+   * of all fetch() requests made by this strategy.
    * @param {number} options.networkTimeoutSeconds If set, any network requests
    * that fail to respond within the timeout will fallback to the cache.
    *
@@ -77,6 +80,8 @@ class NetworkFirst {
         });
       }
     }
+
+    this._fetchOptions = options.fetchOptions || null;
   }
 
   /**
@@ -181,6 +186,7 @@ class NetworkFirst {
     try {
       response = await fetchWrapper.fetch(
         event.request,
+        this._fetchOptions,
         this._plugins
       );
     } catch (err) {

--- a/packages/workbox-strategies/NetworkOnly.mjs
+++ b/packages/workbox-strategies/NetworkOnly.mjs
@@ -41,10 +41,14 @@ class NetworkOnly {
    * [workbox-core]{@link workbox.core.cacheNames}.
    * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
    * to use in conjunction with this caching strategy.
+   * @param {Object} options.fetchOptions Values passed along to the
+   * [`init`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)
+   * of all fetch() requests made by this strategy.
    */
   constructor(options = {}) {
     this._cacheName = cacheNames.getRuntimeName(options.cacheName);
     this._plugins = options.plugins || [];
+    this._fetchOptions = options.fetchOptions || null;
   }
 
   /**
@@ -72,7 +76,7 @@ class NetworkOnly {
     try {
       response = await fetchWrapper.fetch(
         event.request,
-        null,
+        this._fetchOptions,
         this._plugins
       );
     } catch (err) {

--- a/packages/workbox-strategies/StaleWhileRevalidate.mjs
+++ b/packages/workbox-strategies/StaleWhileRevalidate.mjs
@@ -52,6 +52,9 @@ class StaleWhileRevalidate {
    * [workbox-core]{@link workbox.core.cacheNames}.
    * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
    * to use in conjunction with this caching strategy.
+   * @param {Object} options.fetchOptions Values passed along to the
+   * [`init`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)
+   * of all fetch() requests made by this strategy.
    */
   constructor(options = {}) {
     this._cacheName = cacheNames.getRuntimeName(options.cacheName);
@@ -66,6 +69,8 @@ class StaleWhileRevalidate {
       // No plugins passed in, use the default plugin.
       this._plugins = [cacheOkAndOpaquePlugin];
     }
+
+    this._fetchOptions = options.fetchOptions || null;
   }
 
   /**
@@ -134,7 +139,7 @@ class StaleWhileRevalidate {
   async _getFromNetwork(event) {
     const response = await fetchWrapper.fetch(
       event.request,
-      null,
+      this._fetchOptions,
       this._plugins
     );
 

--- a/test/workbox-strategies/node/test-CacheFirst.mjs
+++ b/test/workbox-strategies/node/test-CacheFirst.mjs
@@ -77,7 +77,7 @@ describe(`[workbox-strategies] CacheFirst`, function() {
     expect(fetch.callCount).to.equal(0);
   });
 
-  it(`should be able to cache a non-existant request to custom cache`, async function() {
+  it(`should be able to cache a non-existent request to custom cache`, async function() {
     const cacheName = 'test-cache-name';
     const request = new Request('http://example.io/test/');
     const event = new FetchEvent('fetch', {request});
@@ -220,7 +220,7 @@ describe(`[workbox-strategies] CacheFirst`, function() {
     // Wait until cache.put is finished.
     await cachePromise;
 
-    // The cache should be overriden
+    // The cache should be overridden.
     const firstCachedResponse = await cache.match(request);
 
     await compareResponses(firstCachedResponse, fetchResponse, true);
@@ -242,5 +242,19 @@ describe(`[workbox-strategies] CacheFirst`, function() {
     } catch (err) {
       expect(err).to.equal(injectedError);
     }
+  });
+
+  it(`should use the fetchOptions provided`, async function() {
+    const fetchOptions = {credentials: 'include'};
+    const cacheFirst = new CacheFirst({fetchOptions});
+
+    const fetchStub = sandbox.stub(global, 'fetch').resolves(new Response());
+    const request = new Request('http://example.io/test/');
+    const event = new FetchEvent('fetch', {request});
+
+    await cacheFirst.handle({event});
+
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(fetchStub.calledWith(request, fetchOptions)).to.be.true;
   });
 });

--- a/test/workbox-strategies/node/test-NetworkFirst.mjs
+++ b/test/workbox-strategies/node/test-NetworkFirst.mjs
@@ -247,4 +247,18 @@ describe(`[workbox-strategies] NetworkFirst`, function() {
     const cachedResponse = await cache.match(request);
     expect(cachedResponse).to.not.exist;
   });
+
+  it(`should use the fetchOptions provided`, async function() {
+    const fetchOptions = {credentials: 'include'};
+    const networkFirst = new NetworkFirst({fetchOptions});
+
+    const fetchStub = sandbox.stub(global, 'fetch').resolves(new Response());
+    const request = new Request('http://example.io/test/');
+    const event = new FetchEvent('fetch', {request});
+
+    await networkFirst.handle({event});
+
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(fetchStub.calledWith(request, fetchOptions)).to.be.true;
+  });
 });

--- a/test/workbox-strategies/node/test-NetworkOnly.mjs
+++ b/test/workbox-strategies/node/test-NetworkOnly.mjs
@@ -102,4 +102,18 @@ describe(`[workbox-strategies] NetworkOnly`, function() {
     const keys = await cache.keys();
     expect(keys).to.be.empty;
   });
+
+  it(`should use the fetchOptions provided`, async function() {
+    const fetchOptions = {credentials: 'include'};
+    const networkOnly = new NetworkOnly({fetchOptions});
+
+    const fetchStub = sandbox.stub(global, 'fetch').resolves(new Response());
+    const request = new Request('http://example.io/test/');
+    const event = new FetchEvent('fetch', {request});
+
+    await networkOnly.handle({event});
+
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(fetchStub.calledWith(request, fetchOptions)).to.be.true;
+  });
 });

--- a/test/workbox-strategies/node/test-StaleWhileRevalidate.mjs
+++ b/test/workbox-strategies/node/test-StaleWhileRevalidate.mjs
@@ -147,4 +147,18 @@ describe(`[workbox-strategies] StaleWhileRevalidate`, function() {
     });
     expect(staleWhileRevalidate._plugins).to.equal(plugins);
   });
+
+  it(`should use the fetchOptions provided`, async function() {
+    const fetchOptions = {credentials: 'include'};
+    const staleWhileRevalidate = new StaleWhileRevalidate({fetchOptions});
+
+    const fetchStub = sandbox.stub(global, 'fetch').resolves(new Response());
+    const request = new Request('http://example.io/test/');
+    const event = new FetchEvent('fetch', {request});
+
+    await staleWhileRevalidate.handle({event});
+
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(fetchStub.calledWith(request, fetchOptions)).to.be.true;
+  });
 });


### PR DESCRIPTION
R: @addyosmani @gauntface

This is related to #1131.

I don't know if we want to mark it as fixed once this is merged—that issue tracks docs, and while this PR adds the code that's required, along with JSDocs, I guess we could still put together a standalone guide on d.g.c.