### PR TITLE
New workbox.Plugin.deleteCacheAndMetadata() method

### DIFF
--- a/gulp-tasks/test-integration.js
+++ b/gulp-tasks/test-integration.js
@@ -128,9 +128,7 @@ gulp.task('test-integration', async () => {
           }
           break;
         case 'safari':
-          if (localBrowser.getReleaseName() === 'beta') {
-            await runIntegrationForBrowser(localBrowser);
-          }
+          await runIntegrationForBrowser(localBrowser);
           break;
         default:
           logHelper.warn(oneLine`

--- a/packages/workbox-cache-expiration/CacheExpiration.mjs
+++ b/packages/workbox-cache-expiration/CacheExpiration.mjs
@@ -268,8 +268,6 @@ class CacheExpiration {
   /**
    * Removes the IndexedDB object store used to keep track of cache expiration
    * metadata.
-   *
-   * @return {Promise<void>}
    */
   async delete() {
     // Make sure we don't attempt another rerun if we're called in the middle of

--- a/packages/workbox-cache-expiration/CacheExpiration.mjs
+++ b/packages/workbox-cache-expiration/CacheExpiration.mjs
@@ -264,6 +264,19 @@ class CacheExpiration {
     const expireOlderThan = Date.now() - (this._maxAgeSeconds * 1000);
     return (timestamp < expireOlderThan);
   }
+
+  /**
+   * Removes the IndexedDB object store used to keep track of cache expiration
+   * metadata.
+   *
+   * @return {Promise<void>}
+   */
+  async delete() {
+    // Make sure we don't attempt another rerun if we're called in the middle of
+    // a cache expiration.
+    this._rerunRequested = false;
+    await this._timestampModel.delete();
+  }
 }
 
 export {CacheExpiration};

--- a/packages/workbox-cache-expiration/Plugin.mjs
+++ b/packages/workbox-cache-expiration/Plugin.mjs
@@ -216,6 +216,37 @@ class Plugin {
     await cacheExpiration.updateTimestamp(request.url);
     await cacheExpiration.expireEntries();
   }
+
+
+  /**
+   * This is a helper method that performs two operations:
+   *
+   * - Deletes *all* the underlying Cache instances associated with this plugin
+   * instance, by calling caches.delete() on you behalf.
+   * - Deletes the metadata from IndexedDB used to keep track of expiration
+   * details for each Cache instance.
+   *
+   * When using cache expiration, calling this method is preferable to calling
+   * `caches.delete()` directly, since this will ensure that the IndexedDB
+   * metadata is also cleanly removed and open IndexedDB instances are deleted.
+   *
+   * Note that if you're *not* using cache expiration for a given cache, calling
+   * `caches.delete()` and passing in the cache's name should be sufficient.
+   * There is no Workbox-specific method needed for cleanup in that case.
+   *
+   * @return {Promise} A promise which resolves when cleanup is complete.
+   */
+  async deleteCacheAndMetadata() {
+    // Do this one at at a time instance of all at once via `Promise.all()` to
+    // reduce the chance of inconsistency if a promise rejects.
+    for (const [cacheName, cacheExpiration] of this._cacheExpirations) {
+      await caches.delete(cacheName);
+      await cacheExpiration.delete();
+    }
+
+    // Reset this._cacheExpirations to its initial state.
+    this._cacheExpirations = new Map();
+  }
 }
 
 export {Plugin};

--- a/packages/workbox-cache-expiration/Plugin.mjs
+++ b/packages/workbox-cache-expiration/Plugin.mjs
@@ -233,8 +233,6 @@ class Plugin {
    * Note that if you're *not* using cache expiration for a given cache, calling
    * `caches.delete()` and passing in the cache's name should be sufficient.
    * There is no Workbox-specific method needed for cleanup in that case.
-   *
-   * @return {Promise} A promise which resolves when cleanup is complete.
    */
   async deleteCacheAndMetadata() {
     // Do this one at at a time instance of all at once via `Promise.all()` to

--- a/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
+++ b/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
@@ -114,8 +114,6 @@ class CacheTimestampsModel {
 
   /**
    * Removes the underlying IndexedDB object store entirely.
-   *
-   * @return {Promise<void>} A promise which resolves once deletion is complete.
    */
   async delete() {
     await this._db.deleteDatabase();

--- a/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
+++ b/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
@@ -111,6 +111,16 @@ class CacheTimestampsModel {
   async deleteUrl(url) {
     await this._db.delete(this._storeName, new URL(url, location).href);
   }
+
+  /**
+   * Removes the underlying IndexedDB object store entirely.
+   *
+   * @return {Promise<void>} A promise which resolves once deletion is complete.
+   */
+  async delete() {
+    await this._db.deleteDatabase();
+    this._db = null;
+  }
 }
 
 export default CacheTimestampsModel;

--- a/packages/workbox-core/_private/DBWrapper.mjs
+++ b/packages/workbox-core/_private/DBWrapper.mjs
@@ -144,6 +144,23 @@ class DBWrapper {
   }
 
   /**
+   * Deletes the underlying database, ensuring that any open connections are
+   * closed first.
+   *
+   * @private
+   */
+  async deleteDatabase() {
+    this.close();
+    this._db = null;
+    await new Promise((resolve, reject) => {
+      const request = indexedDB.deleteDatabase(this._name);
+      request.onerror = (evt) => reject(evt.target.error);
+      request.onblocked = () => reject(new Error('Deletion was blocked.'));
+      request.onsuccess = () => resolve();
+    });
+  }
+
+  /**
    * Delegates to the native `getAll()` or polyfills it via the `find()`
    * method in older browsers.
    *

--- a/test/workbox-cache-expiration/static/expiration-plugin/index.html
+++ b/test/workbox-cache-expiration/static/expiration-plugin/index.html
@@ -2,8 +2,7 @@
   <head>
   </head>
   <body>
-    <p>You need to manually register sw.js</p>
-    <script src="/node_modules/sinon/pkg/sinon.js"></script>
+    <p>You need to manually register the service worker.</p>
     <script>
       window.__test = {};
     </script>

--- a/test/workbox-cache-expiration/static/expiration-plugin/sw-deletion.js
+++ b/test/workbox-cache-expiration/static/expiration-plugin/sw-deletion.js
@@ -1,0 +1,58 @@
+importScripts('/__WORKBOX/buildFile/workbox-core');
+importScripts('/__WORKBOX/buildFile/workbox-cache-expiration');
+importScripts('/__WORKBOX/buildFile/workbox-routing');
+importScripts('/__WORKBOX/buildFile/workbox-strategies');
+
+const expirationPlugin = new workbox.expiration.Plugin({
+  maxEntries: 1,
+});
+
+const cacheName = 'expiration-plugin-deletion';
+
+workbox.routing.registerRoute(
+  /.*.txt/,
+  workbox.strategies.cacheFirst({
+    cacheName,
+    plugins: [
+      expirationPlugin,
+    ],
+  })
+);
+
+const doesDbExist = () => {
+  return new Promise((resolve) => {
+    const result = indexedDB.open(cacheName);
+    result.onupgradeneeded = (event) => {
+      event.target.transaction.abort();
+      event.target.result.close();
+      resolve(false);
+    };
+    result.onsuccess = (event) => {
+      event.target.result.close();
+      resolve(true);
+    };
+  });
+};
+
+self.addEventListener('message', async (event) => {
+  let message;
+
+  if (event.data === 'delete') {
+    try {
+      await expirationPlugin.deleteCacheAndMetadata();
+    } catch (error) {
+      message = error.message;
+    }
+  } else if (event.data === 'doesDbExist') {
+    message = await doesDbExist(cacheName);
+  }
+
+  // Send all open clients a message indicating that deletion is done.
+  const clients = await self.clients.matchAll();
+  for (const client of clients) {
+    client.postMessage(message);
+  }
+});
+
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());


### PR DESCRIPTION
R: @philipwalton
CC: @josephliccini 

Fixes #1365

It took a while to get a hang of what needed to be explicitly `close()`d in order to avoid `blocked` errors, but I think this implementation works.

I envision making use of this as part of a future PR that will start introducing some opt-in automatic cleanup logic to handle, e.g., `QUOTA_EXCEEDED` errors. For the time being, though, this is just a standalone method that won't be called anywhere automatically.