### PR TITLE
Improve the code that swaps 'prod' for 'dev' in copyWorkboxLibraries

### DIFF
--- a/packages/workbox-build/src/lib/use-build-type.js
+++ b/packages/workbox-build/src/lib/use-build-type.js
@@ -27,6 +27,7 @@ const DEFAULT_BUILD_TYPE = 'prod';
  * @param {string} buildType The alternative build type value to swap in.
  * @return {string} source, with the last occurrence of DEFAULT_BUILD_TYPE
  * replaced with buildType.
+ * @private
  */
 module.exports = (source, buildType) => {
   // If we want the DEFAULT_BUILD_TYPE, then just return things as-is.

--- a/packages/workbox-build/src/lib/use-build-type.js
+++ b/packages/workbox-build/src/lib/use-build-type.js
@@ -36,7 +36,8 @@ module.exports = (source, buildType) => {
   // Otherwise, look for the last instance of DEFAULT_BUILD_TYPE, and replace it
   // with the new buildType. This is easier via split/join than RegExp.
   const parts = source.split(DEFAULT_BUILD_TYPE);
-  // Join the last two split parts with the new buildType.
+  // Join the last two split parts with the new buildType. (If parts only has
+  // one item, this will be a no-op.)
   const replaced = parts.slice(parts.length - 2).join(buildType);
   // Take the remaining parts, if any exist, and join them with the replaced
   // part using the DEFAULT_BUILD_TYPE, to restore any other matches as-is.

--- a/packages/workbox-build/src/lib/use-build-type.js
+++ b/packages/workbox-build/src/lib/use-build-type.js
@@ -14,9 +14,34 @@
   limitations under the License.
 */
 
-// TODO (jeffposnick): More flexibility in case naming conventions change.
+// This is the build type that is expected to be present "by default".
 const DEFAULT_BUILD_TYPE = 'prod';
 
+/**
+ * Switches a string from using the "default" build type to an alternative
+ * build type. In practice, this is used to swap out "prod" for "dev" in the
+ * filename of a Workbox library.
+ *
+ * @param {string} source The path to a file, which will normally contain
+ * DEFAULT_BUILD_TYPE somewhere in it.
+ * @param {string} buildType The alternative build type value to swap in.
+ * @return {string} source, with the last occurrence of DEFAULT_BUILD_TYPE
+ * replaced with buildType.
+ */
 module.exports = (source, buildType) => {
-  return source.replace(DEFAULT_BUILD_TYPE, buildType);
+  // If we want the DEFAULT_BUILD_TYPE, then just return things as-is.
+  if (buildType === DEFAULT_BUILD_TYPE) {
+    return source;
+  }
+  // Otherwise, look for the last instance of DEFAULT_BUILD_TYPE, and replace it
+  // with the new buildType. This is easier via split/join than RegExp.
+  const parts = source.split(DEFAULT_BUILD_TYPE);
+  // Join the last two split parts with the new buildType.
+  const replaced = parts.slice(parts.length - 2).join(buildType);
+  // Take the remaining parts, if any exist, and join them with the replaced
+  // part using the DEFAULT_BUILD_TYPE, to restore any other matches as-is.
+  return [
+    ...parts.slice(0, parts.length - 2),
+    replaced,
+  ].join(DEFAULT_BUILD_TYPE);
 };

--- a/test/workbox-build/node/lib/use-build-type.js
+++ b/test/workbox-build/node/lib/use-build-type.js
@@ -18,7 +18,7 @@ describe(`[workbox-build] lib/use-build-type.js`, function() {
     expect(result).to.eql('/path/to/production/also.prod.path/workbox.dev.js');
   });
 
-  it(`should not update anything is there is no match for the default build type`, function() {
+  it(`should not update anything if there is no match for the default build type`, function() {
     const result = useBuildType('/does/not/match', 'dev');
     expect(result).to.eql('/does/not/match');
   });

--- a/test/workbox-build/node/lib/use-build-type.js
+++ b/test/workbox-build/node/lib/use-build-type.js
@@ -15,7 +15,7 @@ describe(`[workbox-build] lib/use-build-type.js`, function() {
 
   it(`should only update the last match when buildType is 'dev'`, function() {
     const result = useBuildType('/path/to/production/and.prod.check/workbox.prod.js', 'dev');
-    expect(result).to.eql('/path/to/production/also.prod.path/workbox.dev.js');
+    expect(result).to.eql('/path/to/production/and.prod.check/workbox.dev.js');
   });
 
   it(`should not update anything if there is no match for the default build type`, function() {

--- a/test/workbox-build/node/lib/use-build-type.js
+++ b/test/workbox-build/node/lib/use-build-type.js
@@ -1,0 +1,25 @@
+const expect = require('chai').expect;
+
+const useBuildType = require('../../../../packages/workbox-build/src/lib/use-build-type');
+
+describe(`[workbox-build] lib/use-build-type.js`, function() {
+  it(`should not update anything when buildType is 'prod'`, function() {
+    const result = useBuildType('/path/to/workbox.prod.js', 'prod');
+    expect(result).to.eql('/path/to/workbox.prod.js');
+  });
+
+  it(`should update when buildType is 'dev'`, function() {
+    const result = useBuildType('/path/to/workbox.prod.js', 'dev');
+    expect(result).to.eql('/path/to/workbox.dev.js');
+  });
+
+  it(`should only update the last match when buildType is 'dev'`, function() {
+    const result = useBuildType('/path/to/production/and.prod.check/workbox.prod.js', 'dev');
+    expect(result).to.eql('/path/to/production/also.prod.path/workbox.dev.js');
+  });
+
+  it(`should not update anything is there is no match for the default built type`, function() {
+    const result = useBuildType('/does/not/match', 'dev');
+    expect(result).to.eql('/does/not/match');
+  });
+});

--- a/test/workbox-build/node/lib/use-build-type.js
+++ b/test/workbox-build/node/lib/use-build-type.js
@@ -18,7 +18,7 @@ describe(`[workbox-build] lib/use-build-type.js`, function() {
     expect(result).to.eql('/path/to/production/also.prod.path/workbox.dev.js');
   });
 
-  it(`should not update anything is there is no match for the default built type`, function() {
+  it(`should not update anything is there is no match for the default build type`, function() {
     const result = useBuildType('/does/not/match', 'dev');
     expect(result).to.eql('/does/not/match');
   });


### PR DESCRIPTION
R: @philipwalton

Fixes #1478 

This code path is still a bit hacky, and there's a lot of hardcoded assumptions, but at least it should now work as expected when the `source` path contains multiple instances of `DEFAULT_BUILD_TYPE`.