### PR TITLE
Properly set Cache-Control on CDN hosting

### DIFF
--- a/gulp-tasks/utils/cdn-helper.js
+++ b/gulp-tasks/utils/cdn-helper.js
@@ -83,7 +83,7 @@ class CDNHelper {
           public: true,
           resumable: false,
           metadata: {
-            metadata: {'Cache-Control': 'max-age=31536000'},
+            cacheControl: 'public, max-age=31536000',
           },
         });
       } catch (err) {


### PR DESCRIPTION
As per https://github.com/GoogleCloudPlatform/google-cloud-node/issues/1087#issuecomment-175105508, perhaps this will work?