### PR TITLE
Set webpack's compilation.warnings when glob-related options are used

### DIFF
--- a/packages/workbox-webpack-plugin/src/generate-sw.js
+++ b/packages/workbox-webpack-plugin/src/generate-sw.js
@@ -24,6 +24,7 @@ const getWorkboxSWImports = require('./lib/get-workbox-sw-imports');
 const relativeToOutputPath = require('./lib/relative-to-output-path');
 const sanitizeConfig = require('./lib/sanitize-config');
 const stringifyManifest = require('./lib/stringify-manifest');
+const warnAboutConfig = require('./lib/warn-about-config');
 
 /**
  * This class supports creating a new, ready-to-use service worker file as
@@ -64,6 +65,11 @@ class GenerateSW {
    * @private
    */
   async handleEmit(compilation) {
+    const configWarning = warnAboutConfig(this.config);
+    if (configWarning) {
+      compilation.warnings.push(configWarning);
+    }
+
     const workboxSWImports = await getWorkboxSWImports(
       compilation, this.config);
     const entries = getManifestEntriesFromCompilation(compilation, this.config);

--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -27,6 +27,7 @@ const readFileWrapper = require('./lib/read-file-wrapper');
 const relativeToOutputPath = require('./lib/relative-to-output-path');
 const sanitizeConfig = require('./lib/sanitize-config');
 const stringifyManifest = require('./lib/stringify-manifest');
+const warnAboutConfig = require('./lib/warn-about-config');
 
 /**
  * This class supports taking an existing service worker file which already
@@ -73,6 +74,11 @@ class InjectManifest {
    * @private
    */
   async handleEmit(compilation, readFile) {
+    const configWarning = warnAboutConfig(this.config);
+    if (configWarning) {
+      compilation.warnings.push(configWarning);
+    }
+
     const workboxSWImports = await getWorkboxSWImports(
       compilation, this.config);
 

--- a/packages/workbox-webpack-plugin/src/lib/warn-about-config.js
+++ b/packages/workbox-webpack-plugin/src/lib/warn-about-config.js
@@ -1,0 +1,54 @@
+/*
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+module.exports = (config) => {
+  const moreInfoUrl = 'https://goo.gl/EQ4Rhm';
+
+  const globOptions = [
+    'globDirectory',
+    'globFollow',
+    'globIgnores',
+    'globPatterns',
+    'globStrict',
+  ];
+
+  const usedGlobOptions = globOptions.filter((option) => option in config);
+  if (usedGlobOptions.length > 0) {
+    return `You're using the following Workbox configuration options: ` +
+      `[${usedGlobOptions.join(', ')}] In Workbox v3 and later, these ` +
+      `options are usually not needed. Please see ${moreInfoUrl} for ` +
+      `more info.`;
+  }
+
+  const optionsToWarnAboutWhenGlobPatternsIsNotSet = [
+    'dontCacheBustUrlsMatching',
+    'manifestTransforms',
+    'maximumFileSizeToCacheInBytes',
+    'modifyUrlPrefix',
+  ];
+
+  const usedNoopOptions = optionsToWarnAboutWhenGlobPatternsIsNotSet
+    .filter((option) => option in config);
+  if (usedNoopOptions.length > 0) {
+    return `You're using the following Workbox configuration options: ` +
+      `[${usedNoopOptions.join(', ')}] These options will not have any ` +
+      `effect, as they only modify files that are matched via ` +
+      `'globPatterns'. You can remove them from your config, and learn more ` +
+      `at ${moreInfoUrl}`;
+  }
+
+  return null;
+};

--- a/packages/workbox-webpack-plugin/src/lib/warn-about-config.js
+++ b/packages/workbox-webpack-plugin/src/lib/warn-about-config.js
@@ -27,10 +27,10 @@ module.exports = (config) => {
 
   const usedGlobOptions = globOptions.filter((option) => option in config);
   if (usedGlobOptions.length > 0) {
-    return `You're using the following Workbox configuration options: ` +
-      `[${usedGlobOptions.join(', ')}] In Workbox v3 and later, these ` +
-      `options are usually not needed. Please see ${moreInfoUrl} for ` +
-      `more info.`;
+    return `You're using the following Workbox configuration option` +
+      `${usedGlobOptions.length === 1 ? '' : 's'}: ` +
+      `[${usedGlobOptions.join(', ')}]. In Workbox v3 and later, this is ` +
+      `usually not needed. Please see ${moreInfoUrl} for more info.`;
   }
 
   const optionsToWarnAboutWhenGlobPatternsIsNotSet = [
@@ -43,11 +43,11 @@ module.exports = (config) => {
   const usedNoopOptions = optionsToWarnAboutWhenGlobPatternsIsNotSet
     .filter((option) => option in config);
   if (usedNoopOptions.length > 0) {
-    return `You're using the following Workbox configuration options: ` +
-      `[${usedNoopOptions.join(', ')}] These options will not have any ` +
-      `effect, as they only modify files that are matched via ` +
-      `'globPatterns'. You can remove them from your config, and learn more ` +
-      `at ${moreInfoUrl}`;
+    return `You're using the following Workbox configuration option` +
+      `${usedGlobOptions.length === 1 ? '' : 's'}: ` +
+      `[${usedNoopOptions.join(', ')}]. This will not have any effect, as ` +
+      `it will only modify files that are matched via 'globPatterns'. You ` +
+      `can remove them from your config, and learn more at ${moreInfoUrl}`;
   }
 
   return null;

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -124,6 +124,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         const swFile = path.join(outputDir, 'service-worker.js');
 
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -179,13 +182,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -236,13 +242,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -291,13 +300,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // Validate the copied library files.
           const libraryFiles = glob.sync(`${WORKBOX_DIRECTORY_PREFIX}*/*.js*`,
             {cwd: outputDir});
@@ -365,13 +377,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // Validate the copied library files.
           const libraryFiles = glob.sync(`${WORKBOX_DIRECTORY_PREFIX}*/*.js*`,
             {cwd: outputDir});
@@ -441,13 +456,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -499,13 +517,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -558,13 +579,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -621,13 +645,17 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          // There's a warning about globDirectory that is expected.
+          expect(statsJson.warnings).to.have.lengthOf(1);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -662,79 +690,6 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         }
       });
     });
-
-    it(`should add warnings from the workbox-build methods to compilation.warnings`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.eca1a14406dbeefe3925758a8999609a.js';
-      const outputDir = tempy.directory();
-      const config = {
-        entry: {
-          entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
-        },
-        output: {
-          filename: '[name]-[chunkhash].js',
-          path: outputDir,
-        },
-        plugins: [
-          // This is not an exhaustive test of all the supported options, but
-          // it should be enough to confirm that they're being interpreted
-          // by workbox-build.generateSWString() properly.
-          new GenerateSW({
-            globDirectory: SRC_DIR,
-            globPatterns: ['**/*'],
-            // Make this large enough to cache some, but not all, files.
-            maximumFileSizeToCacheInBytes: 20,
-          }),
-        ],
-      };
-
-      const compiler = webpack(config);
-      compiler.run(async (webpackError, stats) => {
-        if (webpackError) {
-          return done(webpackError);
-        }
-
-        // Check to make sure we have warnings about the files that are too large to cache.
-        const statsJson = stats.toJson('verbose');
-        expect(statsJson.warnings).to.have.lengthOf(5);
-
-        const swFile = path.join(outputDir, 'service-worker.js');
-        try {
-          // First, validate that the generated service-worker.js meets some basic assumptions.
-          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [
-              [WORKBOX_SW_FILE_NAME],
-              [FILE_MANIFEST_NAME],
-            ],
-            suppressWarnings: [[]],
-            precacheAndRoute: [[[{
-              revision: '544658ab25ee8762dc241e8b1c5ed96d',
-              url: 'page-1.html',
-            }, {
-              revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
-              url: 'page-2.html',
-            }, {
-              revision: 'edeab2a4c398a3f25d7b92bedea10d31',
-              url: 'webpackEntry.js',
-            }], {}]],
-          }});
-
-          // Next, test the generated manifest to ensure that it contains
-          // exactly the entries that we expect.
-          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
-          const context = {self: {}};
-          vm.runInNewContext(manifestFileContents, context);
-
-          const expectedEntries = [{
-            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
-          }];
-          expect(context.self.__precacheManifest).to.eql(expectedEntries);
-
-          done();
-        } catch (error) {
-          done(error);
-        }
-      });
-    });
   });
 
   describe(`[workbox-webpack-plugin] html-webpack-plugin and a single chunk`, function() {
@@ -757,13 +712,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -818,13 +776,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -903,13 +864,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -957,13 +921,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -1018,13 +985,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -1083,13 +1053,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -1142,13 +1115,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [
@@ -1168,6 +1144,232 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           const expectedEntries = [{
             revision: '8e8e9f093f036bd18dfa',
             url: 'webpackEntry.js',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+  });
+
+  describe(`[workbox-webpack-plugin] Reporting webpack warnings`, function() {
+    it(`should add warnings from the workbox-build methods to compilation.warnings`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.eca1a14406dbeefe3925758a8999609a.js';
+      const outputDir = tempy.directory();
+      const config = {
+        entry: {
+          entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        },
+        output: {
+          filename: '[name]-[chunkhash].js',
+          path: outputDir,
+        },
+        plugins: [
+          // This is not an exhaustive test of all the supported options, but
+          // it should be enough to confirm that they're being interpreted
+          // by workbox-build.generateSWString() properly.
+          new GenerateSW({
+            globDirectory: SRC_DIR,
+            globPatterns: ['**/*'],
+            // Make this large enough to cache some, but not all, files.
+            maximumFileSizeToCacheInBytes: 20,
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError, stats) => {
+        if (webpackError) {
+          return done(webpackError);
+        }
+
+        try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(6);
+
+          const swFile = path.join(outputDir, 'service-worker.js');
+
+          // First, validate that the generated service-worker.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+              importScripts: [
+                [WORKBOX_SW_FILE_NAME],
+                [FILE_MANIFEST_NAME],
+              ],
+              suppressWarnings: [[]],
+              precacheAndRoute: [[[{
+                revision: '544658ab25ee8762dc241e8b1c5ed96d',
+                url: 'page-1.html',
+              }, {
+                revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+                url: 'page-2.html',
+              }, {
+                revision: 'edeab2a4c398a3f25d7b92bedea10d31',
+                url: 'webpackEntry.js',
+              }], {}]],
+            }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+
+    it(`should add a warning when various glob-related options are set`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.eca1a14406dbeefe3925758a8999609a.js';
+      const outputDir = tempy.directory();
+      const globOptionsToWarnAbout = [
+        'globDirectory',
+        'globFollow',
+        'globIgnores',
+        'globPatterns',
+        'globStrict',
+      ];
+      const config = {
+        entry: {
+          entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        },
+        output: {
+          filename: '[name]-[chunkhash].js',
+          path: outputDir,
+        },
+        plugins: [
+          new GenerateSW({
+            globDirectory: SRC_DIR,
+            globFollow: true,
+            globIgnores: ['ignored'],
+            globPatterns: ['**/*.html'],
+            globStrict: true,
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError, stats) => {
+        if (webpackError) {
+          return done(webpackError);
+        }
+
+        try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(1);
+          for (const globOptionToWarnAbout of globOptionsToWarnAbout) {
+            expect(statsJson.warnings[0]).to.include(globOptionToWarnAbout);
+          }
+
+          const swFile = path.join(outputDir, 'service-worker.js');
+
+          // First, validate that the generated service-worker.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+              importScripts: [
+                [WORKBOX_SW_FILE_NAME],
+                [FILE_MANIFEST_NAME],
+              ],
+              suppressWarnings: [[]],
+              precacheAndRoute: [[[{
+                revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+                url: 'index.html',
+              }, {
+                revision: '544658ab25ee8762dc241e8b1c5ed96d',
+                url: 'page-1.html',
+              }, {
+                revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+                url: 'page-2.html',
+              }], {}]],
+            }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+
+    it(`should add a warning when certain options are used, but globPatterns isn't set`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.eca1a14406dbeefe3925758a8999609a.js';
+      const outputDir = tempy.directory();
+      const optionsToWarnAboutWhenGlobPatternsIsNotSet = [
+        'dontCacheBustUrlsMatching',
+        'manifestTransforms',
+        'maximumFileSizeToCacheInBytes',
+        'modifyUrlPrefix',
+      ];
+      const config = {
+        entry: {
+          entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        },
+        output: {
+          filename: '[name]-[chunkhash].js',
+          path: outputDir,
+        },
+        plugins: [
+          new GenerateSW({
+            dontCacheBustUrlsMatching: /testing/,
+            manifestTransforms: [],
+            maximumFileSizeToCacheInBytes: 1000000,
+            modifyUrlPrefix: {abc: 'def'},
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError, stats) => {
+        if (webpackError) {
+          return done(webpackError);
+        }
+
+        try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(1);
+          for (const optionToWarnAboutWhenGlobPatternsIsNotSet of optionsToWarnAboutWhenGlobPatternsIsNotSet) {
+            expect(statsJson.warnings[0]).to.include(optionToWarnAboutWhenGlobPatternsIsNotSet);
+          }
+
+          const swFile = path.join(outputDir, 'service-worker.js');
+
+          // First, validate that the generated service-worker.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+              importScripts: [
+                [WORKBOX_SW_FILE_NAME],
+                [FILE_MANIFEST_NAME],
+              ],
+              suppressWarnings: [[]],
+              precacheAndRoute: [[[], {}]],
+            }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -132,6 +132,9 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         const swFile = path.join(outputDir, path.basename(SW_SRC));
 
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -189,13 +192,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -249,13 +255,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
               importScripts: [[
@@ -307,13 +316,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // Validate the copied library files.
           const libraryFiles = glob.sync(`${WORKBOX_DIRECTORY_PREFIX}*/*.js*`,
             {cwd: outputDir});
@@ -384,13 +396,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // Validate the copied library files.
           const libraryFiles = glob.sync(`${WORKBOX_DIRECTORY_PREFIX}*/*.js*`,
             {cwd: outputDir});
@@ -465,13 +480,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -524,13 +542,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -583,13 +604,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -643,13 +667,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -701,13 +728,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -767,13 +797,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, SW_DEST);
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -832,13 +865,17 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          // There's an expected warning due to the use of globDirectory.
+          expect(statsJson.warnings).to.have.lengthOf(1);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -898,13 +935,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -985,13 +1025,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -1040,13 +1083,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -1102,13 +1148,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -1168,13 +1217,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, path.basename(SW_SRC));
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -1228,13 +1280,16 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       };
 
       const compiler = webpack(config);
-      compiler.run(async (webpackError) => {
+      compiler.run(async (webpackError, stats) => {
         if (webpackError) {
           return done(webpackError);
         }
 
         const swFile = path.join(outputDir, 'service-worker.js');
         try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(0);
+
           // First, validate that the generated service-worker.js meets some basic assumptions.
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
@@ -1254,6 +1309,235 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           const expectedEntries = [{
             revision: '8e8e9f093f036bd18dfa',
             url: 'webpackEntry.js',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+  });
+
+  describe(`[workbox-webpack-plugin] Reporting webpack warnings`, function() {
+    it(`should add warnings from the workbox-build methods to compilation.warnings`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.1e68970ed92c9878c08bead8696e8376.js';
+      const outputDir = tempy.directory();
+      const config = {
+        entry: {
+          entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        },
+        output: {
+          filename: '[name]-[chunkhash].js',
+          path: outputDir,
+        },
+        plugins: [
+          // This is not an exhaustive test of all the supported options, but
+          // it should be enough to confirm that they're being interpreted
+          // by workbox-build.generateSWString() properly.
+          new InjectManifest({
+            swSrc: SW_SRC,
+            globDirectory: SRC_DIR,
+            globPatterns: ['**/*'],
+            // Make this large enough to cache some, but not all, files.
+            maximumFileSizeToCacheInBytes: 20,
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError, stats) => {
+        if (webpackError) {
+          return done(webpackError);
+        }
+
+        try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(6);
+
+          const swFile = path.join(outputDir, path.basename(SW_SRC));
+
+          // First, validate that the generated service-worker.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+              importScripts: [[
+                FILE_MANIFEST_NAME,
+                WORKBOX_SW_FILE_NAME,
+              ]],
+              suppressWarnings: [[]],
+              precacheAndRoute: [[[], {}]],
+            }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            revision: 'edeab2a4c398a3f25d7b92bedea10d31',
+            url: 'webpackEntry.js',
+          }, {
+            revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+            url: 'page-2.html',
+          }, {
+            revision: '544658ab25ee8762dc241e8b1c5ed96d',
+            url: 'page-1.html',
+          }, {
+            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+
+    it(`should add a warning when various glob-related options are set`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.8a33bfca407a014b4ac8aef433c23386.js';
+      const outputDir = tempy.directory();
+      const globOptionsToWarnAbout = [
+        'globDirectory',
+        'globFollow',
+        'globIgnores',
+        'globPatterns',
+        'globStrict',
+      ];
+      const config = {
+        entry: {
+          entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        },
+        output: {
+          filename: '[name]-[chunkhash].js',
+          path: outputDir,
+        },
+        plugins: [
+          new InjectManifest({
+            swSrc: SW_SRC,
+            globDirectory: SRC_DIR,
+            globFollow: true,
+            globIgnores: ['ignored'],
+            globPatterns: ['**/*.html'],
+            globStrict: true,
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError, stats) => {
+        if (webpackError) {
+          return done(webpackError);
+        }
+
+        try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(1);
+          for (const globOptionToWarnAbout of globOptionsToWarnAbout) {
+            expect(statsJson.warnings[0]).to.include(globOptionToWarnAbout);
+          }
+
+          const swFile = path.join(outputDir, path.basename(SW_SRC));
+
+          // First, validate that the generated service-worker.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+              importScripts: [[
+                FILE_MANIFEST_NAME,
+                WORKBOX_SW_FILE_NAME,
+              ]],
+              suppressWarnings: [[]],
+              precacheAndRoute: [[[], {}]],
+            }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+            url: 'page-2.html',
+          }, {
+            revision: '544658ab25ee8762dc241e8b1c5ed96d',
+            url: 'page-1.html',
+          }, {
+            revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+            url: 'index.html',
+          }, {
+            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+          }];
+          expect(context.self.__precacheManifest).to.eql(expectedEntries);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+
+    it(`should add a warning when certain options are used, but globPatterns isn't set`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.eca1a14406dbeefe3925758a8999609a.js';
+      const outputDir = tempy.directory();
+      const optionsToWarnAboutWhenGlobPatternsIsNotSet = [
+        'dontCacheBustUrlsMatching',
+        'manifestTransforms',
+        'maximumFileSizeToCacheInBytes',
+        'modifyUrlPrefix',
+      ];
+      const config = {
+        entry: {
+          entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        },
+        output: {
+          filename: '[name]-[chunkhash].js',
+          path: outputDir,
+        },
+        plugins: [
+          new InjectManifest({
+            swSrc: SW_SRC,
+            dontCacheBustUrlsMatching: /testing/,
+            manifestTransforms: [],
+            maximumFileSizeToCacheInBytes: 1000000,
+            modifyUrlPrefix: {abc: 'def'},
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError, stats) => {
+        if (webpackError) {
+          return done(webpackError);
+        }
+
+        try {
+          const statsJson = stats.toJson('verbose');
+          expect(statsJson.warnings).to.have.lengthOf(1);
+          for (const optionToWarnAboutWhenGlobPatternsIsNotSet of optionsToWarnAboutWhenGlobPatternsIsNotSet) {
+            expect(statsJson.warnings[0]).to.include(optionToWarnAboutWhenGlobPatternsIsNotSet);
+          }
+
+          const swFile = path.join(outputDir, path.basename(SW_SRC));
+
+          // First, validate that the generated service-worker.js meets some basic assumptions.
+          await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+              importScripts: [[
+                FILE_MANIFEST_NAME,
+                WORKBOX_SW_FILE_NAME,
+              ]],
+              suppressWarnings: [[]],
+              precacheAndRoute: [[[], {}]],
+            }});
+
+          // Next, test the generated manifest to ensure that it contains
+          // exactly the entries that we expect.
+          const manifestFileContents = await fse.readFile(path.join(outputDir, FILE_MANIFEST_NAME), 'utf-8');
+          const context = {self: {}};
+          vm.runInNewContext(manifestFileContents, context);
+
+          const expectedEntries = [{
+            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #1380

Happy to iterate on the warning language.

This PR also includes updates to the existing test suite to ensure that warnings were not previously being set when they were not expected.