### PR TITLE
Require options.cacheName when options.expiration is set.

### DIFF
--- a/packages/workbox-build/src/entry-points/options/common-generate-schema.js
+++ b/packages/workbox-build/src/entry-points/options/common-generate-schema.js
@@ -58,7 +58,7 @@ module.exports = baseSchema.keys({
       }).or('maxEntries', 'maxAgeSeconds'),
       networkTimeoutSeconds: joi.number().min(1),
       plugins: joi.array().items(joi.object()),
-    }),
+    }).with('expiration', 'cacheName'),
   }).requiredKeys('urlPattern', 'handler')),
   skipWaiting: joi.boolean().default(defaults.skipWaiting),
 });

--- a/test/workbox-build/node/entry-points/generate-sw-string.js
+++ b/test/workbox-build/node/entry-points/generate-sw-string.js
@@ -453,5 +453,28 @@ describe(`[workbox-build] entry-points/generate-sw-string.js (End to End)`, func
         ],
       }});
     });
+
+    it(`should reject when 'options.expiration' is used without 'options.cacheName'`, async function() {
+      const urlPattern = REGEXP_URL_PATTERN;
+      const options = Object.assign({}, BASE_OPTIONS, {
+        runtimeCaching: [{
+          urlPattern,
+          handler: 'networkFirst',
+          options: {
+            expiration: {
+              maxEntries: 5,
+            },
+          },
+        }],
+      });
+
+      try {
+        await generateSWString(options);
+        throw new Error('Unexpected success.');
+      } catch (error) {
+        expect(error.name).to.eql('ValidationError');
+        expect(error.details[0].context.key).to.eql('expiration');
+      }
+    });
   });
 });

--- a/test/workbox-build/node/entry-points/generate-sw.js
+++ b/test/workbox-build/node/entry-points/generate-sw.js
@@ -696,5 +696,28 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
         ],
       }});
     });
+
+    it(`should reject when 'options.expiration' is used without 'options.cacheName'`, async function() {
+      const urlPattern = REGEXP_URL_PATTERN;
+      const options = Object.assign({}, BASE_OPTIONS, {
+        runtimeCaching: [{
+          urlPattern,
+          handler: 'networkFirst',
+          options: {
+            expiration: {
+              maxEntries: 5,
+            },
+          },
+        }],
+      });
+
+      try {
+        await generateSW(options);
+        throw new Error('Unexpected success.');
+      } catch (error) {
+        expect(error.name).to.eql('ValidationError');
+        expect(error.details[0].context.key).to.eql('expiration');
+      }
+    });
   });
 });


### PR DESCRIPTION
R: @philipwalton

Fixes #1443

As described in the issue, this prevents a developer from generating a service worker using a configuring that would lead to a runtime error.