### PR TITLE
Run the webpack test suite against webpack v4

### DIFF
--- a/infra/testing/create-webpack-asset-plugin.js
+++ b/infra/testing/create-webpack-asset-plugin.js
@@ -1,0 +1,24 @@
+// A small helper class to generate a "fake" webpack asset for testing purposes.
+// Roughly equivalent to https://www.npmjs.com/package/generate-asset-webpack-plugin,
+// but this uses the webpack v4 syntax.
+
+class CreateWebpackAssetPlugin {
+  constructor(name) {
+    if (typeof name !== 'string') {
+      throw new Error('Please pass in a string.');
+    }
+    this.name = name;
+  }
+
+  apply(compiler) {
+    compiler.hooks.emit.tap(
+      this.constructor.name,
+      (compilation) => compilation.assets[this.name] = {
+        source: () => this.name,
+        size: () => this.name.length,
+      }
+    );
+  }
+}
+
+module.exports = CreateWebpackAssetPlugin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -606,6 +606,164 @@
       "integrity": "sha512-GbuVyWFeh+HYCX0cgvKoY0jWN3t8s11+i2mvBtXswl2WDNNaHpF6JwbZQxdf3cfRRO4E7bS9FeZ2Y+HB1WwFPg==",
       "dev": true
     },
+    "@webassemblyjs/ast": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.4.3.tgz",
+      "integrity": "sha512-S6npYhPcTHDYe9nlsKa9CyWByFi8Vj8HovcAgtmMAQZUOczOZbQ8CnwMYKYC5HEZzxEE+oY0jfQk4cVlI3J59Q==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+        "@webassemblyjs/wast-parser": "1.4.3",
+        "debug": "3.1.0",
+        "webassemblyjs": "1.4.3"
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.4.3.tgz",
+      "integrity": "sha512-3zTkSFswwZOPNHnzkP9ONq4bjJSeKVMcuahGXubrlLmZP8fmTIJ58dW7h/zOVWiFSuG2em3/HH3BlCN7wyu9Rw==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.4.3.tgz",
+      "integrity": "sha512-e8+KZHh+RV8MUvoSRtuT1sFXskFnWG9vbDy47Oa166xX+l0dD5sERJ21g5/tcH8Yo95e9IN3u7Jc3NbhnUcSkw==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0"
+      }
+    },
+    "@webassemblyjs/helper-code-frame": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.4.3.tgz",
+      "integrity": "sha512-9FgHEtNsZQYaKrGCtsjswBil48Qp1agrzRcPzCbQloCoaTbOXLJ9IRmqT+uEZbenpULLRNFugz3I4uw18hJM8w==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/wast-printer": "1.4.3"
+      }
+    },
+    "@webassemblyjs/helper-fsm": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.4.3.tgz",
+      "integrity": "sha512-JINY76U+702IRf7ePukOt037RwmtH59JHvcdWbTTyHi18ixmQ+uOuNhcdCcQHTquDAH35/QgFlp3Y9KqtyJsCQ==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.4.3.tgz",
+      "integrity": "sha512-I7bS+HaO0K07Io89qhJv+z1QipTpuramGwUSDkwEaficbSvCcL92CUZEtgykfNtk5wb0CoLQwWlmXTwGbNZUeQ==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.4.3.tgz",
+      "integrity": "sha512-p0yeeO/h2r30PyjnJX9xXSR6EDcvJd/jC6xa/Pxg4lpfcNi7JUswOpqDToZQ55HMMVhXDih/yqkaywHWGLxqyQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/helper-buffer": "1.4.3",
+        "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+        "@webassemblyjs/wasm-gen": "1.4.3",
+        "debug": "3.1.0"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.4.3.tgz",
+      "integrity": "sha512-4u0LJLSPzuRDWHwdqsrThYn+WqMFVqbI2ltNrHvZZkzFPO8XOZ0HFQ5eVc4jY/TNHgXcnwrHjONhPGYuuf//KQ==",
+      "dev": true,
+      "requires": {
+        "leb": "0.3.0"
+      }
+    },
+    "@webassemblyjs/validation": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/validation/-/validation-1.4.3.tgz",
+      "integrity": "sha512-R+rRMKfhd9mq0rj2mhU9A9NKI2l/Rw65vIYzz4lui7eTKPcCu1l7iZNi4b9Gen8D42Sqh/KGiaQNk/x5Tn/iBQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.4.3"
+      }
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.4.3.tgz",
+      "integrity": "sha512-qzuwUn771PV6/LilqkXcS0ozJYAeY/OKbXIWU3a8gexuqb6De2p4ya/baBeH5JQ2WJdfhWhSvSbu86Vienttpw==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/helper-buffer": "1.4.3",
+        "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+        "@webassemblyjs/helper-wasm-section": "1.4.3",
+        "@webassemblyjs/wasm-gen": "1.4.3",
+        "@webassemblyjs/wasm-opt": "1.4.3",
+        "@webassemblyjs/wasm-parser": "1.4.3",
+        "@webassemblyjs/wast-printer": "1.4.3",
+        "debug": "3.1.0"
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.4.3.tgz",
+      "integrity": "sha512-eR394T8dHZfpLJ7U/Z5pFSvxl1L63JdREebpv9gYc55zLhzzdJPAuxjBYT4XqevUdW67qU2s0nNA3kBuNJHbaQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+        "@webassemblyjs/leb128": "1.4.3"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.4.3.tgz",
+      "integrity": "sha512-7Gp+nschuKiDuAL1xmp4Xz0rgEbxioFXw4nCFYEmy+ytynhBnTeGc9W9cB1XRu1w8pqRU2lbj2VBBA4cL5Z2Kw==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/helper-buffer": "1.4.3",
+        "@webassemblyjs/wasm-gen": "1.4.3",
+        "@webassemblyjs/wasm-parser": "1.4.3",
+        "debug": "3.1.0"
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.4.3.tgz",
+      "integrity": "sha512-KXBjtlwA3BVukR/yWHC9GF+SCzBcgj0a7lm92kTOaa4cbjaTaa47bCjXw6cX4SGQpkncB9PU2hHGYVyyI7wFRg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+        "@webassemblyjs/leb128": "1.4.3",
+        "@webassemblyjs/wasm-parser": "1.4.3",
+        "webassemblyjs": "1.4.3"
+      }
+    },
+    "@webassemblyjs/wast-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.4.3.tgz",
+      "integrity": "sha512-QhCsQzqV0CpsEkRYyTzQDilCNUZ+5j92f+g35bHHNqS22FppNTywNFfHPq8ZWZfYCgbectc+PoghD+xfzVFh1Q==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/floating-point-hex-parser": "1.4.3",
+        "@webassemblyjs/helper-code-frame": "1.4.3",
+        "@webassemblyjs/helper-fsm": "1.4.3",
+        "long": "3.2.0",
+        "webassemblyjs": "1.4.3"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.4.3.tgz",
+      "integrity": "sha512-EgXk4anf8jKmuZJsqD8qy5bz2frEQhBvZruv+bqwNoLWUItjNSFygk8ywL3JTEz9KtxTlAmqTXNrdD1d9gNDtg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/wast-parser": "1.4.3",
+        "long": "3.2.0"
+      }
+    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -637,23 +795,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
       "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
       "dev": true
