### PR TITLE
Passes along the underlying error to a fetchDidFail plugin

### DIFF
--- a/packages/workbox-core/_private/fetchWrapper.mjs
+++ b/packages/workbox-core/_private/fetchWrapper.mjs
@@ -96,20 +96,21 @@ const wrappedFetch = async (request, fetchOptions, plugins = []) => {
       `status '${response.status}'.`);
     }
     return response;
-  } catch (err) {
+  } catch (error) {
     if (process.env.NODE_ENV !== 'production') {
       logger.error(`Network request for `+
-      `'${getFriendlyURL(request.url)}' threw an error.`, err);
+      `'${getFriendlyURL(request.url)}' threw an error.`, error);
     }
 
     for (let plugin of failedFetchPlugins) {
       await plugin[pluginEvents.FETCH_DID_FAIL].call(plugin, {
+        error,
         originalRequest: originalRequest.clone(),
         request: pluginFilteredRequest.clone(),
       });
     }
 
-    throw err;
+    throw error;
   }
 };
 

--- a/test/workbox-core/node/_private/test-fetchWrapper.mjs
+++ b/test/workbox-core/node/_private/test-fetchWrapper.mjs
@@ -119,9 +119,10 @@ describe(`workbox-core fetchWrapper`, function() {
       });
 
       const secondPlugin = {
-        fetchDidFail: ({originalRequest, request}) => {
+        fetchDidFail: ({originalRequest, request, error}) => {
           expect(originalRequest.url).to.equal('/test/failingRequest/0');
           expect(request.url).to.equal('/test/failingRequest/1');
+          expect(error.message).to.equal('Injected Error.');
         },
       };
       const spyTwo = sandbox.spy(secondPlugin, 'fetchDidFail');
@@ -130,11 +131,12 @@ describe(`workbox-core fetchWrapper`, function() {
         requestWillFetch: ({request}) => {
           return new Request('/test/failingRequest/1');
         },
-        fetchDidFail: ({originalRequest, request}) => {
+        fetchDidFail: ({originalRequest, request, error}) => {
           // This should be called first
           expect(spyTwo.callCount).to.equal(0);
           expect(originalRequest.url).to.equal('/test/failingRequest/0');
           expect(request.url).to.equal('/test/failingRequest/1');
+          expect(error.message).to.equal('Injected Error.');
         },
       };
       const spyOne = sandbox.spy(firstPlugin, 'fetchDidFail');


### PR DESCRIPTION
R: @philipwalton

Fixes #1484

We need to update https://developers.google.com/web/tools/workbox/guides/using-plugins#custom_plugins as well once this is merged.
