### PR TITLE
Cache put error

### DIFF
--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -36,6 +36,17 @@ import '../_version.mjs';
  * @memberof module:workbox-core
  */
 const putWrapper = async (cacheName, request, response, plugins = []) => {
+  if (!response) {
+    if (process.env.NODE_ENV !== 'production') {
+      logger.error(`Cannot cache non-existant response for ` +
+        `'${getFriendlyURL(request.url)}'.`);
+    }
+
+    throw new WorkboxError('cache-put-with-no-response', {
+      url: getFriendlyURL(request.url),
+    });
+  }
+
   let responseToCache = await _isResponseSafeToCache(
     request, response, plugins);
 

--- a/packages/workbox-core/models/messages/messages.mjs
+++ b/packages/workbox-core/models/messages/messages.mjs
@@ -228,4 +228,8 @@ export default {
     return `Unable to cache '${url}' because it is a '${method}' request and ` +
       `only 'GET' requests can be cached.`;
   },
+  'cache-put-with-no-response': ({url}) => {
+    return `There was an attempt to cache '${url}' but the response was not ` +
+      `defined.`;
+  },
 };


### PR DESCRIPTION
Somewhat addresses: #1368

This will throw with a meaningful error if we try to cache a non-existant response, BUT I think the error in #1368 is actually an issue with precaching going from temp -> final cache but I'm not 100%.