### PR TITLE
Deal with null cachedResponses passed to workbox.rangeRequests.Plugin

### DIFF
--- a/packages/workbox-range-requests/Plugin.mjs
+++ b/packages/workbox-range-requests/Plugin.mjs
@@ -37,12 +37,14 @@ class Plugin {
    * @private
    */
   async cachedResponseWillBeUsed({request, cachedResponse}) {
-    // Only return a sliced response if there's a Range: header in the request.
-    if (request.headers.has('range')) {
+    // Only return a sliced response if there's something valid in the cache,
+    // and there's a Range: header in the request.
+    if (cachedResponse && request.headers.has('range')) {
       return await createPartialResponse(request, cachedResponse);
     }
 
-    // If there was no Range: header, return the original response as-is.
+    // If there was no Range: header, or if cachedResponse wasn't valid, just
+    // pass it through as-is.
     return cachedResponse;
   }
 }

--- a/test/workbox-range-requests/node/Plugin.mjs
+++ b/test/workbox-range-requests/node/Plugin.mjs
@@ -7,7 +7,7 @@ describe(`[workbox-range-requests] Plugin`, function() {
     new Plugin();
   });
 
-  it(`should return untouched response if no range-request header`, async function() {
+  it(`should return an untouched response if there's no Range: request header`, async function() {
     const response = new Response();
 
     const plugin = new Plugin();
@@ -18,7 +18,7 @@ describe(`[workbox-range-requests] Plugin`, function() {
     expect(resultResponse).to.equal(response);
   });
 
-  it(`should return partial response response if range header`, async function() {
+  it(`should return partial response response if there's a valid Range: request header`, async function() {
     const response = new Response('hello, world.');
 
     const plugin = new Plugin();
@@ -34,5 +34,19 @@ describe(`[workbox-range-requests] Plugin`, function() {
 
     const responseBody = await resultResponse.text();
     expect(responseBody).to.equal('ello');
+  });
+
+  it(`should return null when the cachedResponse is null`, async function() {
+    const cachedResponse = null;
+    const plugin = new Plugin();
+    const resultResponse = await plugin.cachedResponseWillBeUsed({
+      request: new Request('/', {
+        headers: {
+          'range': 'bytes=1-4',
+        },
+      }),
+      cachedResponse,
+    });
+    expect(resultResponse).to.eql(null);
   });
 });


### PR DESCRIPTION
R: @addyosmani @gauntface

This ensures that if `workbox.rangeRequests.Plugin` is used to handle a request before the cache is populated, the cache miss will just propagate outward to the strategy (which could then go to the network), instead of throwing a runtime exception.