### PR TITLE
Explicitly support absolute swDest paths

### DIFF
--- a/packages/workbox-webpack-plugin/src/generate-sw.js
+++ b/packages/workbox-webpack-plugin/src/generate-sw.js
@@ -21,6 +21,7 @@ const getAssetHash = require('./lib/get-asset-hash');
 const getManifestEntriesFromCompilation =
   require('./lib/get-manifest-entries-from-compilation');
 const getWorkboxSWImports = require('./lib/get-workbox-sw-imports');
+const relativeToOutputPath = require('./lib/relative-to-output-path');
 const sanitizeConfig = require('./lib/sanitize-config');
 const stringifyManifest = require('./lib/stringify-manifest');
 
@@ -100,7 +101,9 @@ class GenerateSW {
     sanitizedConfig.workboxSWImport = workboxSWImport;
     const {swString, warnings} = await generateSWString(sanitizedConfig);
     compilation.warnings = compilation.warnings.concat(warnings || []);
-    compilation.assets[this.config.swDest] = convertStringToAsset(swString);
+
+    const relSwDest = relativeToOutputPath(compilation, this.config.swDest);
+    compilation.assets[relSwDest] = convertStringToAsset(swString);
   }
 
   /**

--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -24,6 +24,7 @@ const getManifestEntriesFromCompilation =
   require('./lib/get-manifest-entries-from-compilation');
 const getWorkboxSWImports = require('./lib/get-workbox-sw-imports');
 const readFileWrapper = require('./lib/read-file-wrapper');
+const relativeToOutputPath = require('./lib/relative-to-output-path');
 const sanitizeConfig = require('./lib/sanitize-config');
 const stringifyManifest = require('./lib/stringify-manifest');
 
@@ -128,8 +129,8 @@ ${setConfigString}
 ${originalSWString}
 `;
 
-    compilation.assets[this.config.swDest] =
-      convertStringToAsset(postInjectionSWString);
+    const relSwDest = relativeToOutputPath(compilation, this.config.swDest);
+    compilation.assets[relSwDest] = convertStringToAsset(postInjectionSWString);
   }
 
   /**

--- a/packages/workbox-webpack-plugin/src/lib/relative-to-output-path.js
+++ b/packages/workbox-webpack-plugin/src/lib/relative-to-output-path.js
@@ -22,6 +22,8 @@ const path = require('path');
  *
  * @return {string} If swDest was not absolute, the returns swDest as-is.
  * Otheriwse, returns swDest relative to the compilation's output path.
+ *
+ * @private
  */
 module.exports = (compilation, swDest) => {
   // See https://github.com/jantimon/html-webpack-plugin/pull/266/files#diff-168726dbe96b3ce427e7fedce31bb0bcR38

--- a/packages/workbox-webpack-plugin/src/lib/relative-to-output-path.js
+++ b/packages/workbox-webpack-plugin/src/lib/relative-to-output-path.js
@@ -1,0 +1,34 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const path = require('path');
+
+/**
+ * @param {Object} compilation The webpack compilation.
+ * @param {string} swDest The original swDest value.
+ *
+ * @return {string} If swDest was not absolute, the returns swDest as-is.
+ * Otheriwse, returns swDest relative to the compilation's output path.
+ */
+module.exports = (compilation, swDest) => {
+  // See https://github.com/jantimon/html-webpack-plugin/pull/266/files#diff-168726dbe96b3ce427e7fedce31bb0bcR38
+  if (path.resolve(swDest) === path.normalize(swDest)) {
+    return path.relative(compilation.options.output.path, swDest);
+  }
+
+  // Otherwise, return swDest as-is.
+  return swDest;
+};

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -1122,4 +1122,60 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       });
     });
   });
+
+  describe(`[workbox-webpack-plugin] swDest variations`, function() {
+    it(`should work when swDest is an absolute path`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.43591bdf46c7ac47eb8d7b2bcd41f13e.js';
+      const outputDir = tempy.directory();
+      const config = {
+        entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        output: {
+          filename: WEBPACK_ENTRY_FILENAME,
+          path: outputDir,
+        },
+        plugins: [
+          new GenerateSW({
+            // path.resolve() will always return an absolute path.
+            swDest: path.resolve(path.join(outputDir, 'service-worker.js')),
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError) => {
+        if (webpackError) {
+          return done(webpackError);
+        }
+
+        const swFile = path.join(outputDir, 'service-worker.js');
+        try {
+          // First, validate that the generated service-worker.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [
+              [WORKBOX_SW_FILE_NAME],
+              [FILE_MANIFEST_NAME],
+            ],
+            suppressWarnings: [[]],
+            precacheAndRoute: [[[], {}]],
+          }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            revision: '8e8e9f093f036bd18dfa',
+            url: 'webpackEntry.js',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
R: @addyosmani @gauntface
CC: @freezy

At least one of the two issues reported in https://github.com/GoogleChrome/workbox/issues/1367 are due to webpack hanging when an absolute Windows path is used as a new asset filename. This PR should address that scenario by translating absolute paths into paths that are relative to the output directory.