### PR TITLE
Precaching plugins for active and install events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -946,6 +946,7 @@
       "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
       "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
       "dev": true,
+      "optional": true,
       "requires": {
         "colour": "0.7.1",
         "optjs": "3.2.2"
@@ -1374,7 +1375,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0",
@@ -2779,8 +2779,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -2899,7 +2898,6 @@
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.6.0.tgz",
       "integrity": "sha512-sgmgEodNLbxnSSoR5a2xH23CoDJ9J5MKsJS/tqplfmJLpikG0oWMpAb+tM8ERQCMpp9I+ERf6SYl158G6GwX0w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -3051,7 +3049,6 @@
           "version": "5.2.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
           "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
-          "dev": true,
           "requires": {
             "co": "4.6.0",
             "fast-deep-equal": "1.0.0",
@@ -5166,8 +5163,7 @@
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-      "dev": true
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -10352,14 +10348,12 @@
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
@@ -10394,8 +10388,7 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -15665,17 +15658,6 @@
         "regjsparser": "0.1.5"
       }
     },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
-      "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
-    },
     "registry-auth-token": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
@@ -15743,29 +15725,6 @@
         "remove-bom-buffer": "3.0.0",
         "safe-buffer": "5.1.1",
         "through2": "2.0.3"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "requires": {
-        "jsesc": "0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
-        }
       }
     },
     "remove-trailing-separator": {
@@ -17592,12 +17551,6 @@
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
-    "taffydb": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
-      "dev": true
-    },
     "tapable": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
@@ -19328,12 +19281,6 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.4.tgz",
       "integrity": "sha1-BPVgkVcks4kIhxXMDteBPpZ3v1c=",
-      "dev": true
-    },
-    "xmlcreate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
-      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
       "dev": true
     },
     "xtend": {

--- a/packages/workbox-precaching/_default.mjs
+++ b/packages/workbox-precaching/_default.mjs
@@ -165,7 +165,9 @@ moduleExports.precache = (entries) => {
     }));
   });
   self.addEventListener('activate', (event) => {
-    event.waitUntil(precacheController.activate());
+    event.waitUntil(precacheController.activate({
+      plugins,
+    }));
   });
 };
 

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -207,18 +207,22 @@ class PrecacheController {
    * Takes the current set of temporary files and moves them to the final
    * cache, deleting the temporary cache once copying is complete.
    *
+   * @param {Object} options
+   * @param {Array<Object>} options.plugins Plugins to be used for fetching
+   * and caching during install.
    * @return {
    * Promise<workbox.precaching.CleanupResult>}
    * Resolves with an object containing details of the deleted cache requests
    * and precache revision details.
    */
-  async activate() {
+  async activate(options = {}) {
     const tempCache = await caches.open(this._getTempCacheName());
 
     const requests = await tempCache.keys();
     await Promise.all(requests.map(async (request) => {
       const response = await tempCache.match(request);
-      await cacheWrapper.put(this._cacheName, request, response);
+      await cacheWrapper.put(this._cacheName, request,
+        response, options.plugins);
       await tempCache.delete(request);
     }));
 

--- a/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
@@ -456,6 +456,12 @@ describe(`[workbox-precaching] PrecacheController`, function() {
 
       expect(fetchWrapper.fetch.args[0][2]).to.equal(testPlugins);
       expect(cacheWrapper.put.args[0][3]).to.equal(testPlugins);
+
+      await precacheController.activate({
+        plugins: testPlugins,
+      });
+
+      expect(cacheWrapper.put.args[1][3]).to.equal(testPlugins);
     });
 
     it(`it should set credentials: 'same-origin' on the precaching requests`, async function() {

--- a/test/workbox-precaching/node/controllers/test-default.mjs
+++ b/test/workbox-precaching/node/controllers/test-default.mjs
@@ -487,12 +487,13 @@ describe(`[workbox-precaching] default export`, function() {
   });
 
   describe(`addPlugins()`, function() {
-    it(`should add plugins during install`, async function() {
+    it(`should add plugins during install and activate`, async function() {
       let eventCallbacks = {};
       sandbox.stub(self, 'addEventListener').callsFake((eventName, cb) => {
         eventCallbacks[eventName] = cb;
       });
       sandbox.spy(PrecacheController.prototype, 'install');
+      sandbox.spy(PrecacheController.prototype, 'activate');
 
       const precacheArgs = ['/'];
 
@@ -517,6 +518,20 @@ describe(`[workbox-precaching] default export`, function() {
       await installPromise;
 
       expect(PrecacheController.prototype.install.args[0][0].plugins).to.deep.equal([
+        plugin1,
+        plugin2,
+      ]);
+
+      const activateEvent = new ExtendableEvent('activate');
+      let activatePromise;
+      activateEvent.waitUntil = (promise) => {
+        activatePromise = promise;
+      };
+      eventCallbacks['activate'](activateEvent);
+
+      await activatePromise;
+
+      expect(PrecacheController.prototype.activate.args[0][0].plugins).to.deep.equal([
         plugin1,
         plugin2,
       ]);


### PR DESCRIPTION
Fixes #1376

This uses plugins for install and activate events. This may cause some confusion between temp vs actual cache, but checking the cache name should allow for figuring out where the cache put is.