### PR TITLE
Precaching temp

### DIFF
--- a/infra/testing/activate-and-control.js
+++ b/infra/testing/activate-and-control.js
@@ -41,6 +41,21 @@ module.exports = async (swUrl) => {
     .then((registration) => {
       return _onStateChangePromise(registration, 'activated');
     })
+    .then(() => {
+      // Ensure the page is being controlled by the SW.
+      if (navigator.serviceWorker.controller &&
+        navigator.serviceWorker.controller.scriptURL === swUrl) {
+        return;
+      } else {
+        return new Promise((resolve) => {
+          navigator.serviceWorker.addEventListener('controllerchange', () => {
+            if (navigator.serviceWorker.controller.scriptURL === swUrl) {
+              resolve();
+            }
+          });
+        });
+      }
+    })
     .then(() => cb())
     .catch((err) => cb(err));
   }, swUrl);

--- a/infra/testing/activate-sw.js
+++ b/infra/testing/activate-sw.js
@@ -6,17 +6,43 @@ module.exports = async (swUrl) => {
   }
 
   const error = await global.__workbox.webdriver.executeAsyncScript((swUrl, cb) => {
-    if (navigator.serviceWorker.controller &&
-        navigator.serviceWorker.controller.scriptURL === swUrl) {
-      cb();
-    } else {
-      navigator.serviceWorker.addEventListener('controllerchange', () => {
-        if (navigator.serviceWorker.controller.scriptURL === swUrl) {
-          cb();
+    function _onStateChangePromise(registration, desiredState) {
+      return new Promise((resolve, reject) => {
+        if (registration.installing === null) {
+          throw new Error('Service worker is not installing.');
         }
+
+        let serviceWorker = registration.installing;
+
+        // We unregister all service workers after each test - this should
+        // always trigger an install state change
+        let stateChangeListener = function(evt) {
+          if (evt.target.state === desiredState) {
+            serviceWorker.removeEventListener('statechange', stateChangeListener);
+            resolve();
+            return;
+          }
+
+          if (evt.target.state === 'redundant') {
+            serviceWorker.removeEventListener('statechange', stateChangeListener);
+
+            // Must call reject rather than throw error here due to this
+            // being inside the scope of the callback function stateChangeListener
+            reject(new Error('Installing servier worker became redundant'));
+            return;
+          }
+        };
+
+        serviceWorker.addEventListener('statechange', stateChangeListener);
       });
-      navigator.serviceWorker.register(swUrl).catch((error) => cb(error));
     }
+
+    navigator.serviceWorker.register(swUrl)
+    .then((registration) => {
+      return _onStateChangePromise(registration, 'activated');
+    })
+    .then(() => cb())
+    .catch((err) => cb(err));
   }, swUrl);
 
   if (error) {

--- a/packages/workbox-precaching/_default.mjs
+++ b/packages/workbox-precaching/_default.mjs
@@ -165,7 +165,7 @@ moduleExports.precache = (entries) => {
     }));
   });
   self.addEventListener('activate', (event) => {
-    event.waitUntil(precacheController.cleanup());
+    event.waitUntil(precacheController.activate());
   });
 };
 

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -210,6 +210,7 @@ class PrecacheController {
     await Promise.all(requests.map(async (request) => {
       const response = await tempCache.match(request);
       await cacheWrapper.put(this._cacheName, request, response);
+      await tempCache.delete(request);
     }));
 
     await caches.delete(this._getTempCacheName());

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -164,11 +164,15 @@ class PrecacheController {
       }
     }
 