-    },
-    "acorn-dynamic-import": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
-      "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-      "dev": true,
-      "requires": {
-        "acorn": "4.0.13"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
-      }
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -2621,6 +2762,7 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
+      "optional": true,
       "requires": {
         "align-text": "0.1.4",
         "lazy-cache": "1.0.4"
@@ -2710,6 +2852,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true
+    },
+    "chrome-trace-event": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.3.tgz",
+      "integrity": "sha512-sjndyZHrrWiu4RY7AkHgjn80GfAM2ZSzUkZLV/Js59Ldmh6JDThf0SUmOHU53rFu2rVxxfCzJ30Ukcfch3Gb/A==",
       "dev": true
     },
     "chromedriver": {
@@ -4794,18 +4942,6 @@
         "has-binary2": "1.0.2"
       }
     },
-    "enhanced-resolve": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
-      "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
-      }
-    },
     "ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
@@ -4836,6 +4972,30 @@
         "is-arrayish": "0.2.1"
       }
     },
+    "es-abstract": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+      "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
     "es5-ext": {
       "version": "0.10.42",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
@@ -4856,20 +5016,6 @@
         "d": "1.0.0",
         "es5-ext": "0.10.42",
         "es6-symbol": "3.1.1"
-      }
-    },
-    "es6-map": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
       }
     },
     "es6-promise": {
@@ -4933,18 +5079,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
-    },
-    "escope": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true,
-      "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
-      }
     },
     "eslint": {
       "version": "4.19.1",
@@ -8299,6 +8433,15 @@
         "har-schema": "2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -8555,17 +8698,18 @@
       }
     },
     "html-webpack-plugin": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
-      "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
         "html-minifier": "3.5.15",
         "loader-utils": "0.2.17",
         "lodash": "4.17.10",
         "pretty-error": "2.1.1",
-        "toposort": "1.0.6"
+        "tapable": "1.0.0",
+        "toposort": "1.0.6",
+        "util.promisify": "1.0.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -8579,6 +8723,12 @@
             "json5": "0.5.1",
             "object-assign": "4.1.1"
           }
+        },
+        "tapable": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
+          "integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
+          "dev": true
         }
       }
     },
@@ -8939,6 +9089,12 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
     "is-ci": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
@@ -8956,6 +9112,12 @@
       "requires": {
         "kind-of": "3.2.2"
       }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -9160,6 +9322,15 @@
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
     "is-relative": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
@@ -9197,6 +9368,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
       "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-text-path": {
@@ -9469,12 +9646,6 @@
       "dev": true,
       "optional": true
     },
-    "json-loader": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
-      "dev": true
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -9726,7 +9897,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lazy-req": {
       "version": "1.1.0",
@@ -9766,6 +9938,12 @@
       "requires": {
         "flush-write-stream": "1.0.3"
       }
+    },
+    "leb": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/leb/-/leb-0.3.0.tgz",
+      "integrity": "sha1-Mr7p+tFoMo1q6oUi2DP0GA7tHaM=",
+      "dev": true
     },
     "lerna": {
       "version": "2.11.0",
@@ -10572,6 +10750,12 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
       "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
+    },
+    "long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
       "dev": true
     },
     "longest": {
@@ -14550,6 +14734,16 @@
         }
       }
     },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.11.0"
+      }
+    },
     "object.map": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
@@ -16386,6 +16580,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "align-text": "0.1.4"
       }
@@ -16623,6 +16818,57 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "schema-utils": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+      "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+      "dev": true,
+      "requires": {
+        "ajv": "6.5.0",
+        "ajv-keywords": "3.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
+          "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "4.2.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        },
+        "uri-js": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
+          "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
+          "dev": true,
+          "requires": {
+            "punycode": "2.1.1"
+          }
+        }
+      }
     },
     "selenium-assistant": {
       "version": "5.3.0",
@@ -17896,12 +18142,6 @@
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
-    "tapable": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-      "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
-      "dev": true
-    },
     "tar": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
@@ -18345,65 +18585,6 @@
       "dev": true,
       "optional": true
     },
