### PR TITLE
Doc repair for wf

### DIFF
--- a/packages/workbox-build/src/_types.js
+++ b/packages/workbox-build/src/_types.js
@@ -24,3 +24,11 @@ import './_version.mjs';
  *
  * @memberof module:workbox-build
  */
+
+/**
+ * @typedef {Object} ManifestTransformResult
+ * @property {Array<ManifestEntry>} manifest
+ * @property {Array<string>|undefined} warnings
+ *
+ * @memberof module:workbox-build
+ */

--- a/packages/workbox-build/src/lib/filter-files.js
+++ b/packages/workbox-build/src/lib/filter-files.js
@@ -60,9 +60,9 @@ const noRevisionForUrlsMatchingTransform =
  * };
  *
  * @callback ManifestTransform
- * @param {Array<ManifestEntry>} manifestEntries The full array of entries,
+ * @param {Array<module:workbox-build.ManifestEntry>} manifestEntries The full array of entries,
  * prior to the current transformation.
- * @return {{manifest: Array<ManifestEntry>, warnings: Array<String>|undefined}}
+ * @return {module:workbox-build.ManifestTransformResult}
  * The array of entries with the transformation applied, and optionally, any
  * warnings that should be reported back to the build tool.
  *

--- a/packages/workbox-build/src/lib/filter-files.js
+++ b/packages/workbox-build/src/lib/filter-files.js
@@ -60,8 +60,8 @@ const noRevisionForUrlsMatchingTransform =
  * };
  *
  * @callback ManifestTransform
- * @param {Array<module:workbox-build.ManifestEntry>} manifestEntries The full array of entries,
- * prior to the current transformation.
+ * @param {Array<module:workbox-build.ManifestEntry>} manifestEntries The full
+ * array of entries, prior to the current transformation.
  * @return {module:workbox-build.ManifestTransformResult}
  * The array of entries with the transformation applied, and optionally, any
  * warnings that should be reported back to the build tool.


### PR DESCRIPTION
Docs were broken on Web Fundamentals due to a clash of syntax (WF expects `{{}}` to be an include but our docs was using it for an object.) 
