### PR TITLE
Add swSrc to list of file dependencies for InjectManifest

### DIFF
--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -120,6 +120,7 @@ class InjectManifest {
     }
 
     const originalSWString = await readFileWrapper(readFile, this.config.swSrc);
+    compilation.fileDependencies.push(this.config.swSrc);
 
     const importScriptsString = importScriptsArray
       .map(JSON.stringify)


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

Fixes #1428 

*Description of what's changed/fixed.*

Currently, webpack won't rebuild when in watch mode if a custom service worker `swSrc` is modified. This PR adds the custom service worker to the list of watched files according to [this part of the webpack docs](https://webpack.js.org/contribute/plugin-patterns/#monitoring-the-watch-graph).

I looked through the tests for `inject-manifest`, but I'm not entirely sure how to write a proper test that validates the functionality. I'm happy to add a test if someone can point me in the right direction!