-    "uglifyjs-webpack-plugin": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
-      "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7",
-        "uglify-js": "2.8.29",
-        "webpack-sources": "1.1.0"
-      },
-      "dependencies": {
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          }
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
-        }
-      }
-    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -18758,23 +18939,6 @@
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
-    "uri-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
-      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
-      "dev": true,
-      "requires": {
-        "punycode": "2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-          "dev": true
-        }
-      }
-    },
     "urijs": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
@@ -18888,6 +19052,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "object.getownpropertydescriptors": "2.0.3"
+      }
     },
     "utila": {
       "version": "0.4.0",
@@ -19461,214 +19635,417 @@
         "defaults": "1.0.3"
       }
     },
-    "webpack": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
-      "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
+    "webassemblyjs": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/webassemblyjs/-/webassemblyjs-1.4.3.tgz",
+      "integrity": "sha512-4lOV1Lv6olz0PJkDGQEp82HempAn147e6BXijWDzz9g7/2nSebVP9GVg62Fz5ZAs55mxq13GA0XLyvY8XkyDjg==",
       "dev": true,
       "requires": {
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/validation": "1.4.3",
+        "@webassemblyjs/wasm-parser": "1.4.3",
+        "@webassemblyjs/wast-parser": "1.4.3",
+        "long": "3.2.0"
+      }
+    },
+    "webpack": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.8.3.tgz",
+      "integrity": "sha512-/hfAjBISycdK597lxONjKEFX7dSIU1PsYwC3XlXUXoykWBlv9QV5HnO+ql3HvrrgfBJ7WXdnjO9iGPR2aAc5sw==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/wasm-edit": "1.4.3",
+        "@webassemblyjs/wasm-parser": "1.4.3",
         "acorn": "5.5.3",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "6.4.0",
-        "ajv-keywords": "3.1.0",
-        "async": "2.6.0",
-        "enhanced-resolve": "3.4.1",
-        "escope": "3.6.0",
-        "interpret": "1.1.0",
-        "json-loader": "0.5.7",
-        "json5": "0.5.1",
+        "acorn-dynamic-import": "3.0.0",
+        "ajv": "6.5.0",
+        "ajv-keywords": "3.2.0",
+        "chrome-trace-event": "0.1.3",
+        "enhanced-resolve": "4.0.0",
+        "eslint-scope": "3.7.1",
         "loader-runner": "2.3.0",
         "loader-utils": "1.1.0",
         "memory-fs": "0.4.1",
+        "micromatch": "3.1.10",
         "mkdirp": "0.5.1",
+        "neo-async": "2.5.1",
         "node-libs-browser": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.5.0",
-        "tapable": "0.2.8",
-        "uglifyjs-webpack-plugin": "0.4.6",
+        "schema-utils": "0.4.5",
+        "tapable": "1.0.0",
+        "uglifyjs-webpack-plugin": "1.2.5",
         "watchpack": "1.6.0",
-        "webpack-sources": "1.1.0",
-        "yargs": "8.0.2"
+        "webpack-sources": "1.1.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+        "acorn-dynamic-import": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+          "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "1.1.0",
+            "acorn": "5.5.3"
+          }
+        },
+        "ajv": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
+          "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "2.0.1",
             "fast-json-stable-stringify": "2.0.0",
             "json-schema-traverse": "0.3.1",
-            "uri-js": "3.0.2"
+            "uri-js": "4.2.1"
           }
         },
         "ajv-keywords": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
-          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
           "dev": true
         },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+        "enhanced-resolve": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.0.0.tgz",
+          "integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "memory-fs": "0.4.1",
+            "tapable": "1.0.0"
           }
         },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
           }
         },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
           "dev": true
         },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
+        "fill-range": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
-        "strip-bom": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
           }
         },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
-        "yargs": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "tapable": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
+          "integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
+          "dev": true
+        },
+        "uglifyjs-webpack-plugin": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.5.tgz",
+          "integrity": "sha512-hIQJ1yxAPhEA2yW/i7Fr+SXZVMp+VEI3d42RTHBgQd2yhp/1UdBcR3QEWPV5ahBxlqQDMEMTuTEvDHSFINfwSw==",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "cacache": "10.0.4",
+            "find-cache-dir": "1.0.0",
+            "schema-utils": "0.4.5",
+            "serialize-javascript": "1.5.0",
+            "source-map": "0.6.1",
+            "uglify-es": "3.3.9",
+            "webpack-sources": "1.1.0",
+            "worker-farm": "1.6.0"
+          }
+        },
+        "uri-js": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
+          "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
+          "dev": true,
+          "requires": {
+            "punycode": "2.1.1"
           }
         }
       }
@@ -19770,6 +20147,15 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
+    },
+    "worker-farm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
+      "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+      "dev": true,
+      "requires": {
+        "errno": "0.1.7"
+      }
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "firebase-tools": "^3.13.1",
     "fs-extra": "^5.0.0",
     "geckodriver": "^1.8.1",
-    "generate-asset-webpack-plugin": "^0.3.0",
     "github": "^13.0.1",
     "glob": "^7.1.2",
     "gulp": "^4.0.0",
@@ -81,7 +80,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^2.6.1",
     "gzip-size": "^4.0.0",
-    "html-webpack-plugin": "^2.30.1",
+    "html-webpack-plugin": "^3.2.0",
     "jsdoc": "^3.5.5",
     "jsdoc-baseline": "https://github.com/hegemonic/baseline/tarball/master",
     "lerna": "^2.4.0",
@@ -106,6 +105,6 @@
     "url-search-params": "^0.10.0",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
