### PR TITLE
More context in the welcome log message

### DIFF
--- a/packages/workbox-core/_default.mjs
+++ b/packages/workbox-core/_default.mjs
@@ -51,7 +51,10 @@ class WorkboxCore {
       logger.groupCollapsed('Welcome to Workbox!');
       if (self.location.hostname === 'localhost') {
         logger.unprefixed.log(`The development build with extra logging is ` +
-          `automatically enabled when accessing your web app via localhost.`);
+          `automatically enabled when accessing your web app via localhost.` +
+          `More info is available at\n` +
+          `${padding}https://developers.google.com/web/tools/workbox/` +
+          `guides/troubleshoot-and-debug`);
       }
       logger.unprefixed.log(
         `📖 Read the guides and documentation\n` +

--- a/packages/workbox-core/_default.mjs
+++ b/packages/workbox-core/_default.mjs
@@ -49,13 +49,9 @@ class WorkboxCore {
     if (process.env.NODE_ENV !== 'production') {
       const padding = '   ';
       logger.groupCollapsed('Welcome to Workbox!');
-      if (self.location.hostname === 'localhost') {
-        logger.unprefixed.log(`The development build with extra logging is ` +
-          `automatically enabled when accessing your web app via localhost.` +
-          `More info is available at\n` +
-          `${padding}https://developers.google.com/web/tools/workbox/` +
-          `guides/troubleshoot-and-debug`);
-      }
+      logger.unprefixed.log(`You are currently using a development build. ` +
+        `By default this will switch to prod builds when not on localhost. ` +
+        `You can force this with workbox.setConfig({debug: true|false}).`);
       logger.unprefixed.log(
         `📖 Read the guides and documentation\n` +
         `${padding}https://developers.google.com/web/tools/workbox/`

--- a/packages/workbox-core/_default.mjs
+++ b/packages/workbox-core/_default.mjs
@@ -49,12 +49,16 @@ class WorkboxCore {
     if (process.env.NODE_ENV !== 'production') {
       const padding = '   ';
       logger.groupCollapsed('Welcome to Workbox!');
+      if (self.location.hostname === 'localhost') {
+        logger.unprefixed.log(`The development build with extra logging is ` +
+          `automatically enabled when accessing your web app via localhost.`);
+      }
       logger.unprefixed.log(
         `📖 Read the guides and documentation\n` +
         `${padding}https://developers.google.com/web/tools/workbox/`
       );
       logger.unprefixed.log(
-        `❓ Use the [workbox] tag on StackOverflow to ask questions\n` +
+        `❓ Use the [workbox] tag on Stack Overflow to ask questions\n` +
         `${padding}https://stackoverflow.com/questions/ask?tags=workbox`
       );
       logger.unprefixed.log(


### PR DESCRIPTION
R: @addyosmani @gauntface

@developit was asking me about when we load `.dev.` vs. `.prod.` bundles, and I realized that we could provide some extra context in our Welcome message to help explain what's going on.

Happy to tweak the actual language if it's too wordy.