### PR TITLE
RegExp tweak to allow for precacheAndRoute() options

### DIFF
--- a/packages/workbox-build/src/entry-points/options/defaults.js
+++ b/packages/workbox-build/src/entry-points/options/defaults.js
@@ -24,5 +24,5 @@ module.exports = {
   navigateFallback: undefined,
   skipWaiting: false,
   importWorkboxFrom: 'cdn',
-  injectionPointRegexp: /(\.precacheAndRoute\()\s*\[\s*\]\s*(\))/,
+  injectionPointRegexp: /(\.precacheAndRoute\()\s*\[\s*\]\s*(\)|,)/,
 };

--- a/test/workbox-build/node/entry-points/inject-manifest.js
+++ b/test/workbox-build/node/entry-points/inject-manifest.js
@@ -255,5 +255,41 @@ describe(`[workbox-build] entry-points/inject-manifest.js (End to End)`, functio
         }]]],
       }});
     });
+
+    it(`should support using the default 'injectionPointRegexp' when precacheAndRoute() is called with options`, async function() {
+      const swDest = tempy.file();
+      const options = Object.assign({}, BASE_OPTIONS, {
+        swDest,
+        swSrc: path.join(SW_SRC_DIR, 'precache-and-route-options.js'),
+      });
+
+      const {count, size, warnings} = await injectManifest(options);
+      expect(warnings).to.be.empty;
+      expect(count).to.eql(6);
+      expect(size).to.eql(2421);
+      await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
+          precacheAndRoute: [[[{
+            url: 'index.html',
+            revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          }, {
+            url: 'page-1.html',
+            revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          }, {
+            url: 'page-2.html',
+            revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          }, {
+            url: 'styles/stylesheet-1.css',
+            revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          }, {
+            url: 'styles/stylesheet-2.css',
+            revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          }, {
+            url: 'webpackEntry.js',
+            revision: 'd41d8cd98f00b204e9800998ecf8427e',
+          }], {
+            cleanUrls: true,
+          }]],
+        }});
+    });
   });
 });

--- a/test/workbox-build/static/sw-injections/precache-and-route-options.js
+++ b/test/workbox-build/static/sw-injections/precache-and-route-options.js
@@ -1,1 +1,1 @@
-workbox.precaching.precacheAndRoute([], { cleanUrls: true });
+workbox.precaching.precacheAndRoute([], {cleanUrls: true});

--- a/test/workbox-build/static/sw-injections/precache-and-route-options.js
+++ b/test/workbox-build/static/sw-injections/precache-and-route-options.js
@@ -1,0 +1,1 @@
+workbox.precaching.precacheAndRoute([], { cleanUrls: true });


### PR DESCRIPTION
R: @philipwalton
CC: @Nooshu to confirm that this behaves as per their expectation.

Fixes #1453 

This tweaks the default `injectionPointRegexp` to support matching calls to `precacheAndRoute` that configure options, while maintaining backwards compatibility.

I.e. both of these can be used now inside the `swSrc`, while in `injectManifest` mode:

```js
workbox.precaching.precacheAndRoute([], {cleanUrls: true});
workbox.precaching.precacheAndRoute([]);
```