-    "webpack": "^3.8.1"
+    "webpack": "^4.8.3"
   }
 }

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -1,5 +1,4 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const GenerateAssetPlugin = require('generate-asset-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const expect = require('chai').expect;
 const fse = require('fs-extra');
@@ -9,8 +8,9 @@ const tempy = require('tempy');
 const vm = require('vm');
 const webpack = require('webpack');
 
-const {GenerateSW} = require('../../../packages/workbox-webpack-plugin/src/index');
+const CreateWebpackAssetPlugin = require('../../../infra/testing/create-webpack-asset-plugin');
 const validateServiceWorkerRuntime = require('../../../infra/testing/validator/service-worker-runtime');
+const {GenerateSW} = require('../../../packages/workbox-webpack-plugin/src/index');
 const {getModuleUrl} = require('../../../packages/workbox-build/src/lib/cdn-utils');
 
 describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
@@ -71,6 +71,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     it(`should throw when importWorkboxFrom is set to an invalid chunk name`, function(done) {
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -102,6 +103,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     it(`should throw when precacheManifestFilename doesn't include [manifestHash]`, function(done) {
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -133,9 +135,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Ensure only one precache-manifest is present on re-compile`, function() {
     it(`should only have one reference to precache-manifest file in 'importScripts'`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.b6f6b1b151c4f027ee1e1aa3061eeaf7.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.fae694daec42acd5171efe1585b77a25.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -183,9 +186,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-17c2a1b5c94290899539.js',
+            url: 'entry2-3a66319e95a85614711d.js',
           }, {
-            url: 'entry1-d7f4e7088b64a9896b23.js',
+            url: 'entry1-bc538ab2d7590b7b8664.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -204,9 +207,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] multiple chunks`, function() {
     it(`should work when called without any parameters`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.b6f6b1b151c4f027ee1e1aa3061eeaf7.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.fae694daec42acd5171efe1585b77a25.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -248,9 +252,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-17c2a1b5c94290899539.js',
+            url: 'entry2-3a66319e95a85614711d.js',
           }, {
-            url: 'entry1-d7f4e7088b64a9896b23.js',
+            url: 'entry1-bc538ab2d7590b7b8664.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -262,10 +266,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should support setting importWorkboxFrom to a chunk's name`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.77e720b5deee9dafb4df79d5e4c2f2e0.js';
-      const workboxEntryName = 'workboxEntry-51dca2278b60b4b86e8c.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.4c6fd1686fa3f8695bebd46f4b7b3f3f.js';
+      const workboxEntryName = 'workboxEntry-dadac8f5b128154abc67.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -308,9 +313,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-0c3c00f8cd0d3271089c.js',
+            url: 'entry2-92dccaedfeb393526fc6.js',
           }, {
-            url: 'entry1-3865b3908d1988da1758.js',
+            url: 'entry1-e4a456eedf0d4e07ee29.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -322,9 +327,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should support setting importWorkboxFrom to 'local'`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.b6f6b1b151c4f027ee1e1aa3061eeaf7.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.fae694daec42acd5171efe1585b77a25.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -383,9 +389,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-17c2a1b5c94290899539.js',
+            url: 'entry2-3a66319e95a85614711d.js',
           }, {
-            url: 'entry1-d7f4e7088b64a9896b23.js',
+            url: 'entry1-bc538ab2d7590b7b8664.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -397,10 +403,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should support setting importWorkboxFrom to 'local', respecting output.publicPath`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.ded0a9e68272d64590dbeebac7c52fd7.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.b363a71c57109c5192734efb6ea514fb.js';
       const outputDir = tempy.directory();
       const publicPath = '/testing/';
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -461,9 +468,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: publicPath + 'entry2-9700b0cb6282320b628f.js',
+            url: publicPath + 'entry2-7d5e55c5530155394735.js',
           }, {
-            url: publicPath + 'entry1-ebb39acd9a53861a2a43.js',
+            url: publicPath + 'entry1-771d72ade2e26e13b31b.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -475,9 +482,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should honor the 'chunks' whitelist config`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.77e720b5deee9dafb4df79d5e4c2f2e0.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.4c6fd1686fa3f8695bebd46f4b7b3f3f.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -522,9 +530,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-0c3c00f8cd0d3271089c.js',
+            url: 'entry2-92dccaedfeb393526fc6.js',
           }, {
-            url: 'entry1-3865b3908d1988da1758.js',
+            url: 'entry1-e4a456eedf0d4e07ee29.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -536,9 +544,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should honor the 'excludeChunks' blacklist config`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.77e720b5deee9dafb4df79d5e4c2f2e0.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.4c6fd1686fa3f8695bebd46f4b7b3f3f.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -583,9 +592,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-0c3c00f8cd0d3271089c.js',
+            url: 'entry2-92dccaedfeb393526fc6.js',
           }, {
-            url: 'entry1-3865b3908d1988da1758.js',
+            url: 'entry1-e4a456eedf0d4e07ee29.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -597,9 +606,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should honor setting both the 'chunks' and 'excludeChunks', with the blacklist taking precedence`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.8b017100ab9e5377c63145f3034bae3f.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.d0932095ef143b3b996b149416acecb3.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -645,7 +655,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry1-3865b3908d1988da1758.js',
+            url: 'entry1-e4a456eedf0d4e07ee29.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -657,9 +667,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should pass through the config to workbox-build.generateSWString()`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.b6f6b1b151c4f027ee1e1aa3061eeaf7.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.fae694daec42acd5171efe1585b77a25.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -717,9 +728,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-17c2a1b5c94290899539.js',
+            url: 'entry2-3a66319e95a85614711d.js',
           }, {
-            url: 'entry1-d7f4e7088b64a9896b23.js',
+            url: 'entry1-bc538ab2d7590b7b8664.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -733,9 +744,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] html-webpack-plugin and a single chunk`, function() {
     it(`should work when called without any parameters`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.3025354ee867087a8f380b661c2ed62f.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.dfbc1d9214ba28c6bcc481cfe5817ac5.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -778,12 +790,12 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            revision: 'df7649048255d9f47e0f80cbe11cd4ef',
+            revision: 'f1e52b85db9f9855556de4af08872738',
             url: 'index.html',
           }, {
-            url: 'entry2-17c2a1b5c94290899539.js',
+            url: 'entry2-3a66319e95a85614711d.js',
           }, {
-            url: 'entry1-d7f4e7088b64a9896b23.js',
+            url: 'entry1-bc538ab2d7590b7b8664.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -797,9 +809,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] copy-webpack-plugin and a single chunk`, function() {
     it(`should work when called without any parameters`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.f7220180c1f86202aa3bd9ed1ef02890.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.652bcd9d1eb54020ea188382f5baae93.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
           filename: WEBPACK_ENTRY_FILENAME,
@@ -842,7 +855,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            revision: '8e8e9f093f036bd18dfa',
+            revision: '1b6ab2dabb8f64fd207b',
             url: 'webpackEntry.js',
           }, {
             revision: '884f6853a4fc655e4c2dc0c0f27a227c',
@@ -877,12 +890,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
   });
 
   describe(`[workbox-webpack-plugin] Filtering via test/include/exclude`, function() {
-    const TEST_ASSET_CB = (compilation, callback) => callback(null, 'test');
-
     it(`should exclude .map and manifest.js(on) files by default`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.43591bdf46c7ac47eb8d7b2bcd41f13e.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.5cb9aa420ab5dcfaddb13269cf52baad.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
           filename: WEBPACK_ENTRY_FILENAME,
@@ -890,14 +902,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         },
         devtool: 'source-map',
         plugins: [
-          new GenerateAssetPlugin({
-            filename: 'manifest.js',
-            fn: TEST_ASSET_CB,
-          }),
-          new GenerateAssetPlugin({
-            filename: 'manifest.json',
-            fn: TEST_ASSET_CB,
-          }),
+          new CreateWebpackAssetPlugin('manifest.js'),
+          new CreateWebpackAssetPlugin('manifest.json'),
+          new CreateWebpackAssetPlugin('not-ignored.js'),
           new GenerateSW(),
         ],
       };
@@ -930,8 +937,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            revision: '8e8e9f093f036bd18dfa',
+            revision: '1b6ab2dabb8f64fd207b',
             url: 'webpackEntry.js',
+          }, {
+            revision: 'aef75af28f6de0771a8d6bae84d9e71d',
+            url: 'not-ignored.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -943,9 +953,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should allow developers to override the default exclude filter`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.b87ef85173e527290f94979b09e72d12.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.0eb25ac79cff069c5cfe5475a6328248.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
           filename: WEBPACK_ENTRY_FILENAME,
@@ -987,10 +998,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            revision: '8e8e9f093f036bd18dfa',
+            revision: '1b6ab2dabb8f64fd207b',
             url: 'webpackEntry.js.map',
           }, {
-            revision: '8e8e9f093f036bd18dfa',
+            revision: '1b6ab2dabb8f64fd207b',
             url: 'webpackEntry.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
@@ -1006,6 +1017,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       const FILE_MANIFEST_NAME = 'precache-manifest.1242f9e007897f035a52e56690ff17a6.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
           filename: WEBPACK_ENTRY_FILENAME,
@@ -1073,6 +1085,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       const FILE_MANIFEST_NAME = 'precache-manifest.83df65831eb442f8ad5fbeb8edecc558.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
           filename: WEBPACK_ENTRY_FILENAME,
@@ -1137,9 +1150,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] swDest variations`, function() {
     it(`should work when swDest is an absolute path`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.43591bdf46c7ac47eb8d7b2bcd41f13e.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.a795adfa9739556c5b0399d7e7db5112.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
           filename: WEBPACK_ENTRY_FILENAME,
@@ -1181,7 +1195,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            revision: '8e8e9f093f036bd18dfa',
+            revision: '1b6ab2dabb8f64fd207b',
             url: 'webpackEntry.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
@@ -1196,9 +1210,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Reporting webpack warnings`, function() {
     it(`should add warnings from the workbox-build methods to compilation.warnings`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.eca1a14406dbeefe3925758a8999609a.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.12f50ce2c09ebfbcf80a7052010d2aa5.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -1257,7 +1272,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+            url: 'entry1-bfe67dbdc61e895ab6cb.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -1269,7 +1284,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should add a warning when various glob-related options are set`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.eca1a14406dbeefe3925758a8999609a.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.12f50ce2c09ebfbcf80a7052010d2aa5.js';
       const outputDir = tempy.directory();
       const globOptionsToWarnAbout = [
         'globDirectory',
@@ -1279,6 +1294,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         'globStrict',
       ];
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -1338,7 +1354,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+            url: 'entry1-bfe67dbdc61e895ab6cb.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -1350,7 +1366,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should add a warning when certain options are used, but globPatterns isn't set`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.eca1a14406dbeefe3925758a8999609a.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.12f50ce2c09ebfbcf80a7052010d2aa5.js';
       const outputDir = tempy.directory();
       const optionsToWarnAboutWhenGlobPatternsIsNotSet = [
         'dontCacheBustUrlsMatching',
@@ -1359,6 +1375,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         'modifyUrlPrefix',
       ];
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -1408,7 +1425,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+            url: 'entry1-bfe67dbdc61e895ab6cb.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -1422,9 +1439,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Customizing output paths and names`, function() {
     it(`should allow overriding precacheManifestFilename`, function(done) {
-      const FILE_MANIFEST_NAME = 'custom-name.eca1a14406dbeefe3925758a8999609a.js';
+      const FILE_MANIFEST_NAME = 'custom-name.12f50ce2c09ebfbcf80a7052010d2aa5.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -1469,7 +1487,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+            url: 'entry1-bfe67dbdc61e895ab6cb.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -1481,10 +1499,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should allow setting importsDirectory`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.eca1a14406dbeefe3925758a8999609a.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.12f50ce2c09ebfbcf80a7052010d2aa5.js';
       const outputDir = tempy.directory();
       const importsDirectory = path.join('one', 'two');
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -1530,7 +1549,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+            url: 'entry1-bfe67dbdc61e895ab6cb.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -1542,11 +1561,12 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should allow setting importsDirectory, publicPath, and importWorkboxFrom: 'local'`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.d9302c9dad14c032f73ccb9cb3458c49.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.41207b4b29b325602ab0d53ebf082054.js';
       const outputDir = tempy.directory();
       const importsDirectory = path.join('one', 'two');
       const publicPath = '/testing/';
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -1611,7 +1631,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: publicPath + 'entry1-b094b08f0ec931508d19.js',
+            url: publicPath + 'entry1-4e6d0549fb91663b22af.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -1,5 +1,4 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const GenerateAssetPlugin = require('generate-asset-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const expect = require('chai').expect;
 const fse = require('fs-extra');
@@ -9,8 +8,9 @@ const tempy = require('tempy');
 const vm = require('vm');
 const webpack = require('webpack');
 
-const {InjectManifest} = require('../../../packages/workbox-webpack-plugin/src/index');
+const CreateWebpackAssetPlugin = require('../../../infra/testing/create-webpack-asset-plugin');
 const validateServiceWorkerRuntime = require('../../../infra/testing/validator/service-worker-runtime');
+const {InjectManifest} = require('../../../packages/workbox-webpack-plugin/src/index');
 const {getModuleUrl} = require('../../../packages/workbox-build/src/lib/cdn-utils');
 
 describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
@@ -140,9 +140,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Ensure only one precache-manifest is present on re-compile`, function() {
     it(`should only have one reference to precache-manifest file in 'importScripts'`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.b6f6b1b151c4f027ee1e1aa3061eeaf7.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.fae694daec42acd5171efe1585b77a25.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -192,9 +193,9 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-17c2a1b5c94290899539.js',
+            url: 'entry2-3a66319e95a85614711d.js',
           }, {
-            url: 'entry1-d7f4e7088b64a9896b23.js',
+            url: 'entry1-bc538ab2d7590b7b8664.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -213,9 +214,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] multiple chunks`, function() {
     it(`should work when called with just swSrc`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.b6f6b1b151c4f027ee1e1aa3061eeaf7.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.fae694daec42acd5171efe1585b77a25.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -259,9 +261,9 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-17c2a1b5c94290899539.js',
+            url: 'entry2-3a66319e95a85614711d.js',
           }, {
-            url: 'entry1-d7f4e7088b64a9896b23.js',
+            url: 'entry1-bc538ab2d7590b7b8664.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -273,10 +275,11 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should support setting importWorkboxFrom to a chunk's name`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.77e720b5deee9dafb4df79d5e4c2f2e0.js';
-      const workboxEntryName = 'workboxEntry-51dca2278b60b4b86e8c.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.4c6fd1686fa3f8695bebd46f4b7b3f3f.js';
+      const workboxEntryName = 'workboxEntry-dadac8f5b128154abc67.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -322,9 +325,9 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-0c3c00f8cd0d3271089c.js',
+            url: 'entry2-92dccaedfeb393526fc6.js',
           }, {
-            url: 'entry1-3865b3908d1988da1758.js',
+            url: 'entry1-e4a456eedf0d4e07ee29.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -336,9 +339,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should support setting importWorkboxFrom to 'local'`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.b6f6b1b151c4f027ee1e1aa3061eeaf7.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.fae694daec42acd5171efe1585b77a25.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -400,9 +404,9 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-17c2a1b5c94290899539.js',
+            url: 'entry2-3a66319e95a85614711d.js',
           }, {
-            url: 'entry1-d7f4e7088b64a9896b23.js',
+            url: 'entry1-bc538ab2d7590b7b8664.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -414,10 +418,11 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should support setting importWorkboxFrom to 'local', and respect output.publicPath`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.1f4b80f3bf4cbdfc323cd47d280a9561.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.a56451d8617f6ffe4a7d72fe57b8d2d8.js';
       const outputDir = tempy.directory();
       const publicPath = 'https://testing.path/';
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -480,9 +485,9 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: publicPath + 'entry2-a73dfbc0c0f27e33c997.js',
+            url: publicPath + 'entry2-1eff2377dba2c92e5056.js',
           }, {
-            url: publicPath + 'entry1-72d0a5a3a44942369363.js',
+            url: publicPath + 'entry1-a400dfb12a1e0f9a71cb.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -494,13 +499,14 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should respect output.publicPath if importWorkboxFrom is set to a Webpack chunk name`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.c8c87b7b2af4d79242a895050ff70e48.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.2de865c7ea9d93d83af195f69f0fe74f.js';
       const publicPath = 'https://testing.path/';
       const workboxChunkName = 'workbox-sw-chunk-name';
 
       const outputDir = tempy.directory();
 
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -534,7 +540,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[
               publicPath + FILE_MANIFEST_NAME,
-              `${publicPath}${workboxChunkName}-a045703b655e4960bca0.js`,
+              `${publicPath}${workboxChunkName}-5288405087d75df53376.js`,
             ]],
             suppressWarnings: [[]],
             precacheAndRoute: [[[], {}]],
@@ -547,9 +553,9 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: publicPath + 'entry2-61ee477935384006abe1.js',
+            url: publicPath + 'entry2-a7d75619e725e2e82bec.js',
           }, {
-            url: publicPath + 'entry1-2970939c7fd9c82eaf46.js',
+            url: publicPath + 'entry1-e51a8e38171f088483ce.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -561,9 +567,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should honor the 'chunks' whitelist config`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.77e720b5deee9dafb4df79d5e4c2f2e0.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.4c6fd1686fa3f8695bebd46f4b7b3f3f.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -609,9 +616,9 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-0c3c00f8cd0d3271089c.js',
+            url: 'entry2-92dccaedfeb393526fc6.js',
           }, {
-            url: 'entry1-3865b3908d1988da1758.js',
+            url: 'entry1-e4a456eedf0d4e07ee29.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -623,9 +630,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should honor the 'excludeChunks' blacklist config`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.77e720b5deee9dafb4df79d5e4c2f2e0.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.4c6fd1686fa3f8695bebd46f4b7b3f3f.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -671,9 +679,9 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry2-0c3c00f8cd0d3271089c.js',
+            url: 'entry2-92dccaedfeb393526fc6.js',
           }, {
-            url: 'entry1-3865b3908d1988da1758.js',
+            url: 'entry1-e4a456eedf0d4e07ee29.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -685,9 +693,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should honor setting both the 'chunks' and 'excludeChunks', with the blacklist taking precedence`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.8b017100ab9e5377c63145f3034bae3f.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.d0932095ef143b3b996b149416acecb3.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -734,7 +743,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry1-3865b3908d1988da1758.js',
+            url: 'entry1-e4a456eedf0d4e07ee29.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -748,9 +757,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] html-webpack-plugin and a single chunk`, function() {
     it(`should work when called with just swSrc`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.3025354ee867087a8f380b661c2ed62f.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.dfbc1d9214ba28c6bcc481cfe5817ac5.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -795,12 +805,12 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            revision: 'df7649048255d9f47e0f80cbe11cd4ef',
+            revision: 'f1e52b85db9f9855556de4af08872738',
             url: 'index.html',
           }, {
-            url: 'entry2-17c2a1b5c94290899539.js',
+            url: 'entry2-3a66319e95a85614711d.js',
           }, {
-            url: 'entry1-d7f4e7088b64a9896b23.js',
+            url: 'entry1-bc538ab2d7590b7b8664.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -812,12 +822,13 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should honor a custom swDest and publicPath`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.06492856a9a2f9af91f132aa316c5572.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.5221dd4eca2b6cdd8e519edf834aceb7.js';
       const SW_DEST = 'custom-sw-dest.js';
       const publicPath = '/testing/';
 
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -864,12 +875,12 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            revision: '35473c67acf1c2d0caffebd0cc31cbb5',
+            revision: '0962c1d73795b14153bfd4e3a09d15fb',
             url: publicPath + 'index.html',
           }, {
-            url: publicPath + 'entry2-9700b0cb6282320b628f.js',
+            url: publicPath + 'entry2-7d5e55c5530155394735.js',
           }, {
-            url: publicPath + 'entry1-ebb39acd9a53861a2a43.js',
+            url: publicPath + 'entry1-771d72ade2e26e13b31b.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -881,9 +892,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should support passing options through to workbox-build.getManifest() to precache additional files`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.06576212e1040579b494a559d9e82d3c.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.f02f2a15a790656dae498a170b246a05.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           entry2: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -933,12 +945,12 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            revision: 'df7649048255d9f47e0f80cbe11cd4ef',
+            revision: 'f1e52b85db9f9855556de4af08872738',
             url: 'index.html',
           }, {
-            url: 'entry2-17c2a1b5c94290899539.js',
+            url: 'entry2-3a66319e95a85614711d.js',
           }, {
-            url: 'entry1-d7f4e7088b64a9896b23.js',
+            url: 'entry1-bc538ab2d7590b7b8664.js',
           }, {
             revision: '5cfecbd12c9fa32f03eafe27e2ac798e',
             url: '/shell',
@@ -955,9 +967,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] copy-webpack-plugin and a single chunk`, function() {
     it(`should work when called with just swSrc`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.f7220180c1f86202aa3bd9ed1ef02890.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.652bcd9d1eb54020ea188382f5baae93.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
           filename: WEBPACK_ENTRY_FILENAME,
@@ -1002,7 +1015,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            revision: '8e8e9f093f036bd18dfa',
+            revision: '1b6ab2dabb8f64fd207b',
             url: 'webpackEntry.js',
           }, {
             revision: '884f6853a4fc655e4c2dc0c0f27a227c',
@@ -1037,12 +1050,11 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
   });
 
   describe(`[workbox-webpack-plugin] Filtering via test/include/exclude`, function() {
-    const TEST_ASSET_CB = (compilation, callback) => callback(null, 'test');
-
     it(`should exclude .map and manifest.js(on) files by default`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.43591bdf46c7ac47eb8d7b2bcd41f13e.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.5cb9aa420ab5dcfaddb13269cf52baad.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
           filename: WEBPACK_ENTRY_FILENAME,
@@ -1050,14 +1062,9 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         },
         devtool: 'source-map',
         plugins: [
-          new GenerateAssetPlugin({
-            filename: 'manifest.js',
-            fn: TEST_ASSET_CB,
-          }),
-          new GenerateAssetPlugin({
-            filename: 'manifest.json',
-            fn: TEST_ASSET_CB,
-          }),
+          new CreateWebpackAssetPlugin('manifest.js'),
+          new CreateWebpackAssetPlugin('manifest.json'),
+          new CreateWebpackAssetPlugin('not-ignored.js'),
           new InjectManifest({
             swSrc: SW_SRC,
           }),
@@ -1092,8 +1099,11 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            revision: '8e8e9f093f036bd18dfa',
+            revision: '1b6ab2dabb8f64fd207b',
             url: 'webpackEntry.js',
+          }, {
+            revision: 'aef75af28f6de0771a8d6bae84d9e71d',
+            url: 'not-ignored.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -1105,9 +1115,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should allow developers to override the default exclude filter`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.b87ef85173e527290f94979b09e72d12.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.0eb25ac79cff069c5cfe5475a6328248.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
           filename: WEBPACK_ENTRY_FILENAME,
@@ -1150,10 +1161,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            revision: '8e8e9f093f036bd18dfa',
+            revision: '1b6ab2dabb8f64fd207b',
             url: 'webpackEntry.js.map',
           }, {
-            revision: '8e8e9f093f036bd18dfa',
+            revision: '1b6ab2dabb8f64fd207b',
             url: 'webpackEntry.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
@@ -1169,6 +1180,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       const FILE_MANIFEST_NAME = 'precache-manifest.1242f9e007897f035a52e56690ff17a6.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
           filename: WEBPACK_ENTRY_FILENAME,
@@ -1237,6 +1249,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       const FILE_MANIFEST_NAME = 'precache-manifest.83df65831eb442f8ad5fbeb8edecc558.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
           filename: WEBPACK_ENTRY_FILENAME,
@@ -1302,9 +1315,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] swDest variations`, function() {
     it(`should work when swDest is an absolute path`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.43591bdf46c7ac47eb8d7b2bcd41f13e.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.a795adfa9739556c5b0399d7e7db5112.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
           filename: WEBPACK_ENTRY_FILENAME,
@@ -1347,7 +1361,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            revision: '8e8e9f093f036bd18dfa',
+            revision: '1b6ab2dabb8f64fd207b',
             url: 'webpackEntry.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
@@ -1362,9 +1376,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Reporting webpack warnings`, function() {
     it(`should add warnings from the workbox-build methods to compilation.warnings`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.1e68970ed92c9878c08bead8696e8376.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.1d2a1a3368fde54e6c953eb8ff3dca82.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -1424,7 +1439,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             revision: '544658ab25ee8762dc241e8b1c5ed96d',
             url: 'page-1.html',
           }, {
-            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+            url: 'entry1-bfe67dbdc61e895ab6cb.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -1436,7 +1451,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should add a warning when various glob-related options are set`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.8a33bfca407a014b4ac8aef433c23386.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.a83bd3e7b900d2e2aa3e918387c9043e.js';
       const outputDir = tempy.directory();
       const globOptionsToWarnAbout = [
         'globDirectory',
@@ -1446,6 +1461,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         'globStrict',
       ];
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -1506,7 +1522,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
             url: 'index.html',
           }, {
-            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+            url: 'entry1-bfe67dbdc61e895ab6cb.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -1518,7 +1534,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should add a warning when certain options are used, but globPatterns isn't set`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.eca1a14406dbeefe3925758a8999609a.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.12f50ce2c09ebfbcf80a7052010d2aa5.js';
       const outputDir = tempy.directory();
       const optionsToWarnAboutWhenGlobPatternsIsNotSet = [
         'dontCacheBustUrlsMatching',
@@ -1527,6 +1543,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         'modifyUrlPrefix',
       ];
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -1577,7 +1594,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+            url: 'entry1-bfe67dbdc61e895ab6cb.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -1591,9 +1608,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Customizing output paths and names`, function() {
     it(`should allow overriding precacheManifestFilename`, function(done) {
-      const FILE_MANIFEST_NAME = 'custom-name.eca1a14406dbeefe3925758a8999609a.js';
+      const FILE_MANIFEST_NAME = 'custom-name.12f50ce2c09ebfbcf80a7052010d2aa5.js';
       const outputDir = tempy.directory();
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -1639,7 +1657,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+            url: 'entry1-bfe67dbdc61e895ab6cb.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -1651,10 +1669,11 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should allow setting importsDirectory`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.eca1a14406dbeefe3925758a8999609a.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.12f50ce2c09ebfbcf80a7052010d2aa5.js';
       const outputDir = tempy.directory();
       const importsDirectory = path.join('one', 'two');
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -1701,7 +1720,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: 'entry1-89d6aad5d80ebcfb2e8a.js',
+            url: 'entry1-bfe67dbdc61e895ab6cb.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 
@@ -1713,11 +1732,12 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should allow setting importsDirectory, publicPath, and importWorkboxFrom: 'local'`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.d9302c9dad14c032f73ccb9cb3458c49.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.41207b4b29b325602ab0d53ebf082054.js';
       const outputDir = tempy.directory();
       const importsDirectory = path.join('one', 'two');
       const publicPath = '/testing/';
       const config = {
+        mode: 'production',
         entry: {
           entry1: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
@@ -1783,7 +1803,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           vm.runInNewContext(manifestFileContents, context);
 
           const expectedEntries = [{
-            url: publicPath + 'entry1-b094b08f0ec931508d19.js',
+            url: publicPath + 'entry1-4e6d0549fb91663b22af.js',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 


### PR DESCRIPTION
R: @philipwalton 

Fixes #1281 

Given that there doesn't seem to be a clean way to run our tests under both webpack v3 & v4, and given that webpack v4 has all the momentum behind it, it seems like just switching over to run our test suite against v4 makes the most sense.

This PR does not change our compatibility story with webpack v3—it's just changes to our tests.