### PR TITLE
Fixing temporary cache deletion issue

### DIFF
--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -164,8 +164,17 @@ class PrecacheController {
       }
     }
 
-    // Clear any existing temp cache
-    await caches.delete(this._getTempCacheName());
+    // Empty the temporary cache.
+    // NOTE: We remove all entries instead of deleting the cache as the cache
+    // may be marked for deletion but still exist until a later stage
+    // resulting in unexpected behavior of being deletect when all references
+    // are dropped.
+    // https://github.com/GoogleChrome/workbox/issues/1368
+    const tempCache = await caches.open(this._getTempCacheName());
+    const requests = await tempCache.keys();
+    await Promise.all(requests.map((request) => {
+      return tempCache.delete(request);
+    }));
 
     const entriesToPrecache = [];
     const entriesAlreadyPrecached = [];

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -222,8 +222,6 @@ class PrecacheController {
       await tempCache.delete(request);
     }));
 
-    await caches.delete(this._getTempCacheName());
-
     return this._cleanup();
   }
 

--- a/test/workbox-precaching/integration/precache-and-update.js
+++ b/test/workbox-precaching/integration/precache-and-update.js
@@ -54,11 +54,12 @@ describe(`[workbox-precaching] Precache and Update`, function() {
       caches.keys().then((keys) => cb(keys));
     });
     expect(keys).to.deep.equal([
+      'workbox-precache-http://localhost:3004/test/workbox-precaching/static/precache-and-update/-temp',
       'workbox-precache-http://localhost:3004/test/workbox-precaching/static/precache-and-update/',
     ]);
 
     // Check that the cached requests are what we expect for sw-1.js
-    let cachedRequests = await getCachedRequests(keys[0]);
+    let cachedRequests = await getCachedRequests('workbox-precache-http://localhost:3004/test/workbox-precaching/static/precache-and-update/');
     expect(cachedRequests).to.deep.equal([
       'http://localhost:3004/test/workbox-precaching/static/precache-and-update/index.html',
       'http://localhost:3004/test/workbox-precaching/static/precache-and-update/styles/index.css',
@@ -122,7 +123,7 @@ describe(`[workbox-precaching] Precache and Update`, function() {
 
     // Check that the cached entries were deleted / added as expected when
     // updating from sw-1.js to sw-2.js
-    cachedRequests = await getCachedRequests(keys[0]);
+    cachedRequests = await getCachedRequests('workbox-precache-http://localhost:3004/test/workbox-precaching/static/precache-and-update/');
     expect(cachedRequests).to.deep.equal([
       'http://localhost:3004/test/workbox-precaching/static/precache-and-update/index.html',
       'http://localhost:3004/test/workbox-precaching/static/precache-and-update/new-request.txt',

--- a/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
@@ -351,9 +351,10 @@ describe(`[workbox-precaching] PrecacheController`, function() {
 
       await precacheControllerOne.activate();
 
-      // Ensure temp cache is deleted
-      let availableCaches = await caches.keys();
-      expect(availableCaches.indexOf(tempCacheName)).to.equal(-1);
+      // Ensure temp cache is empty
+       tempCache = await caches.open(tempCache);
+      let requests = await tempCache.keys();
+      expect(requests.length).to.equal(0);
 
       // The cache mock needs the cache to be re-opened to have up-to-date keys.
       finalCache = await caches.open(cacheNames.getPrecacheName());
@@ -416,9 +417,10 @@ describe(`[workbox-precaching] PrecacheController`, function() {
 
       await precacheControllerTwo.activate();
 
-      // Ensure temp cache is deleted
-      availableCaches = await caches.keys();
-      expect(availableCaches.indexOf(tempCacheName)).to.equal(-1);
+      // Ensure temp cache is empty
+      tempCache = await caches.open(tempCache);
+      requests = await tempCache.keys();
+      expect(requests.length).to.equal(0);
 
       // Cache mock needs this to update keys
       finalCache = await caches.open(cacheNames.getPrecacheName());


### PR DESCRIPTION
Fixes #1368

Instead of deleting the temporary cache - empty it during install. This avoids any possible condition where the temp cache is deleted even though we want it to be used *after* deletion.