### PR TITLE
Use an empty object rather than undefined when calling new Headers()

### DIFF
--- a/packages/workbox-streams/utils/createHeaders.mjs
+++ b/packages/workbox-streams/utils/createHeaders.mjs
@@ -29,7 +29,8 @@ import '../_version.mjs';
  * @memberof workbox.streams
  */
 function createHeaders(headersInit) {
-  const headers = new Headers(headersInit);
+  // See https://github.com/GoogleChrome/workbox/issues/1461
+  const headers = new Headers(headersInit || {});
   if (!headers.has('content-type')) {
     headers.set('content-type', 'text/html');
   }

--- a/packages/workbox-streams/utils/createHeaders.mjs
+++ b/packages/workbox-streams/utils/createHeaders.mjs
@@ -28,9 +28,9 @@ import '../_version.mjs';
  *
  * @memberof workbox.streams
  */
-function createHeaders(headersInit) {
+function createHeaders(headersInit = {}) {
   // See https://github.com/GoogleChrome/workbox/issues/1461
-  const headers = new Headers(headersInit || {});
+  const headers = new Headers(headersInit);
   if (!headers.has('content-type')) {
     headers.set('content-type', 'text/html');
   }

--- a/test/workbox-streams/node/utils/test-createHeaders.mjs
+++ b/test/workbox-streams/node/utils/test-createHeaders.mjs
@@ -6,7 +6,7 @@ import {createHeaders} from '../../../../packages/workbox-streams/utils/createHe
 describe(`[workbox-streams] utils/createHeaders`, function() {
   const sandbox = sinon.sandbox.create();
 
-  afterEach(async function() {
+  afterEach(function() {
     sandbox.restore();
   });
 

--- a/test/workbox-streams/node/utils/test-createHeaders.mjs
+++ b/test/workbox-streams/node/utils/test-createHeaders.mjs
@@ -1,15 +1,26 @@
 import {expect} from 'chai';
+import sinon from 'sinon';
 
 import {createHeaders} from '../../../../packages/workbox-streams/utils/createHeaders.mjs';
 
 describe(`[workbox-streams] utils/createHeaders`, function() {
+  const sandbox = sinon.sandbox.create();
+
+  afterEach(async function() {
+    sandbox.restore();
+  });
+
   const DEFAULT_CONTENT_TYPE = ['content-type', 'text/html'];
 
-  it(`should use the default Content-Type when headersInit is undefined`, function() {
+  it(`should use the default Content-Type, and construct with an empty object, when headersInit is undefined`, function() {
+    const headersSpy = sandbox.spy(global, 'Headers');
     const headers = createHeaders();
     expect(headers.entries()).to.eql([
       DEFAULT_CONTENT_TYPE,
     ]);
+    expect(headersSpy.calledOnce).to.be.true;
+    // See https://github.com/GoogleChrome/workbox/issues/1461
+    expect(headersSpy.args[0][0]).to.eql({});
   });
 
   it(`should use the default Content-Type along with custom headersInit values`, function() {


### PR DESCRIPTION
R: @philipwalton

Fixes #1461

Small change needed to accommodate a quirk with the `Headers` constructor in Samsung Internet 6.4 (Chrome 56).