### PR TITLE
Adds makeRequest() method to workbox.strategies

### DIFF
--- a/packages/workbox-strategies/CacheFirst.mjs
+++ b/packages/workbox-strategies/CacheFirst.mjs
@@ -164,7 +164,7 @@ class CacheFirst {
    * Handles the network and cache part of CacheFirst.
    *
    * @param {Request} request
-   * @param {FetchEvent} event
+   * @param {FetchEvent} [event]
    * @return {Promise<Response>}
    *
    * @private

--- a/packages/workbox-strategies/CacheFirst.mjs
+++ b/packages/workbox-strategies/CacheFirst.mjs
@@ -1,5 +1,5 @@
 /*
- Copyright 2016 Google Inc. All Rights Reserved.
+ Copyright 2018 Google Inc. All Rights Reserved.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -26,21 +26,19 @@ import './_version.mjs';
  * An implementation of a [cache-first]{@link https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#cache-falling-back-to-network}
  * request strategy.
  *
- * A cache first strategy is useful for assets that have beeng revisioned,
+ * A cache first strategy is useful for assets that have been revisioned,
  * such as URLs like `/styles/example.a8f5f1.css`, since they
  * can be cached for long periods of time.
  *
  * @memberof workbox.strategies
  */
 class CacheFirst {
-  // TODO: Replace `plugins` parameter link with link to d.g.c.
-
   /**
    * @param {Object} options
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
    * [workbox-core]{@link workbox.core.cacheNames}.
-   * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
+   * @param {string} options.plugins [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
    * to use in conjunction with this caching strategy.
    * @param {Object} options.fetchOptions Values passed along to the
    * [`init`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)
@@ -63,7 +61,6 @@ class CacheFirst {
    * @return {Promise<Response>}
    */
   async handle({event}) {
-    const logs = [];
     if (process.env.NODE_ENV !== 'production') {
       assert.isInstance(event, FetchEvent, {
         moduleName: 'workbox-strategies',
@@ -73,9 +70,46 @@ class CacheFirst {
       });
     }
 
+    return this.makeRequest({
+      event,
+      request: event.request,
+    });
+  }
+
+  /**
+   * This method can be used to perform a make a standalone request outside the
+   * context of the [Workbox Router]{@link workbox.routing.Router}.
+   *
+   * See "[Advanced Recipes](https://developers.google.com/web/tools/workbox/guides/advanced-recipes#make-requests)"
+   * for more usage information.
+   *
+   * @param {Object} input
+   * @param {Request|string} input.request Either a
+   * [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
+   * object, or a string URL, corresponding to the request to be made.
+   * @param {FetchEvent} [input.event] If provided, `event.waitUntil()` will be
+   * called automatically to extend the service worker's lifetime.
+   * @return {Promise<Response>}
+   */
+  async makeRequest({event, request}) {
+    const logs = [];
+
+    if (typeof request === 'string') {
+      request = new Request(request);
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      assert.isInstance(request, Request, {
+        moduleName: 'workbox-strategies',
+        className: 'CacheFirst',
+        funcName: 'makeRequest',
+        paramName: 'request',
+      });
+    }
+
     let response = await cacheWrapper.match(
       this._cacheName,
-      event.request,
+      request,
       null,
       this._plugins
     );
@@ -88,7 +122,7 @@ class CacheFirst {
           `Will respond with a network request.`);
       }
       try {
-        response = await this._getFromNetwork(event);
+        response = await this._getFromNetwork(request, event);
       } catch (err) {
         error = err;
       }
@@ -109,7 +143,7 @@ class CacheFirst {
 
     if (process.env.NODE_ENV !== 'production') {
       logger.groupCollapsed(
-        messages.strategyStart('CacheFirst', event));
+        messages.strategyStart('CacheFirst', request));
       for (let log of logs) {
         logger.log(log);
       }
@@ -129,28 +163,31 @@ class CacheFirst {
   /**
    * Handles the network and cache part of CacheFirst.
    *
+   * @param {Request} request
    * @param {FetchEvent} event
    * @return {Promise<Response>}
    *
    * @private
    */
-  async _getFromNetwork(event) {
+  async _getFromNetwork(request, event) {
     const response = await fetchWrapper.fetch(
-      event.request,
+      request,
       this._fetchOptions,
       this._plugins
     );
 
     // Keep the service worker while we put the request to the cache
     const responseClone = response.clone();
-    event.waitUntil(
-      cacheWrapper.put(
-        this._cacheName,
-        event.request,
-        responseClone,
-        this._plugins
-      )
+    const cachePutPromise = cacheWrapper.put(
+      this._cacheName,
+      request,
+      responseClone,
+      this._plugins
     );
+
+    if (event) {
+      event.waitUntil(cachePutPromise);
+    }
 
     return response;
   }

--- a/packages/workbox-strategies/CacheOnly.mjs
+++ b/packages/workbox-strategies/CacheOnly.mjs
@@ -1,5 +1,5 @@
 /*
- Copyright 2016 Google Inc. All Rights Reserved.
+ Copyright 2018 Google Inc. All Rights Reserved.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -21,16 +21,13 @@ import {logger} from 'workbox-core/_private/logger.mjs';
 import messages from './utils/messages.mjs';
 import './_version.mjs';
 
-// TODO: Replace `Workbox plugins` link in the class description with a
-// link to d.g.c.
-// TODO: Replace `plugins` parameter link with link to d.g.c.
 
 /**
  * An implementation of a
  * [cache-only]{@link https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#cache-only}
  * request strategy.
  *
- * This class is useful if you want to take advantage of any [Workbox plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}.
+ * This class is useful if you want to take advantage of any [Workbox plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}.
  *
  * @memberof workbox.strategies
  */
@@ -40,7 +37,7 @@ class CacheOnly {
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
    * [workbox-core]{@link workbox.core.cacheNames}.
-   * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
+   * @param {string} options.plugins [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
    * to use in conjunction with this caching strategy.
    */
   constructor(options = {}) {
@@ -68,16 +65,51 @@ class CacheOnly {
       });
     }
 
+    return this.makeRequest({
+      event,
+      request: event.request,
+    });
+  }
+
+  /**
+   * This method can be used to perform a make a standalone request outside the
+   * context of the [Workbox Router]{@link workbox.routing.Router}.
+   *
+   * See "[Advanced Recipes](https://developers.google.com/web/tools/workbox/guides/advanced-recipes#make-requests)"
+   * for more usage information.
+   *
+   * @param {Object} input
+   * @param {Request|string} input.request Either a
+   * [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
+   * object, or a string URL, corresponding to the request to be made.
+   * @param {FetchEvent} [input.event] If provided, `event.waitUntil()` will be
+   * called automatically to extend the service worker's lifetime.
+   * @return {Promise<Response>}
+   */
+  async makeRequest({event, request}) {
+    if (typeof request === 'string') {
+      request = new Request(request);
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      assert.isInstance(request, Request, {
+        moduleName: 'workbox-strategies',
+        className: 'CacheOnly',
+        funcName: 'makeRequest',
+        paramName: 'request',
+      });
+    }
+
     const response = await cacheWrapper.match(
       this._cacheName,
-      event.request,
+      request,
       null,
       this._plugins
     );
 
     if (process.env.NODE_ENV !== 'production') {
       logger.groupCollapsed(
-        messages.strategyStart('CacheOnly', event));
+        messages.strategyStart('CacheOnly', request));
       if (response) {
         logger.log(`Found a cached response in the '${this._cacheName}'` +
           ` cache.`);

--- a/packages/workbox-strategies/NetworkFirst.mjs
+++ b/packages/workbox-strategies/NetworkFirst.mjs
@@ -1,5 +1,5 @@
 /*
- Copyright 2016 Google Inc. All Rights Reserved.
+ Copyright 2018 Google Inc. All Rights Reserved.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -24,9 +24,6 @@ import messages from './utils/messages.mjs';
 import cacheOkAndOpaquePlugin from './plugins/cacheOkAndOpaquePlugin.mjs';
 import './_version.mjs';
 
-// TODO: Change opaque responses to d.g.c link
-// TODO: Replace `plugins` parameter link with link to d.g.c.
-
 /**
  * An implementation of a
  * [network first]{@link https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#network-falling-back-to-cache}
@@ -45,7 +42,7 @@ class NetworkFirst {
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
    * [workbox-core]{@link workbox.core.cacheNames}.
-   * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
+   * @param {string} options.plugins [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
    * to use in conjunction with this caching strategy.
    * @param {Object} options.fetchOptions Values passed along to the
    * [`init`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)
@@ -96,7 +93,6 @@ class NetworkFirst {
    * @return {Promise<Response>}
    */
   async handle({event}) {
-    const logs = [];
     if (process.env.NODE_ENV !== 'production') {
       assert.isInstance(event, FetchEvent, {
         moduleName: 'workbox-strategies',
@@ -106,16 +102,54 @@ class NetworkFirst {
       });
     }
 
+    return this.makeRequest({
+      event,
+      request: event.request,
+    });
+  }
+
+  /**
+   * This method can be used to perform a make a standalone request outside the
+   * context of the [Workbox Router]{@link workbox.routing.Router}.
+   *
+   * See "[Advanced Recipes](https://developers.google.com/web/tools/workbox/guides/advanced-recipes#make-requests)"
+   * for more usage information.
+   *
+   * @param {Object} input
+   * @param {Request|string} input.request Either a
+   * [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
+   * object, or a string URL, corresponding to the request to be made.
+   * @param {FetchEvent} [input.event] If provided, `event.waitUntil()` will be
+   * called automatically to extend the service worker's lifetime.
+   * @return {Promise<Response>}
+   */
+  async makeRequest({event, request}) {
+    const logs = [];
+
+    if (typeof request === 'string') {
+      request = new Request(request);
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      assert.isInstance(request, Request, {
+        moduleName: 'workbox-strategies',
+        className: 'NetworkFirst',
+        funcName: 'handle',
+        paramName: 'makeRequest',
+      });
+    }
+
     const promises = [];
     let timeoutId;
+
     if (this._networkTimeoutSeconds) {
-      const {id, promise} = this._getTimeoutPromise(event, logs);
+      const {id, promise} = this._getTimeoutPromise(request, logs);
       timeoutId = id;
       promises.push(promise);
     }
 
-    const networkPromise = this._getNetworkPromise(
-      timeoutId, event, logs);
+    const networkPromise = this._getNetworkPromise(timeoutId, event, request,
+      logs);
     promises.push(networkPromise);
 
     // Promise.race() will resolve as soon as the first promise resolves.
@@ -131,7 +165,7 @@ class NetworkFirst {
 
     if (process.env.NODE_ENV !== 'production') {
       logger.groupCollapsed(
-        messages.strategyStart('NetworkFirst', event));
+        messages.strategyStart('NetworkFirst', request));
       for (let log of logs) {
         logger.log(log);
       }
@@ -149,7 +183,7 @@ class NetworkFirst {
    *
    * @private
    */
-  _getTimeoutPromise(event, logs) {
+  _getTimeoutPromise(request, logs) {
     let timeoutId;
     const timeoutPromise = new Promise((resolve) => {
       const onNetworkTimeout = async () => {
@@ -158,7 +192,7 @@ class NetworkFirst {
             `${this._networkTimeoutSeconds} seconds.`);
         }
 
-        resolve(await this._respondFromCache(event.request));
+        resolve(await this._respondFromCache(request));
       };
 
       timeoutId = setTimeout(
@@ -176,17 +210,18 @@ class NetworkFirst {
   /**
    * @param {number} timeoutId
    * @param {FetchEvent} event
+   * @param {Request} request
    * @param {Array} logs A reference to the logs Array.
    * @return {Promise<Response>}
    *
    * @private
    */
-  async _getNetworkPromise(timeoutId, event, logs) {
+  async _getNetworkPromise(timeoutId, event, request, logs) {
     let error;
     let response;
     try {
       response = await fetchWrapper.fetch(
-        event.request,
+        request,
         this._fetchOptions,
         this._plugins
       );
@@ -208,7 +243,7 @@ class NetworkFirst {
     }
 
     if (error || !response) {
-      response = await this._respondFromCache(event.request);
+      response = await this._respondFromCache(request);
       if (process.env.NODE_ENV !== 'production') {
         if (response) {
           logs.push(`Found a cached response in the '${this._cacheName}'` +
@@ -220,22 +255,23 @@ class NetworkFirst {
     } else {
       // Keep the service worker alive while we put the request in the cache
       const responseClone = response.clone();
-
       const cachePut = cacheWrapper.put(
         this._cacheName,
-        event.request,
+        request,
         responseClone,
         this._plugins
       );
 
-      try {
-        // The event has been responded to so we can keep the SW alive to
-        // respond to the request
-        event.waitUntil(cachePut);
-      } catch (err) {
-        if (process.env.NODE_ENV !== 'production') {
-          logger.warn(`Unable to ensure service worker stays alive when ` +
-            `updating cache entry for '${getFriendlyURL(event.request.url)}'.`);
+      if (event) {
+        try {
+          // The event has been responded to so we can keep the SW alive to
+          // respond to the request
+          event.waitUntil(cachePut);
+        } catch (err) {
+          if (process.env.NODE_ENV !== 'production') {
+            logger.warn(`Unable to ensure service worker stays alive when ` +
+              `updating cache for '${getFriendlyURL(event.request.url)}'.`);
+          }
         }
       }
     }

--- a/packages/workbox-strategies/NetworkFirst.mjs
+++ b/packages/workbox-strategies/NetworkFirst.mjs
@@ -177,7 +177,7 @@ class NetworkFirst {
   }
 
   /**
-   * @param {FetchEvent} event
+   * @param {Request} request
    * @param {Array} logs A reference to the logs array
    * @return {Promise<Response>}
    *
@@ -209,7 +209,7 @@ class NetworkFirst {
 
   /**
    * @param {number} timeoutId
-   * @param {FetchEvent} event
+   * @param {FetchEvent|null} event
    * @param {Request} request
    * @param {Array} logs A reference to the logs Array.
    * @return {Promise<Response>}

--- a/packages/workbox-strategies/StaleWhileRevalidate.mjs
+++ b/packages/workbox-strategies/StaleWhileRevalidate.mjs
@@ -1,5 +1,5 @@
 /*
- Copyright 2016 Google Inc. All Rights Reserved.
+ Copyright 2018 Google Inc. All Rights Reserved.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -22,10 +22,6 @@ import {assert} from 'workbox-core/_private/assert.mjs';
 import messages from './utils/messages.mjs';
 import cacheOkAndOpaquePlugin from './plugins/cacheOkAndOpaquePlugin.mjs';
 import './_version.mjs';
-
-// TODO: Replace `Workbox plugins` link in the class description with a
-// link to d.g.c.
-// TODO: Replace `plugins` parameter link with link to d.g.c.
 
 /**
  * An implementation of a
@@ -50,7 +46,7 @@ class StaleWhileRevalidate {
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
    * [workbox-core]{@link workbox.core.cacheNames}.
-   * @param {string} options.plugins [Plugins]{@link https://docs.google.com/document/d/1Qye_GDVNF1lzGmhBaUvbgwfBWRQDdPgwUAgsbs8jhsk/edit?usp=sharing}
+   * @param {string} options.plugins [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
    * to use in conjunction with this caching strategy.
    * @param {Object} options.fetchOptions Values passed along to the
    * [`init`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)
@@ -58,7 +54,7 @@ class StaleWhileRevalidate {
    */
   constructor(options = {}) {
     this._cacheName = cacheNames.getRuntimeName(options.cacheName);
-      this._plugins = options.plugins || [];
+    this._plugins = options.plugins || [];
 
     if (options.plugins) {
       let isUsingCacheWillUpdate =
@@ -84,7 +80,6 @@ class StaleWhileRevalidate {
    * @return {Promise<Response>}
    */
   async handle({event}) {
-    const logs = [];
     if (process.env.NODE_ENV !== 'production') {
       assert.isInstance(event, FetchEvent, {
         moduleName: 'workbox-strategies',
@@ -94,11 +89,48 @@ class StaleWhileRevalidate {
       });
     }
 
-    const fetchAndCachePromise = this._getFromNetwork(event);
+    return this.makeRequest({
+      event,
+      request: event.request,
+    });
+  }
+
+  /**
+   * This method can be used to perform a make a standalone request outside the
+   * context of the [Workbox Router]{@link workbox.routing.Router}.
+   *
+   * See "[Advanced Recipes](https://developers.google.com/web/tools/workbox/guides/advanced-recipes#make-requests)"
+   * for more usage information.
+   *
+   * @param {Object} input
+   * @param {Request|string} input.request Either a
+   * [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
+   * object, or a string URL, corresponding to the request to be made.
+   * @param {FetchEvent} [input.event] If provided, `event.waitUntil()` will be
+   * called automatically to extend the service worker's lifetime.
+   * @return {Promise<Response>}
+   */
+  async makeRequest({event, request}) {
+    const logs = [];
+
+    if (typeof request === 'string') {
+      request = new Request(request);
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      assert.isInstance(request, Request, {
+        moduleName: 'workbox-strategies',
+        className: 'StaleWhileRevalidate',
+        funcName: 'handle',
+        paramName: 'request',
+      });
+    }
+
+    const fetchAndCachePromise = this._getFromNetwork(request, event);
 
     let response = await cacheWrapper.match(
       this._cacheName,
-      event.request,
+      request,
       null,
       this._plugins
     );
@@ -119,7 +151,7 @@ class StaleWhileRevalidate {
 
     if (process.env.NODE_ENV !== 'production') {
       logger.groupCollapsed(
-        messages.strategyStart('StaleWhileRevalidate', event));
+        messages.strategyStart('StaleWhileRevalidate', request));
       for (let log of logs) {
         logger.log(log);
       }
@@ -136,21 +168,22 @@ class StaleWhileRevalidate {
    *
    * @private
    */
-  async _getFromNetwork(event) {
+  async _getFromNetwork(request, event) {
     const response = await fetchWrapper.fetch(
-      event.request,
+      request,
       this._fetchOptions,
       this._plugins
     );
 
-    event.waitUntil(
-      cacheWrapper.put(
-        this._cacheName,
-        event.request,
-        response.clone(),
-        this._plugins
-      )
+    const cachePutPromise = cacheWrapper.put(
+      this._cacheName,
+      request,
+      response.clone(),
+      this._plugins
     );
+    if (event) {
+      event.waitUntil(cachePutPromise);
+    }
 
     return response;
   }

--- a/packages/workbox-strategies/StaleWhileRevalidate.mjs
+++ b/packages/workbox-strategies/StaleWhileRevalidate.mjs
@@ -163,7 +163,8 @@ class StaleWhileRevalidate {
   }
 
   /**
-   * @param {FetchEvent} event
+   * @param {Request} request
+   * @param {FetchEvent} [event]
    * @return {Promise<Response>}
    *
    * @private

--- a/packages/workbox-strategies/utils/messages.mjs
+++ b/packages/workbox-strategies/utils/messages.mjs
@@ -1,5 +1,5 @@
 /*
- Copyright 2016 Google Inc. All Rights Reserved.
+ Copyright 2018 Google Inc. All Rights Reserved.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -25,8 +25,8 @@ const getFriendlyURL = (url) => {
 };
 
 export default {
-  strategyStart: (strategyName, event) => `Using ${strategyName} to respond ` +
-    `to  '${getFriendlyURL(event.request.url)}'`,
+  strategyStart: (strategyName, request) => `Using ${strategyName} to ` +
+    `respond to '${getFriendlyURL(request.url)}'`,
   printFinalResponse: (response) => {
     if (response) {
       logger.groupCollapsed(`View the final response here.`);

--- a/test/workbox-strategies/node/test-NetworkOnly.mjs
+++ b/test/workbox-strategies/node/test-NetworkOnly.mjs
@@ -20,7 +20,53 @@ import {_private} from '../../../packages/workbox-core/index.mjs';
 
 import {NetworkOnly} from '../../../packages/workbox-strategies/NetworkOnly.mjs';
 
-describe(`[workbox-strategies] NetworkOnly`, function() {
+describe(`[workbox-strategies] NetworkOnly.makeRequest()`, function() {
+  const sandbox = sinon.sandbox.create();
+
+  beforeEach(async function() {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((key) => caches.delete(key)));
+    sandbox.restore();
+  });
+
+  after(async function() {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((key) => caches.delete(key)));
+    sandbox.restore();
+  });
+
+  it(`should return a response without adding anything to the cache when the network request is successful, when passed a URL string`, async function() {
+    const url = 'http://example.io/test/';
+
+    const networkOnly = new NetworkOnly();
+
+    const handleResponse = await networkOnly.makeRequest({
+      request: url,
+    });
+    expect(handleResponse).to.be.instanceOf(Response);
+
+    const cache = await caches.open(_private.cacheNames.getRuntimeName());
+    const keys = await cache.keys();
+    expect(keys).to.be.empty;
+  });
+
+  it(`should return a response without adding anything to the cache when the network request is successful, when passed a Request object`, async function() {
+    const request = new Request('http://example.io/test/');
+
+    const networkOnly = new NetworkOnly();
+
+    const handleResponse = await networkOnly.makeRequest({
+      request,
+    });
+    expect(handleResponse).to.be.instanceOf(Response);
+
+    const cache = await caches.open(_private.cacheNames.getRuntimeName());
+    const keys = await cache.keys();
+    expect(keys).to.be.empty;
+  });
+});
+
+describe(`[workbox-strategies] NetworkOnly.handle()`, function() {
   let sandbox = sinon.sandbox.create();
 
   beforeEach(async function() {


### PR DESCRIPTION
R: @gauntface @philipwalton 

Fixes #1395 

This allows any of the `workbox.strategies.*` classes to be called manually, outside of a `Route` context.

The JSDocs in this PR refer to https://developers.google.com/web/tools/workbox/guides/advanced-recipes#make-requests, which I'll write following this PR.