### PR TITLE
Fix CacheExpiration / IndexedDB OpenCursor for Edge

### DIFF
--- a/packages/workbox-core/_private/DBWrapper.mjs
+++ b/packages/workbox-core/_private/DBWrapper.mjs
@@ -203,7 +203,12 @@ class DBWrapper {
       const target = opts.index ? store.index(opts.index) : store;
       const results = [];
 
-      target.openCursor(opts.query, opts.direction).onsuccess = (evt) => {
+      // Passing `undefined` arguments to Edge's `openCursor(...)` causes
+      // 'DOMException: DataError'
+      // Details in issue: https://github.com/GoogleChrome/workbox/issues/1509
+      const query = opts.query || null;
+      const direction = opts.direction || 'next';
+      target.openCursor(query, direction).onsuccess = (evt) => {
         const cursor = evt.target.result;
         if (cursor) {
           const {primaryKey, key, value} = cursor;


### PR DESCRIPTION
**Prior to filing a PR, please:**
- [open an issue](https://github.com/GoogleChrome/workbox/issues/new) to discuss your proposed change.
- ensure that `gulp lint test` passes locally.

R: @jeffposnick @philipwalton

Fixes #1509

Edge Browser does not support `undefined` arguments being passed into `openCursor(...)`

I handle each case for the arguments to `openCursor(...)`

See https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/openCursor for more information on the API itself.

This will fix the CacheExpiration logic in Edge Browsers that depend on `openCursor(...)` in the expiration entry lookup process.
