### PR TITLE
Opt-in method for purging (some) caches upon a QuotaExceededError

### DIFF
--- a/packages/workbox-build/src/entry-points/options/common-generate-schema.js
+++ b/packages/workbox-build/src/entry-points/options/common-generate-schema.js
@@ -55,6 +55,7 @@ module.exports = baseSchema.keys({
       expiration: joi.object().keys({
         maxEntries: joi.number().min(1),
         maxAgeSeconds: joi.number().min(1),
+        purgeOnQuotaError: joi.boolean().default(defaults.purgeOnQuotaError),
       }).or('maxEntries', 'maxAgeSeconds'),
       networkTimeoutSeconds: joi.number().min(1),
       plugins: joi.array().items(joi.object()),

--- a/packages/workbox-build/src/entry-points/options/defaults.js
+++ b/packages/workbox-build/src/entry-points/options/defaults.js
@@ -15,14 +15,15 @@
 */
 
 module.exports = {
+  clientsClaim: false,
   globFollow: true,
   globIgnores: ['**/node_modules/**/*'],
   globPatterns: ['**/*.{js,css,html}'],
   globStrict: true,
-  maximumFileSizeToCacheInBytes: 2 * 1024 * 1024,
-  clientsClaim: false,
-  navigateFallback: undefined,
-  skipWaiting: false,
   importWorkboxFrom: 'cdn',
   injectionPointRegexp: /(\.precacheAndRoute\()\s*\[\s*\]\s*(\)|,)/,
+  maximumFileSizeToCacheInBytes: 2 * 1024 * 1024,
+  navigateFallback: undefined,
+  purgeOnQuotaError: false,
+  skipWaiting: false,
 };

--- a/packages/workbox-cache-expiration/CacheExpiration.mjs
+++ b/packages/workbox-cache-expiration/CacheExpiration.mjs
@@ -14,10 +14,11 @@
   limitations under the License.
 */
 
+import CacheTimestampsModel from './models/CacheTimestampsModel.mjs';
 import {WorkboxError} from 'workbox-core/_private/WorkboxError.mjs';
 import {assert} from 'workbox-core/_private/assert.mjs';
 import {logger} from 'workbox-core/_private/logger.mjs';
-import CacheTimestampsModel from './models/CacheTimestampsModel.mjs';
+
 import './_version.mjs';
 
 /**

--- a/packages/workbox-cache-expiration/Plugin.mjs
+++ b/packages/workbox-cache-expiration/Plugin.mjs
@@ -15,6 +15,7 @@ import {CacheExpiration} from './CacheExpiration.mjs';
 import {WorkboxError} from 'workbox-core/_private/WorkboxError.mjs';
 import {assert} from 'workbox-core/_private/assert.mjs';
 import {cacheNames} from 'workbox-core/_private/cacheNames.mjs';
+import {registerCallback} from 'workbox-core/_private/quota.mjs';
 
 import './_version.mjs';
 
@@ -43,6 +44,8 @@ class Plugin {
    * Entries used the least will be removed as the maximum is reached.
    * @param {number} [config.maxAgeSeconds] The maximum age of an entry before
    * it's treated as stale and removed.
+   * @param {boolean} [config.purgeOnQuotaError] Whether to opt this cache in to
+   * automatic deletion if the available storage quota has been exceeded.
    */
   constructor(config = {}) {
     if (process.env.NODE_ENV !== 'production') {
@@ -76,6 +79,10 @@ class Plugin {
     this._config = config;
     this._maxAgeSeconds = config.maxAgeSeconds;
     this._cacheExpirations = new Map();
+
+    if (config.purgeOnQuotaError) {
+      registerCallback(() => this.deleteCacheAndMetadata());
+    }
   }
 
   /**
@@ -235,7 +242,7 @@ class Plugin {
    * There is no Workbox-specific method needed for cleanup in that case.
    */
   async deleteCacheAndMetadata() {
-    // Do this one at at a time instance of all at once via `Promise.all()` to
+    // Do this one at at a time instead of all at once via `Promise.all()` to
     // reduce the chance of inconsistency if a promise rejects.
     for (const [cacheName, cacheExpiration] of this._cacheExpirations) {
       await caches.delete(cacheName);

--- a/packages/workbox-cache-expiration/Plugin.mjs
+++ b/packages/workbox-cache-expiration/Plugin.mjs
@@ -242,7 +242,7 @@ class Plugin {
    * There is no Workbox-specific method needed for cleanup in that case.
    */
   async deleteCacheAndMetadata() {
-    // Do this one at at a time instead of all at once via `Promise.all()` to
+    // Do this one at a time instead of all at once via `Promise.all()` to
     // reduce the chance of inconsistency if a promise rejects.
     for (const [cacheName, cacheExpiration] of this._cacheExpirations) {
       await caches.delete(cacheName);

--- a/packages/workbox-core/_private.mjs
+++ b/packages/workbox-core/_private.mjs
@@ -23,7 +23,9 @@ import {cacheWrapper} from './_private/cacheWrapper.mjs';
 import {fetchWrapper} from './_private/fetchWrapper.mjs';
 import {getFriendlyURL} from './_private/getFriendlyURL.mjs';
 import {logger} from './_private/logger.mjs';
-import {registerCallback} from './_private/quota.mjs';
+import {
+  registerCallback as registerQuotaErrorCallback,
+} from './_private/quota.mjs';
 
 import './_version.mjs';
 
@@ -36,5 +38,5 @@ export {
   fetchWrapper,
   getFriendlyURL,
   logger,
-  registerCallback,
+  registerQuotaErrorCallback,
 };

--- a/packages/workbox-core/_private.mjs
+++ b/packages/workbox-core/_private.mjs
@@ -15,23 +15,26 @@
 */
 
 // We either expose defaults or we expose every named export.
+import {DBWrapper} from './_private/DBWrapper.mjs';
+import {WorkboxError} from './_private/WorkboxError.mjs';
 import {assert} from './_private/assert.mjs';
+import {cacheNames} from './_private/cacheNames.mjs';
 import {cacheWrapper} from './_private/cacheWrapper.mjs';
 import {fetchWrapper} from './_private/fetchWrapper.mjs';
-import {DBWrapper} from './_private/DBWrapper.mjs';
-import {logger} from './_private/logger.mjs';
-import {WorkboxError} from './_private/WorkboxError.mjs';
-import {cacheNames} from './_private/cacheNames.mjs';
 import {getFriendlyURL} from './_private/getFriendlyURL.mjs';
+import {logger} from './_private/logger.mjs';
+import {registerCallback} from './_private/quota.mjs';
+
 import './_version.mjs';
 
 export {
-  logger,
+  DBWrapper,
+  WorkboxError,
   assert,
   cacheNames,
   cacheWrapper,
   fetchWrapper,
-  WorkboxError,
-  DBWrapper,
   getFriendlyURL,
+  logger,
+  registerCallback,
 };

--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -14,12 +14,14 @@
   limitations under the License.
 */
 
-import {logger} from './logger.mjs';
-import {assert} from './assert.mjs';
-import {WorkboxError} from './WorkboxError.mjs';
-import {getFriendlyURL} from '../_private/getFriendlyURL.mjs';
 import pluginEvents from '../models/pluginEvents.mjs';
 import pluginUtils from '../utils/pluginUtils.mjs';
+import {WorkboxError} from './WorkboxError.mjs';
+import {assert} from './assert.mjs';
+import {executeCallbacks} from './quota.mjs';
+import {getFriendlyURL} from './getFriendlyURL.mjs';
+import {logger} from './logger.mjs';
+
 import '../_version.mjs';
 
 /**
@@ -38,7 +40,7 @@ import '../_version.mjs';
 const putWrapper = async (cacheName, request, response, plugins = []) => {
   if (!response) {
     if (process.env.NODE_ENV !== 'production') {
-      logger.error(`Cannot cache non-existant response for ` +
+      logger.error(`Cannot cache non-existent response for ` +
         `'${getFriendlyURL(request.url)}'.`);
     }
 
@@ -80,9 +82,15 @@ const putWrapper = async (cacheName, request, response, plugins = []) => {
       `${getFriendlyURL(request.url)}.`);
   }
 
-  // Regardless of whether or not we'll end up invoking
-  // cacheDidUpdate, wait until the cache is updated.
-  await cache.put(request, responseToCache);
+  try {
+    await cache.put(request, responseToCache);
+  } catch (error) {
+    // See https://developer.mozilla.org/en-US/docs/Web/API/DOMException#exception-QuotaExceededError
+    if (error.name === 'QuotaExceededError') {
+      await executeCallbacks();
+    }
+    throw error;
+  }
 
   for (let plugin of updatePlugins) {
     await plugin[pluginEvents.CACHE_DID_UPDATE].call(plugin, {

--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -18,7 +18,7 @@ import pluginEvents from '../models/pluginEvents.mjs';
 import pluginUtils from '../utils/pluginUtils.mjs';
 import {WorkboxError} from './WorkboxError.mjs';
 import {assert} from './assert.mjs';
-import {executeCallbacks} from './quota.mjs';
+import {executeCallbacks as executeQuotaErrorCallbacks} from './quota.mjs';
 import {getFriendlyURL} from './getFriendlyURL.mjs';
 import {logger} from './logger.mjs';
 
@@ -87,7 +87,7 @@ const putWrapper = async (cacheName, request, response, plugins = []) => {
   } catch (error) {
     // See https://developer.mozilla.org/en-US/docs/Web/API/DOMException#exception-QuotaExceededError
     if (error.name === 'QuotaExceededError') {
-      await executeCallbacks();
+      await executeQuotaErrorCallbacks();
     }
     throw error;
   }

--- a/packages/workbox-core/_private/quota.mjs
+++ b/packages/workbox-core/_private/quota.mjs
@@ -25,7 +25,6 @@ const callbacks = new Set();
  * a quota error.
  *
  * @param {Function} callback
- *
  * @memberof workbox.core
  */
 function registerCallback(callback) {

--- a/packages/workbox-core/_private/quota.mjs
+++ b/packages/workbox-core/_private/quota.mjs
@@ -1,0 +1,74 @@
+/*
+ Copyright 2018 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import {logger} from './logger.mjs';
+import {assert} from './assert.mjs';
+
+import '../_version.mjs';
+
+const callbacks = new Set();
+
+/**
+ * Adds a function to the set of callbacks that will be executed when there's
+ * a quota error.
+ *
+ * @param {Function} callback
+ *
+ * @memberof workbox.core
+ */
+function registerCallback(callback) {
+  if (process.env.NODE_ENV !== 'production') {
+    assert.isType(callback, 'function', {
+      moduleName: 'workbox-core',
+      funcName: 'register',
+      paramName: 'callback',
+    });
+  }
+
+  callbacks.add(callback);
+
+  if (process.env.NODE_ENV !== 'production') {
+    logger.log('Registered a callback to respond to quota errors.', callback);
+  }
+}
+
+/**
+ * Runs all of the callback functions, one at a time sequentially, in the order
+ * in which they were registered.
+ *
+ * @memberof workbox.core
+ * @private
+ */
+async function executeCallbacks() {
+  if (process.env.NODE_ENV !== 'production') {
+    logger.log(`About to run ${callbacks.size} callbacks to clean up caches.`);
+  }
+
+  for (const callback of callbacks) {
+    await callback();
+    if (process.env.NODE_ENV !== 'production') {
+      logger.log(callback, 'is complete.');
+    }
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    logger.log('Finished running callbacks.');
+  }
+}
+
+export {
+  executeCallbacks,
+  registerCallback,
+};

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -219,12 +219,14 @@ class PrecacheController {
     const tempCache = await caches.open(this._getTempCacheName());
 
     const requests = await tempCache.keys();
-    await Promise.all(requests.map(async (request) => {
+    // Process each request/response one at a time, deleting the temporary entry
+    // when done, to help avoid triggering quota errors.
+    for (const request of requests) {
       const response = await tempCache.match(request);
       await cacheWrapper.put(this._cacheName, request,
         response, options.plugins);
       await tempCache.delete(request);
-    }));
+    }
 
     return this._cleanup();
   }

--- a/test/workbox-build/node/entry-points/generate-sw-string.js
+++ b/test/workbox-build/node/entry-points/generate-sw-string.js
@@ -371,6 +371,7 @@ describe(`[workbox-build] entry-points/generate-sw-string.js (End to End)`, func
         expiration: {
           maxEntries: 1,
           maxAgeSeconds: 1,
+          purgeOnQuotaError: false,
         },
         cacheableResponse: {
           headers: {
@@ -410,6 +411,7 @@ describe(`[workbox-build] entry-points/generate-sw-string.js (End to End)`, func
         expiration: {
           maxEntries: 1,
           maxAgeSeconds: 1,
+          purgeOnQuotaError: false,
         },
       };
       const secondRuntimeCachingOptions = {

--- a/test/workbox-build/node/entry-points/generate-sw.js
+++ b/test/workbox-build/node/entry-points/generate-sw.js
@@ -563,6 +563,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
         expiration: {
           maxEntries: 1,
           maxAgeSeconds: 1,
+          purgeOnQuotaError: false,
         },
       };
       const secondRuntimeCachingOptions = {

--- a/test/workbox-cache-expiration/node/test-Plugin.mjs
+++ b/test/workbox-cache-expiration/node/test-Plugin.mjs
@@ -20,6 +20,7 @@ import {devOnly} from '../../../infra/testing/env-it';
 import {Plugin} from '../../../packages/workbox-cache-expiration/Plugin.mjs';
 import {CacheExpiration} from '../../../packages/workbox-cache-expiration/CacheExpiration.mjs';
 import {cacheNames} from '../../../packages/workbox-core/_private/cacheNames.mjs';
+import {executeCallbacks} from '../../../packages/workbox-core/_private/quota.mjs';
 
 describe(`[workbox-cache-expiration] Plugin`, function() {
   const sandbox = sinon.sandbox.create();
@@ -67,6 +68,30 @@ describe(`[workbox-cache-expiration] Plugin`, function() {
         maxEntries: 10,
       });
       expect(plugin._config.maxEntries).to.equal(10);
+    });
+
+    it(`should register a quota error callback when purgeOnQuotaError is true`, async function() {
+      const plugin = new Plugin({
+        maxEntries: 10,
+        purgeOnQuotaError: true,
+      });
+      plugin.deleteCacheAndMetadata = sandbox.stub();
+
+      await executeCallbacks();
+
+      expect(plugin.deleteCacheAndMetadata.calledOnce).to.be.true;
+    });
+
+    it(`should not register a quota error callback when purgeOnQuotaError is false`, async function() {
+      const plugin = new Plugin({
+        maxEntries: 10,
+        purgeOnQuotaError: false,
+      });
+      plugin.deleteCacheAndMetadata = sandbox.stub();
+
+      await executeCallbacks();
+
+      expect(plugin.deleteCacheAndMetadata.called).to.be.false;
     });
   });
 

--- a/test/workbox-cache-expiration/node/test-Plugin.mjs
+++ b/test/workbox-cache-expiration/node/test-Plugin.mjs
@@ -20,7 +20,7 @@ import {devOnly} from '../../../infra/testing/env-it';
 import {Plugin} from '../../../packages/workbox-cache-expiration/Plugin.mjs';
 import {CacheExpiration} from '../../../packages/workbox-cache-expiration/CacheExpiration.mjs';
 import {cacheNames} from '../../../packages/workbox-core/_private/cacheNames.mjs';
-import {executeCallbacks} from '../../../packages/workbox-core/_private/quota.mjs';
+import {executeCallbacks as executeQuotaErrorCallbacks} from '../../../packages/workbox-core/_private/quota.mjs';
 
 describe(`[workbox-cache-expiration] Plugin`, function() {
   const sandbox = sinon.sandbox.create();
@@ -77,7 +77,7 @@ describe(`[workbox-cache-expiration] Plugin`, function() {
       });
       plugin.deleteCacheAndMetadata = sandbox.stub();
 
-      await executeCallbacks();
+      await executeQuotaErrorCallbacks();
 
       expect(plugin.deleteCacheAndMetadata.calledOnce).to.be.true;
     });
@@ -89,7 +89,7 @@ describe(`[workbox-cache-expiration] Plugin`, function() {
       });
       plugin.deleteCacheAndMetadata = sandbox.stub();
 
-      await executeCallbacks();
+      await executeQuotaErrorCallbacks();
 
       expect(plugin.deleteCacheAndMetadata.called).to.be.false;
     });

--- a/test/workbox-core/node/_private/test-checkSWFileCacheHeaders.mjs
+++ b/test/workbox-core/node/_private/test-checkSWFileCacheHeaders.mjs
@@ -5,7 +5,7 @@ import {logger} from '../../../../packages/workbox-core/_private/logger.mjs';
 import {checkSWFileCacheHeaders} from '../../../../packages/workbox-core/_private/checkSWFileCacheHeaders.mjs';
 import {devOnly} from '../../../../infra/testing/env-it';
 
-describe(`workbox-core cacheWrapper`, function() {
+describe(`workbox-core checkSWFileCacheHeaders`, function() {
   let sandbox;
 
   before(function() {

--- a/test/workbox-core/node/_private/test-quota.mjs
+++ b/test/workbox-core/node/_private/test-quota.mjs
@@ -1,0 +1,58 @@
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import expectError from '../../../../infra/testing/expectError';
+import {executeCallbacks, registerCallback} from '../../../../packages/workbox-core/_private/quota.mjs';
+import {devOnly} from '../../../../infra/testing/env-it';
+
+describe(`workbox-core quota`, function() {
+  let sandbox;
+
+  before(function() {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  devOnly.it(`registerCallback() should throw when passed a non-function`, async function() {
+    await expectError(() => registerCallback(null), 'incorrect-type');
+  });
+
+  it('executeCallbacks() should call everything registered with registerCallback()', async function() {
+    const callback1 = sandbox.stub();
+    registerCallback(callback1);
+    const callback2 = sandbox.stub();
+    registerCallback(callback2);
+
+    await executeCallbacks();
+
+    expect(callback1.calledOnce).to.be.true;
+    expect(callback2.calledOnce).to.be.true;
+  });
+
+  it(`registerCallback() shouldn't have any effect if called multiple times with the same callback`, async function() {
+    const callback1 = sandbox.stub();
+    registerCallback(callback1);
+    registerCallback(callback1);
+    registerCallback(callback1);
+
+    await executeCallbacks();
+
+    expect(callback1.calledOnce).to.be.true;
+  });
+
+  it(`executeCallbacks() should call everything registered with registerCallback(), each time it's called`, async function() {
+    const callback1 = sandbox.stub();
+    registerCallback(callback1);
+    const callback2 = sandbox.stub();
+    registerCallback(callback2);
+
+    await executeCallbacks();
+    await executeCallbacks();
+
+    expect(callback1.calledTwice).to.be.true;
+    expect(callback2.calledTwice).to.be.true;
+  });
+});

--- a/test/workbox-core/node/_private/test-quota.mjs
+++ b/test/workbox-core/node/_private/test-quota.mjs
@@ -6,53 +6,56 @@ import {executeCallbacks, registerCallback} from '../../../../packages/workbox-c
 import {devOnly} from '../../../../infra/testing/env-it';
 
 describe(`workbox-core quota`, function() {
-  let sandbox;
-
-  before(function() {
-    sandbox = sinon.sandbox.create();
+  describe(`registerCallback()`, function() {
+    devOnly.it(`should throw when passed a non-function`, async function() {
+      await expectError(() => registerCallback(null), 'incorrect-type');
+    });
   });
 
-  afterEach(function() {
-    sandbox.restore();
-  });
+  describe(`executeCallbacks()`, function() {
+    let sandbox;
 
-  devOnly.it(`registerCallback() should throw when passed a non-function`, async function() {
-    await expectError(() => registerCallback(null), 'incorrect-type');
-  });
+    before(function() {
+      sandbox = sinon.sandbox.create();
+    });
 
-  it('executeCallbacks() should call everything registered with registerCallback()', async function() {
-    const callback1 = sandbox.stub();
-    registerCallback(callback1);
-    const callback2 = sandbox.stub();
-    registerCallback(callback2);
+    afterEach(function() {
+      sandbox.restore();
+    });
+    it('should call everything registered with registerCallback()', async function() {
+      const callback1 = sandbox.stub();
+      registerCallback(callback1);
+      const callback2 = sandbox.stub();
+      registerCallback(callback2);
 
-    await executeCallbacks();
+      await executeCallbacks();
 
-    expect(callback1.calledOnce).to.be.true;
-    expect(callback2.calledOnce).to.be.true;
-  });
+      expect(callback1.calledOnce).to.be.true;
+      expect(callback2.calledOnce).to.be.true;
+    });
 
-  it(`registerCallback() shouldn't have any effect if called multiple times with the same callback`, async function() {
-    const callback1 = sandbox.stub();
-    registerCallback(callback1);
-    registerCallback(callback1);
-    registerCallback(callback1);
+    it(`shouldn't have any effect if called multiple times with the same callback`, async function() {
+      const callback1 = sandbox.stub();
+      registerCallback(callback1);
+      registerCallback(callback1);
+      registerCallback(callback1);
 
-    await executeCallbacks();
+      await executeCallbacks();
 
-    expect(callback1.calledOnce).to.be.true;
-  });
+      expect(callback1.calledOnce).to.be.true;
+    });
 
-  it(`executeCallbacks() should call everything registered with registerCallback(), each time it's called`, async function() {
-    const callback1 = sandbox.stub();
-    registerCallback(callback1);
-    const callback2 = sandbox.stub();
-    registerCallback(callback2);
+    it(`should call everything registered with registerCallback(), each time it's called`, async function() {
+      const callback1 = sandbox.stub();
+      registerCallback(callback1);
+      const callback2 = sandbox.stub();
+      registerCallback(callback2);
 
-    await executeCallbacks();
-    await executeCallbacks();
+      await executeCallbacks();
+      await executeCallbacks();
 
-    expect(callback1.calledTwice).to.be.true;
-    expect(callback2.calledTwice).to.be.true;
+      expect(callback1.calledTwice).to.be.true;
+      expect(callback2.calledTwice).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
R: @philipwalton
CC: @raejin @Enalmada @josephliccini

Fixes #1308

There are two changes in this PR:

- There's a check in `workbox-core`'s `cacheWrapper.put()` (which is used "under the hood" throughout Workbox) method to detect when the underlying `cache.put()` fails due to a `QuotaExceededError`. When that happens, one or more previously registered callback functions will automatically be called, and given a chance to free up storage. There is (currently) no attempt made to retry the failed `cache.put()` automatically after the cleanup completes, and the `QuotaExceededError` will be re-thrown and bubble-up to the method that called `cacheWrapper.put()` originally.

- There's a new `purgeOnQuotaError` option added to the `workbox.expiration.Plugin` constructor. It defaults to `false`. When `true`, it will automatically register a quota error callback that will delete the **entire** cache (and IndexedDB) data that the plugin is responsible for. (This is based on #1500.)

Nothing should change by default, but developers who want to opt-in to trying this automatic deletion of caches should make sure that they're using `workbox.expiration.Plugin` for a given strategy, and set `purgeOnQuotaError: true` alongside their `maxEntries` and/or `maxAgeSeconds` configuration when constructing the plugin.

At some point in the future, we might:

- Automatically retry the failed `cache.put()` operation after all the callbacks are complete.
- Default to `purgeOnQuotaError: true` inside of `workbox.expiration.Plugin`.
- Add in some special logic inside `workbox.precaching` to handle quota errors in a different way.

In the meantime, I'd love to start getting some feedback from developers who frequently encounter quota issues with their real-world applications, and figure out how effective opting-in to this new behavior is.

It will have the most significant effect on developers whose runtime caches contribute the largest amounts towards their quota usage (perhaps because they're [caching opaque responses](https://stackoverflow.com/questions/39109789/what-limitations-apply-to-opaque-responses)). If you're precaching a massive amount of data, but not runtime caching much, this PR is not likely to help.