### PR TITLE
Make workbox-build exist in jsdoc

### DIFF
--- a/packages/workbox-build/src/index.js
+++ b/packages/workbox-build/src/index.js
@@ -76,7 +76,7 @@ const {getModuleUrl} = require('./lib/cdn-utils');
  * {@link module:workbox-sw.WorkboxSW|WorkboxSW() constructor} in your `swSrc`
  * file.
  *
- * @memberof module:workbox-build
+ * @module workbox-build
  */
 module.exports = {
   copyWorkboxLibraries,


### PR DESCRIPTION
All workbox-build docs currently hang off of workbox-build module in jsdocs, but that module was never defined which meant the docs have just been lost.

This adds the module to jsdocs but the actual document seems pretty wrong.