### PR TITLE
Runtime check for a functional ReadableStream

### DIFF
--- a/packages/workbox-streams/isSupported.mjs
+++ b/packages/workbox-streams/isSupported.mjs
@@ -15,6 +15,8 @@
 
 import './_version.mjs';
 
+let cachedIsSupported = undefined;
+
 /**
  * This is a utility method that determines whether the current browser supports
  * the features required to create streamed responses. Currently, it checks if
@@ -27,12 +29,17 @@ import './_version.mjs';
  * @memberof workbox.streams
  */
 function isSupported() {
-  try {
-    new ReadableStream({start() {}});
-    return true;
-  } catch (error) {
-    return false;
+  if (cachedIsSupported === undefined) {
+    // See https://github.com/GoogleChrome/workbox/issues/1473
+    try {
+      new ReadableStream({start() {}});
+      cachedIsSupported = true;
+    } catch (error) {
+      cachedIsSupported = false;
+    }
   }
+
+  return cachedIsSupported;
 }
 
 export {isSupported};

--- a/packages/workbox-streams/isSupported.mjs
+++ b/packages/workbox-streams/isSupported.mjs
@@ -19,7 +19,7 @@ import './_version.mjs';
  * This is a utility method that determines whether the current browser supports
  * the features required to create streamed responses. Currently, it checks if
  * [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/ReadableStream)
- * is available.
+ * can be created.
  *
  * @return {boolean} `true`, if the current browser meets the requirements for
  * streaming responses, and `false` otherwise.
@@ -27,7 +27,12 @@ import './_version.mjs';
  * @memberof workbox.streams
  */
 function isSupported() {
-  return 'ReadableStream' in self;
+  try {
+    new ReadableStream({start() {}});
+    return true;
+  } catch (error) {
+    return false;
+  }
 }
 
 export {isSupported};

--- a/test/workbox-streams/node/test-isSupported.mjs
+++ b/test/workbox-streams/node/test-isSupported.mjs
@@ -1,36 +1,43 @@
 import {expect} from 'chai';
-
-import {isSupported} from '../../../packages/workbox-streams/isSupported.mjs';
+import clearRequire from 'clear-require';
 
 describe(`[workbox-streams] isSupported`, function() {
   const originalReadableStream = global.ReadableStream;
+  const MODULE_ID = '../../../packages/workbox-streams/isSupported.mjs';
 
   afterEach(function() {
     global.ReadableStream = originalReadableStream;
+    clearRequire(MODULE_ID);
   });
 
-  it(`should return true when ReadableStream is available`, function() {
+  it(`should return true when ReadableStream is available`, async function() {
     class ReadableStream {
       constructor() {
         // no-op
       }
     }
     global.ReadableStream = ReadableStream;
+
+    const {isSupported} = await import(MODULE_ID);
     expect(isSupported()).to.be.true;
   });
 
-  it(`should return false when ReadableStream is not available`, function() {
+  it(`should return false when ReadableStream is not available`, async function() {
     global.ReadableStream = undefined;
+
+    const {isSupported} = await import(MODULE_ID);
     expect(isSupported()).to.be.false;
   });
 
-  it(`should return false when ReadableStream throws during construction`, function() {
+  it(`should return false when ReadableStream throws during construction`, async function() {
     class ReadableStream {
       constructor() {
         throw new Error();
       }
     }
     global.ReadableStream = ReadableStream;
+
+    const {isSupported} = await import(MODULE_ID);
     expect(isSupported()).to.be.false;
   });
 });

--- a/test/workbox-streams/node/test-isSupported.mjs
+++ b/test/workbox-streams/node/test-isSupported.mjs
@@ -3,22 +3,34 @@ import {expect} from 'chai';
 import {isSupported} from '../../../packages/workbox-streams/isSupported.mjs';
 
 describe(`[workbox-streams] isSupported`, function() {
-  const originalSelf = global.self;
+  const originalReadableStream = global.ReadableStream;
 
   afterEach(function() {
-    global.self = originalSelf;
+    global.ReadableStream = originalReadableStream;
   });
 
   it(`should return true when ReadableStream is available`, function() {
-    global.self = {
-      // This could be set to anything.
-      ReadableStream: Object.prototype,
-    };
+    class ReadableStream {
+      constructor() {
+        // no-op
+      }
+    }
+    global.ReadableStream = ReadableStream;
     expect(isSupported()).to.be.true;
   });
 
   it(`should return false when ReadableStream is not available`, function() {
-    global.self = {};
+    global.ReadableStream = undefined;
+    expect(isSupported()).to.be.false;
+  });
+
+  it(`should return false when ReadableStream throws during construction`, function() {
+    class ReadableStream {
+      constructor() {
+        throw new Error();
+      }
+    }
+    global.ReadableStream = ReadableStream;
     expect(isSupported()).to.be.false;
   });
 });


### PR DESCRIPTION
R: @philipwalton

Fixes #1473

Not urgent, but something to get in for our next patch release.

I've got a locally copy of Workbox with this patch deployed for my streams demo, and can confirm that it properly returned `false` for the current buggy Edge 17 build.