### PR TITLE
Fallback to network if there's a cache miss for registerNavigationRoute

### DIFF
--- a/test/workbox-routing/node/test-default.mjs
+++ b/test/workbox-routing/node/test-default.mjs
@@ -316,6 +316,27 @@ describe(`[workbox-routing] Default Router`, function() {
       }));
       expect(response).to.equal(injectedResponse);
     });
+
+    it(`should fetch() when there's a cache miss for the registered URL`, async function() {
+      const fakeResponse = new Response('fake');
+      const fetchStub = sandbox.stub(self, 'fetch').returns(fakeResponse);
+
+      const cacheName = 'does-not-exist';
+      const shellUrl = '/does-not-exist.html';
+
+      const route = defaultRouter.registerNavigationRoute(shellUrl, {
+        cacheName,
+      });
+      const response = await route.handler.handle(new FetchEvent('fetch', {
+        request: new Request('/random/navigation.html', {
+          mode: 'navigate',
+        }),
+      }));
+
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.firstCall.args[0]).to.eql(shellUrl);
+      expect(response).to.eql(fakeResponse);
+    });
   });
 
   describe(`Fetch Events`, function() {


### PR DESCRIPTION
FYI: @philipwalton
CC: @coryrylan

This provides a fallback for the scenario mentioned in #1441, but I'd like to leave that issue open to track the underlying cause.

This is the equivalent of the previously approached #1300, in a fresh PR against the current `master` branch.
