### PR TITLE
webpack v4 fixes for compilation.fileDependencies

### DIFF
--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -120,7 +120,18 @@ class InjectManifest {
     }
 
     const originalSWString = await readFileWrapper(readFile, this.config.swSrc);
-    compilation.fileDependencies.push(this.config.swSrc);
+
+    // compilation.fileDependencies needs absolute paths.
+    const absoluteSwSrc = path.resolve(this.config.swSrc);
+    if (Array.isArray(compilation.fileDependencies)) {
+      // webpack v3
+      if (compilation.fileDependencies.indexOf(absoluteSwSrc) === -1) {
+        compilation.fileDependencies.push(absoluteSwSrc);
+      }
+    } else if ('add' in compilation.fileDependencies) {
+      // webpack v4; no need to check for membership first, since it's a Set.
+      compilation.fileDependencies.add(absoluteSwSrc);
+    }
 
     const importScriptsString = importScriptsArray
       .map(JSON.stringify)


### PR DESCRIPTION
R: @philipwalton
CC: @green-arrow 

There were a couple of gotchas that I noticed with #1432 when I was doing some manual testing with `webpack`'s dev server environment:

- The change only worked with `webpack` v3. In v4, `compilation.fileDependencies` is a `Set`, not an `Array`, so a conditional check is required for cross-compatibility.
- The file paths that are passed in to `compilation.fileDependencies` need to be absolute paths, or else they won't accomplish anything. (This requirement might be looser in `webpack` v3, but it's definitely the case in v4.)

This does point to a continued hole in our test coverage, in that we're still tied to `webpack` v3 (see #1281) and we don't test against the `webpack` dev environment (see #1456, though that's just one part of the dev environment).

But in the meantime, this tactical fix is needed to ensure `webpack` v4 compatibility.