### PR TITLE
Bugfix - Correctly identify when response does not have `date` header set

### DIFF
--- a/infra/testing/sw-env-mocks/Headers.js
+++ b/infra/testing/sw-env-mocks/Headers.js
@@ -26,7 +26,7 @@ class Headers {
   }
 
   get(key) {
-    return this.obj[key];
+    return this.has(key) ? this.obj[key] : null;
   }
 
   set(key, value) {

--- a/packages/workbox-cache-expiration/Plugin.mjs
+++ b/packages/workbox-cache-expiration/Plugin.mjs
@@ -169,6 +169,10 @@ class Plugin {
    * @private
    */
   _getDateHeaderTimestamp(cachedResponse) {
+    if (!cachedResponse.headers.has('date')) {
+      return null;
+    }
+
     const dateHeader = cachedResponse.headers.get('date');
     const parsedDate = new Date(dateHeader);
     const headerTime = parsedDate.getTime();

--- a/test/workbox-cache-expiration/node/test-Plugin.mjs
+++ b/test/workbox-cache-expiration/node/test-Plugin.mjs
@@ -131,12 +131,20 @@ describe(`[workbox-cache-expiration] Plugin`, function() {
       expect(isFresh).to.equal(true);
     });
 
-    it(`should return true when there is not Date header`, function() {
+    it(`should return true when there is no Date header`, function() {
       const plugin = new Plugin({maxAgeSeconds: 1});
       const isFresh = plugin._isResponseDateFresh(new Response('Hi', {
         // TODO: Remove this when https://github.com/pinterest/service-workers/issues/72
         // is fixed.
         headers: {},
+      }));
+      expect(isFresh).to.equal(true);
+    });
+
+    it(`should return true when the Date header is invalid`, function() {
+      const plugin = new Plugin({maxAgeSeconds: 1});
+      const isFresh = plugin._isResponseDateFresh(new Response('Hi', {
+        headers: {date: 'invalid header'},
       }));
       expect(isFresh).to.equal(true);
     });


### PR DESCRIPTION
Fixes bug where all responses were seen as expired if expiry was set: adds a proper check to see if response `date` header is set.

R: @jeffposnick @addyosmani @gauntface

Fixes #1416 , #1414, #1329 

If the response header did not have `date`, then `cachedResponse.headers.get('date')` would return `null`, as described here: https://developer.mozilla.org/en-US/docs/Web/API/Headers/get. Since `new Date(null).getTime()` returns 0, not `NaN`, all requests were seen as expired if an expiry was specified.

I can open an issue as per the guidelines, but will be duplicates of #1416, and #1414 