+    // Clear any existing temp cache
+    await caches.delete(this._getTempCacheName());
+
     const entriesToPrecache = [];
     const entriesAlreadyPrecached = [];
 
     for (const precacheEntry of this._entriesToCacheMap.values()) {
-      if (await this._precacheDetailsModel._isEntryCached(precacheEntry)) {
+      if (await this._precacheDetailsModel._isEntryCached(
+        this._cacheName, precacheEntry)) {
         entriesAlreadyPrecached.push(precacheEntry);
       } else {
         entriesToPrecache.push(precacheEntry);
@@ -177,7 +181,7 @@ class PrecacheController {
 
     // Wait for all requests to be cached.
     await Promise.all(entriesToPrecache.map((precacheEntry) => {
-      return this._cacheEntry(precacheEntry, options.plugins);
+      return this._cacheEntryInTemp(precacheEntry, options.plugins);
     }));
 
     if (process.env.NODE_ENV !== 'production') {
@@ -188,6 +192,40 @@ class PrecacheController {
       updatedEntries: entriesToPrecache,
       notUpdatedEntries: entriesAlreadyPrecached,
     };
+  }
+
+  /**
+   * Takes the current set of temporary files and moves them to the final
+   * cache, deleting the temporary cache once copying is complete.
+   *
+   * @return {
+   * Promise<workbox.precaching.CleanupResult>}
+   * Resolves with an object containing details of the deleted cache requests
+   * and precache revision details.
+   */
+  async activate() {
+    const tempCache = await caches.open(this._getTempCacheName());
+
+    const requests = await tempCache.keys();
+    await Promise.all(requests.map(async (request) => {
+      const response = await tempCache.match(request);
+      await cacheWrapper.put(this._cacheName, request, response);
+    }));
+
+    await caches.delete(this._getTempCacheName());
+
+    return this._cleanup();
+  }
+
+  /**
+   * Returns the name of the temporary cache.
+   *
+   * @return {string}
+   *
+   * @private
+   */
+  _getTempCacheName() {
+    return `${this._cacheName}-temp`;
   }
 
   /**
@@ -203,7 +241,7 @@ class PrecacheController {
    * promise resolves with true if the entry was cached / updated and
    * false if the entry is already cached and up-to-date.
    */
-  async _cacheEntry(precacheEntry, plugins) {
+  async _cacheEntryInTemp(precacheEntry, plugins) {
     let response = await fetchWrapper.fetch(
       precacheEntry._networkRequest,
       null,
@@ -214,7 +252,7 @@ class PrecacheController {
       response = await cleanRedirect(response);
     }
 
-    await cacheWrapper.put(this._cacheName,
+    await cacheWrapper.put(this._getTempCacheName(),
       precacheEntry._cacheRequest, response, plugins);
 
     await this._precacheDetailsModel._addEntry(precacheEntry);
@@ -232,8 +270,10 @@ class PrecacheController {
    * Promise<workbox.precaching.CleanupResult>}
    * Resolves with an object containing details of the deleted cache requests
    * and precache revision details.
+   *
+   * @private
    */
-  async cleanup() {
+  async _cleanup() {
     const expectedCacheUrls = [];
     this._entriesToCacheMap.forEach((entry) => {
       const fullUrl = new URL(entry._cacheRequest.url, location).toString();

--- a/packages/workbox-precaching/models/PrecachedDetailsModel.mjs
+++ b/packages/workbox-precaching/models/PrecachedDetailsModel.mjs
@@ -15,7 +15,6 @@
 */
 
 import {DBWrapper} from 'workbox-core/_private/DBWrapper.mjs';
-import {cacheNames} from 'workbox-core/_private/cacheNames.mjs';
 import '../_version.mjs';
 
 // Allows minifier to mangle this name
@@ -32,12 +31,9 @@ class PrecachedDetailsModel {
   /**
    * Construct a new model for a specific cache.
    *
-   * @param {string} cacheName
-   *
    * @private
    */
-  constructor(cacheName) {
-    this._cacheName = cacheNames.getPrecacheName(cacheName);
+  constructor() {
     this._db = new DBWrapper(`workbox-precaching`, 2, {
       onupgradeneeded: this._handleUpgrade,
     });
@@ -70,18 +66,19 @@ class PrecachedDetailsModel {
    * Check if an entry is already cached. Returns false if
    * the entry isn't cached or the revision has changed.
    *
+   * @param {string} cacheName
    * @param {PrecacheEntry} precacheEntry
    * @return {boolean}
    *
    * @private
    */
-  async _isEntryCached(precacheEntry) {
+  async _isEntryCached(cacheName, precacheEntry) {
     const revisionDetails = await this._getRevision(precacheEntry._entryId);
     if (revisionDetails !== precacheEntry._revision) {
       return false;
     }
 
-    const openCache = await caches.open(this._cacheName);
+    const openCache = await caches.open(cacheName);
     const cachedResponse = await openCache.match(precacheEntry._cacheRequest);
     return !!cachedResponse;
   }

--- a/test/workbox-background-sync/integration/test-bg-sync.js
+++ b/test/workbox-background-sync/integration/test-bg-sync.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe(`[workbox-background-sync] Load and use Background Sync`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
@@ -27,7 +27,7 @@ describe(`[workbox-background-sync] Load and use Background Sync`, function() {
   it(`should load a page with service worker`, async function() {
     // Load the page and wait for the first service worker to register and activate.
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     const err = await global.__workbox.webdriver.executeAsyncScript((testingUrl, cb) => {
       return fetch(`${testingUrl}example.txt`)

--- a/test/workbox-broadcast-cache-update/integration/broadcast-cache-update-plugin.js
+++ b/test/workbox-broadcast-cache-update/integration/broadcast-cache-update-plugin.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe(`broadcastCacheUpdate.Plugin`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
@@ -10,7 +10,7 @@ describe(`broadcastCacheUpdate.Plugin`, function() {
 
   it(`should broadcast a message on the expected channel when there's a cache update`, async function() {
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     const supported = await global.__workbox.webdriver.executeScript(() => {
       return 'BroadcastChannel' in window;

--- a/test/workbox-cache-expiration/integration/expiration-plugin.js
+++ b/test/workbox-cache-expiration/integration/expiration-plugin.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 const cleanSWEnv = require('../../../infra/testing/clean-sw');
 
 describe(`expiration.Plugin`, function() {
@@ -30,7 +30,7 @@ describe(`expiration.Plugin`, function() {
     const swUrl = `${testingUrl}sw-max-entries.js`;
 
     // Wait for the service worker to register and activate.
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     await global.__workbox.webdriver.executeAsyncScript((testingUrl, cb) => {
       fetch(`${testingUrl}example-1.txt`).then(() => cb()).catch((err) => cb(err.message));
@@ -86,7 +86,7 @@ describe(`expiration.Plugin`, function() {
 
     // Load the page and wait for the service worker to register and activate.
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     await global.__workbox.webdriver.executeAsyncScript((testingUrl, cb) => {
       fetch(`${testingUrl}example-1.txt`).then(() => cb()).catch((err) => cb(err.message));

--- a/test/workbox-cacheable-response/integration/test-cacheable-response-plugin.js
+++ b/test/workbox-cacheable-response/integration/test-cacheable-response-plugin.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe(`cacheableResponse.Plugin`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
@@ -33,7 +33,7 @@ describe(`cacheableResponse.Plugin`, function() {
 
   it(`should load a page and cache entries`, async function() {
     // Wait for the service worker to register and activate.
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     await global.__workbox.webdriver.executeAsyncScript((testingUrl, cb) => {
       fetch(`${testingUrl}example-1.txt`).then(() => cb()).catch((err) => cb(err.message));

--- a/test/workbox-core/integration/test-core.js
+++ b/test/workbox-core/integration/test-core.js
@@ -1,4 +1,4 @@
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe(`[workbox-core] Load core in the browser`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
@@ -7,7 +7,7 @@ describe(`[workbox-core] Load core in the browser`, function() {
 
   it(`should load workbox-core in a service worker.`, async function() {
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     // If the service worker activated, it meant the assertions in sw.js were
     // met and workbox-core exposes the expected API and defaults that were

--- a/test/workbox-google-analytics/integration/basic-example.js
+++ b/test/workbox-google-analytics/integration/basic-example.js
@@ -27,11 +27,14 @@ describe(`[workbox-google-analytics] Load and use Google Analytics`,
         data, [messageChannel.port2]);
   };
 
-  beforeEach(async function() {
+  before(async function() {
     // Load the page and wait for the first service worker to activate.
     await driver.get(testingUrl);
-    await activateSW(swUrl);
 
+    await activateSW(swUrl);
+  });
+
+  beforeEach(async function() {
     // Reset the spied requests array.
     await driver.executeAsyncScript(messageSw, {
       action: 'clear-spied-requests',

--- a/test/workbox-google-analytics/integration/basic-example.js
+++ b/test/workbox-google-analytics/integration/basic-example.js
@@ -1,7 +1,7 @@
 const expect = require('chai').expect;
 const qs = require('qs');
 const {By} = require('selenium-webdriver');
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe(`[workbox-google-analytics] Load and use Google Analytics`,
     function() {
@@ -31,7 +31,7 @@ describe(`[workbox-google-analytics] Load and use Google Analytics`,
     // Load the page and wait for the first service worker to activate.
     await driver.get(testingUrl);
 
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
   });
 
   beforeEach(async function() {

--- a/test/workbox-precaching/integration/precache-and-update.js
+++ b/test/workbox-precaching/integration/precache-and-update.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 const cleanSWEnv = require('../../../infra/testing/clean-sw');
 
 describe(`[workbox-precaching] Precache and Update`, function() {
@@ -45,7 +45,7 @@ describe(`[workbox-precaching] Precache and Update`, function() {
     global.__workbox.server.reset();
 
     // Register the first service worker.
-    await activateSW(SW_1_URL);
+    await activateAndControlSW(SW_1_URL);
 
     // Check that only the precache cache was created.
     const keys = await global.__workbox.webdriver.executeAsyncScript((cb) => {
@@ -106,7 +106,7 @@ describe(`[workbox-precaching] Precache and Update`, function() {
     }
 
     // Activate the second service worker
-    await activateSW(SW_2_URL);
+    await activateAndControlSW(SW_2_URL);
 
     // Ensure that the new assets were requested and cache busted.
     requestsMade = global.__workbox.server.getRequests();

--- a/test/workbox-precaching/integration/precache-and-update.js
+++ b/test/workbox-precaching/integration/precache-and-update.js
@@ -118,32 +118,7 @@ describe(`[workbox-precaching] Precache and Update`, function() {
       expect(requestsMade['/test/workbox-precaching/static/precache-and-update/new-request.txt']).to.equal(1);
     }
 
-    // FF triggers the controllerchange event before our precaching
-    // activate step has finished - this may be WAI.
-    // 2 seconds given to try and settle the activate listeners
-    await new Promise(async (resolve, reject) => {
-      let loop = true;
-      let expectedSize = false;
-
-      setTimeout(() => {
-        loop = false;
-      }, 2000);
-
-      while (loop) {
-        const cachedResults = await getCachedRequests(keys[0]);
-        if (cachedResults.length === 2) {
-          expectedSize = true;
-          loop = false;
-        }
-      }
-      if (expectedSize) {
-        resolve();
-      } else {
-        reject(new Error('Cached assets werent cleaned up'));
-      }
-    });
-
-      // Check that the cached entries were deleted / added as expected when
+    // Check that the cached entries were deleted / added as expected when
     // updating from sw-1.js to sw-2.js
     cachedRequests = await getCachedRequests(keys[0]);
     expect(cachedRequests).to.deep.equal([

--- a/test/workbox-precaching/node/controllers/test-default.mjs
+++ b/test/workbox-precaching/node/controllers/test-default.mjs
@@ -34,13 +34,13 @@ describe(`[workbox-precaching] default export`, function() {
       expect(self.addEventListener.args[1][0]).to.equal('activate');
     });
 
-    it(`should call install and cleanup on install and activate`, async function() {
+    it(`should call install and activate on install and activate`, async function() {
       let eventCallbacks = {};
       sandbox.stub(self, 'addEventListener').callsFake((eventName, cb) => {
         eventCallbacks[eventName] = cb;
       });
       sandbox.spy(PrecacheController.prototype, 'install');
-      sandbox.spy(PrecacheController.prototype, 'cleanup');
+      sandbox.spy(PrecacheController.prototype, 'activate');
 
       expect(PrecacheController.prototype.install.callCount).to.equal(0);
 
@@ -64,7 +64,7 @@ describe(`[workbox-precaching] default export`, function() {
       eventCallbacks['activate'](installEvent);
 
       await controllerActivatePromise;
-      expect(PrecacheController.prototype.cleanup.callCount).to.equal(1);
+      expect(PrecacheController.prototype.activate.callCount).to.equal(1);
     });
   });
 

--- a/test/workbox-precaching/node/models/test-PrecachedDetailsModel.mjs
+++ b/test/workbox-precaching/node/models/test-PrecachedDetailsModel.mjs
@@ -1,7 +1,6 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import {reset as iDBReset} from 'shelving-mock-indexeddb';
-import {_private} from '../../../../packages/workbox-core/index.mjs';
 import PrecachedDetailsModel from '../../../../packages/workbox-precaching/models/PrecachedDetailsModel.mjs';
 import PrecacheEntry from '../../../../packages/workbox-precaching/models/PrecacheEntry.mjs';
 

--- a/test/workbox-precaching/node/models/test-PrecachedDetailsModel.mjs
+++ b/test/workbox-precaching/node/models/test-PrecachedDetailsModel.mjs
@@ -20,16 +20,8 @@ describe('[workbox-precaching] PrecachedDetailsModel', function() {
 
   describe('constructor', function() {
     it(`should construct with no input`, async function() {
-      const model = new PrecachedDetailsModel();
-      expect(model._cacheName).to.equal(`workbox-precache-/`);
+      new PrecachedDetailsModel();
     });
-
-    it(`should construct with custom cacheName`, async function() {
-      const model = new PrecachedDetailsModel(`test-cache-name`);
-      expect(model._cacheName).to.equal(`test-cache-name`);
-    });
-
-    // TODO Bad cache name input
   });
 
   describe('_handleUpgrade', function() {
@@ -141,6 +133,7 @@ describe('[workbox-precaching] PrecachedDetailsModel', function() {
     it(`should return false for non-existant entry`, async function() {
       const model = new PrecachedDetailsModel();
       const isCached = await model._isEntryCached(
+        'test-cache',
         new PrecacheEntry(
           {}, '/', '1234', true
         )
@@ -149,6 +142,8 @@ describe('[workbox-precaching] PrecachedDetailsModel', function() {
     });
 
     it(`should return false for entry with different revision`, async function() {
+      const cacheName = 'test-cache';
+
       const model = new PrecachedDetailsModel();
 
       await model._addEntry(
@@ -158,6 +153,7 @@ describe('[workbox-precaching] PrecachedDetailsModel', function() {
       );
 
       const isCached = await model._isEntryCached(
+        cacheName,
         new PrecacheEntry(
           {}, '/', '4321', true
         )
@@ -166,30 +162,33 @@ describe('[workbox-precaching] PrecachedDetailsModel', function() {
     });
 
     it(`should return false for entry with revision but not in cache`, async function() {
+      const cacheName = 'test-cache';
+
       const model = new PrecachedDetailsModel();
       const entry = new PrecacheEntry(
         {}, '/', '1234', true
       );
 
       await model._addEntry(entry);
-      const isCached = await model._isEntryCached(entry);
+      const isCached = await model._isEntryCached(cacheName, entry);
 
       expect(isCached).to.equal(false);
     });
 
     it(`should return true if entry with revision and in cache`, async function() {
+      const cacheName = 'test-cache';
+
       const model = new PrecachedDetailsModel();
       const entry = new PrecacheEntry(
         {}, '/', '1234', true
       );
 
-      const cacheName = _private.cacheNames.getPrecacheName();
       const openCache = await caches.open(cacheName);
       openCache.put('/', new Response('Hello'));
 
       await model._addEntry(entry);
 
-      const isCached = await model._isEntryCached(entry);
+      const isCached = await model._isEntryCached(cacheName, entry);
       expect(isCached).to.equal(true);
     });
   });

--- a/test/workbox-precaching/static/precache.html
+++ b/test/workbox-precaching/static/precache.html
@@ -3,9 +3,9 @@
   <meta charset="UTF-8">
 </head>
 <body>
-  <h3>precache.install() &amp; precache.cleanup()</h3>
+  <h3>precache.install() &amp; precache.activate()</h3>
   <button class="js-index-install">Install</button>
-  <button class="js-index-cleanup">Cleanup</button>
+  <button class="js-index-activate">Activate</button>
 
 <script>
   // Make sure there is scope available for core.
@@ -45,11 +45,11 @@
     }
   });
 
-  const cleanupBtn = document.querySelector('.js-index-cleanup');
-  cleanupBtn.addEventListener('click', () => {
+  const activateBtn = document.querySelector('.js-index-activate');
+  activateBtn.addEventListener('click', () => {
     const precacheController = new workbox.precaching.PrecacheController();
     precacheController.addToCacheList(lastInstallValues);
-    precacheController.cleanup();
+    precacheController.activate();
   });
 </script>
 </body>

--- a/test/workbox-range-requests/integration/range-requests-plugin.js
+++ b/test/workbox-range-requests/integration/range-requests-plugin.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 const cleanSWEnv = require('../../../infra/testing/clean-sw');
 
 describe(`rangeRequests.Plugin`, function() {
@@ -18,7 +18,7 @@ describe(`rangeRequests.Plugin`, function() {
     const dummyBody = '0123456789';
 
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     const partialResponseBody = await global.__workbox.webdriver.executeAsyncScript((dummyUrl, dummyBody, cb) => {
       const dummyResponse = new Response(dummyBody);

--- a/test/workbox-routing/integration/navigation-route.js
+++ b/test/workbox-routing/integration/navigation-route.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe(`[workbox-routing] Route via NavigationRoute`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
@@ -10,7 +10,7 @@ describe(`[workbox-routing] Route via NavigationRoute`, function() {
   it(`should load a page and route requests`, async function() {
     // Load the page and wait for the first service worker to register and activate.
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     const nestedUrl = `${testingUrl}TestNavigationURL`;
 

--- a/test/workbox-routing/integration/routing-basic.js
+++ b/test/workbox-routing/integration/routing-basic.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe(`[workbox-routing] Basic Route`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
@@ -9,7 +9,7 @@ describe(`[workbox-routing] Basic Route`, function() {
 
   before(async function() {
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
   });
 
   it(`should honor a route created by a Route object`, async function() {

--- a/test/workbox-routing/integration/routing-regex.js
+++ b/test/workbox-routing/integration/routing-regex.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe(`[workbox-routing] Route via RegExp`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
@@ -10,7 +10,7 @@ describe(`[workbox-routing] Route via RegExp`, function() {
   it(`should load a page and route requests`, async function() {
     // Load the page and wait for the first service worker to register and activate.
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     let testCounter = 0;
 

--- a/test/workbox-strategies/integration/test-cacheFirst.js
+++ b/test/workbox-strategies/integration/test-cacheFirst.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe(`[workbox-strategies] CacheFirst Requests`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
@@ -10,7 +10,7 @@ describe(`[workbox-strategies] CacheFirst Requests`, function() {
   it(`should respond with cached and non-cached entry`, async function() {
     // Load the page and wait for the first service worker to register and activate.
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     let response = await global.__workbox.webdriver.executeAsyncScript((cb) => {
       fetch(new URL(`/test/workbox-strategies/static/cache-first/example.txt`, location).href)

--- a/test/workbox-strategies/integration/test-cacheOnly.js
+++ b/test/workbox-strategies/integration/test-cacheOnly.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe(`[workbox-strategies] CacheOnly Requests`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
@@ -10,7 +10,7 @@ describe(`[workbox-strategies] CacheOnly Requests`, function() {
   it(`should respond with cached and non-cached entry`, async function() {
     // Load the page and wait for the first service worker to register and activate.
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     let response = await global.__workbox.webdriver.executeAsyncScript((cb) => {
       fetch(new URL(`/CacheOnly/InCache/`, location).href)

--- a/test/workbox-strategies/integration/test-networkFirst.js
+++ b/test/workbox-strategies/integration/test-networkFirst.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe.only(`[workbox-strategies] NetworkFirst Requests`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
@@ -50,7 +50,7 @@ describe.only(`[workbox-strategies] NetworkFirst Requests`, function() {
 
     // Load the page and wait for the first service worker to register and activate.
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     let response = await global.__workbox.webdriver.executeAsyncScript((cb) => {
       fetch(new URL(`/test/uniqueValue`, location).href)

--- a/test/workbox-strategies/integration/test-networkOnly.js
+++ b/test/workbox-strategies/integration/test-networkOnly.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe.only(`[workbox-strategies] NetworkOnly Requests`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
@@ -12,7 +12,7 @@ describe.only(`[workbox-strategies] NetworkOnly Requests`, function() {
 
     // Load the page and wait for the first service worker to register and activate.
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     let response = await global.__workbox.webdriver.executeAsyncScript((cb) => {
       fetch(new URL(`/test/uniqueValue`, location).href)

--- a/test/workbox-strategies/integration/test-staleWhileRevalidate.js
+++ b/test/workbox-strategies/integration/test-staleWhileRevalidate.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 
-const activateSW = require('../../../infra/testing/activate-sw');
+const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
 describe(`[workbox-strategies] StaleWhileRevalidate Requests`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
@@ -50,7 +50,7 @@ describe(`[workbox-strategies] StaleWhileRevalidate Requests`, function() {
 
     // Load the page and wait for the first service worker to register and activate.
     await global.__workbox.webdriver.get(testingUrl);
-    await activateSW(swUrl);
+    await activateAndControlSW(swUrl);
 
     let response = await global.__workbox.webdriver.executeAsyncScript((cb) => {
       fetch(new URL(`/test/uniqueValue`, location).href)


### PR DESCRIPTION
Fixes #1316

Precaching first occurs into a cache with `-temp` appended to the end and during the activate step I copy the requests over to the originally intended cache.

For the most part this seems like a minor and safe change. I extended the test that installs and activates two sets of assets to ensure new expectations are being met, there was a bug in the cache API where keys weren't updated and the integration test had a weird issue with Firefox where multiple `activate` events seem to enter into a race condition and we can't rely on the cache cleanup being done by the time the client is claimed.

Let me know what you thinkg