### PR TITLE
3.2.0 version strings

### DIFF
--- a/demos/functions/cdn-details.json
+++ b/demos/functions/cdn-details.json
@@ -1,1 +1,1 @@
-{"latestUrl":"https://storage.googleapis.com/workbox-cdn/releases/3.1.0"}
+{"latestUrl":"https://storage.googleapis.com/workbox-cdn/releases/3.2.0"}

--- a/packages/workbox-background-sync/_version.mjs
+++ b/packages/workbox-background-sync/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:background-sync:3.1.0']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:background-sync:3.2.0']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-broadcast-cache-update/_version.mjs
+++ b/packages/workbox-broadcast-cache-update/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:broadcast-cache-update:3.1.0']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:broadcast-cache-update:3.2.0']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-build/src/cdn-details.json
+++ b/packages/workbox-build/src/cdn-details.json
@@ -2,5 +2,5 @@
   "origin": "https://storage.googleapis.com",
   "bucketName": "workbox-cdn",
   "releasesDir": "releases",
-  "latestVersion": "3.1.0"
+  "latestVersion": "3.2.0"
 }

--- a/packages/workbox-cache-expiration/_version.mjs
+++ b/packages/workbox-cache-expiration/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:cache-expiration:3.1.0']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:cache-expiration:3.2.0']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-cacheable-response/_version.mjs
+++ b/packages/workbox-cacheable-response/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:cacheable-response:3.1.0']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:cacheable-response:3.2.0']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-core/_version.mjs
+++ b/packages/workbox-core/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:core:3.1.0']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:core:3.2.0']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-google-analytics/_version.mjs
+++ b/packages/workbox-google-analytics/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:google-analytics:3.1.0']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:google-analytics:3.2.0']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-precaching/_version.mjs
+++ b/packages/workbox-precaching/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:precaching:3.1.0']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:precaching:3.2.0']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-range-requests/_version.mjs
+++ b/packages/workbox-range-requests/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:range-requests:3.1.0']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:range-requests:3.2.0']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-routing/_version.mjs
+++ b/packages/workbox-routing/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:routing:3.1.0']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:routing:3.2.0']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-strategies/_version.mjs
+++ b/packages/workbox-strategies/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:strategies:3.1.0']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:strategies:3.2.0']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-streams/_version.mjs
+++ b/packages/workbox-streams/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:streams:3.1.0']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:streams:3.2.0']=1;}catch(e){} // eslint-disable-line

--- a/packages/workbox-sw/_version.mjs
+++ b/packages/workbox-sw/_version.mjs
@@ -1,1 +1,1 @@
-try{self.workbox.v['workbox:sw:3.1.0']=1;}catch(e){} // eslint-disable-line
+try{self.workbox.v['workbox:sw:3.2.0']=1;}catch(e){} // eslint-disable-line


### PR DESCRIPTION
R: @philipwalton 

`gulp publish` will end up bumping these version strings, but the changes aren't automatically committed to `master`. So there's a follow-up PR after each release to get them checked in.