### PR TITLE
#1393: Only use public API of 'compiler.inputFileSystem'

### DIFF
--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -145,17 +145,18 @@ ${originalSWString}
    * @private
    */
   apply(compiler) {
+    const readFile = compiler.inputFileSystem.readFile
+      .bind(compiler.inputFileSystem);
     if ('hooks' in compiler) {
       // We're in webpack 4+.
       compiler.hooks.emit.tapPromise(
         this.constructor.name,
-        (compilation) => this.handleEmit(compilation,
-          compiler.inputFileSystem._readFile)
+        (compilation) => this.handleEmit(compilation, readFile)
       );
     } else {
       // We're in webpack 2 or 3.
       compiler.plugin('emit', (compilation, callback) => {
-        this.handleEmit(compilation, compiler.inputFileSystem._readFile)
+        this.handleEmit(compilation, readFile)
           .then(callback)
           .catch(callback);
       });

--- a/packages/workbox-webpack-plugin/src/lib/read-file-wrapper.js
+++ b/packages/workbox-webpack-plugin/src/lib/read-file-wrapper.js
@@ -18,7 +18,7 @@
  * A wrapper that calls readFileFn and returns a promise for the contents of
  * filePath.
  *
- * readFileFn is expected to be set to compiler.inputFileSystem._readFile, to
+ * readFileFn is expected to be set to compiler.inputFileSystem.readFile, to
  * ensure compatibility with webpack dev server's in-memory filesystem.
  *
  * @param {Function} readFileFn The function to use for readFile.
@@ -28,7 +28,7 @@
  */
 function readFileWrapper(readFileFn, filePath) {
   return new Promise((resolve, reject) => {
-    readFileFn(filePath, 'utf8', (error, data) => {
+    readFileFn(filePath, (error, data) => {
       if (error) {
         return reject(error);
       }


### PR DESCRIPTION
R: @jeffposnick @philipwalton 

Fixes https://github.com/GoogleChrome/workbox/issues/1393.

*Description of what's changed/fixed.*
The issue linked above provides a more detailed explanation about the source of this problem.
Short version: The `InjectManifest` version of `workbox-webpack-plugin` currently relies on an internal function `_readFile` of the filesystem API. This only works under specific circumstances, and is unreliable in a more general case (e.g. in case of a decorated filesystem version).

Changes included in this PR:
- Use the public `readFile` function of `webpack`'s filesystem API. Requires an explicit binding for `this`.
- Omit the encoding in `readFileFn` of `readFileWrapper` - it cannot be provided explicitly in this case.
