### PR TITLE
Don't alias the exported workbox.core.registerQuotaExceededCallback symbol

### DIFF
--- a/packages/workbox-cache-expiration/Plugin.mjs
+++ b/packages/workbox-cache-expiration/Plugin.mjs
@@ -15,12 +15,12 @@ import {CacheExpiration} from './CacheExpiration.mjs';
 import {WorkboxError} from 'workbox-core/_private/WorkboxError.mjs';
 import {assert} from 'workbox-core/_private/assert.mjs';
 import {cacheNames} from 'workbox-core/_private/cacheNames.mjs';
-import {registerCallback} from 'workbox-core/_private/quota.mjs';
+import {registerQuotaErrorCallback} from 'workbox-core/_private/quota.mjs';
 
 import './_version.mjs';
 
 /**
- * This plugin can be used in the Workbox API's to regularly enforce a
+ * This plugin can be used in the Workbox APIs to regularly enforce a
  * limit on the age and / or the number of cached requests.
  *
  * Whenever a cached request is used or updated, this plugin will look
@@ -81,7 +81,7 @@ class Plugin {
     this._cacheExpirations = new Map();
 
     if (config.purgeOnQuotaError) {
-      registerCallback(() => this.deleteCacheAndMetadata());
+      registerQuotaErrorCallback(() => this.deleteCacheAndMetadata());
     }
   }
 

--- a/packages/workbox-core/_private.mjs
+++ b/packages/workbox-core/_private.mjs
@@ -23,9 +23,7 @@ import {cacheWrapper} from './_private/cacheWrapper.mjs';
 import {fetchWrapper} from './_private/fetchWrapper.mjs';
 import {getFriendlyURL} from './_private/getFriendlyURL.mjs';
 import {logger} from './_private/logger.mjs';
-import {
-  registerCallback as registerQuotaErrorCallback,
-} from './_private/quota.mjs';
+import {registerQuotaErrorCallback} from './_private/quota.mjs';
 
 import './_version.mjs';
 

--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -18,7 +18,7 @@ import pluginEvents from '../models/pluginEvents.mjs';
 import pluginUtils from '../utils/pluginUtils.mjs';
 import {WorkboxError} from './WorkboxError.mjs';
 import {assert} from './assert.mjs';
-import {executeCallbacks as executeQuotaErrorCallbacks} from './quota.mjs';
+import {executeQuotaErrorCallbacks} from './quota.mjs';
 import {getFriendlyURL} from './getFriendlyURL.mjs';
 import {logger} from './logger.mjs';
 

--- a/packages/workbox-core/_private/quota.mjs
+++ b/packages/workbox-core/_private/quota.mjs
@@ -27,7 +27,7 @@ const callbacks = new Set();
  * @param {Function} callback
  * @memberof workbox.core
  */
-function registerCallback(callback) {
+function registerQuotaErrorCallback(callback) {
   if (process.env.NODE_ENV !== 'production') {
     assert.isType(callback, 'function', {
       moduleName: 'workbox-core',
@@ -50,7 +50,7 @@ function registerCallback(callback) {
  * @memberof workbox.core
  * @private
  */
-async function executeCallbacks() {
+async function executeQuotaErrorCallbacks() {
   if (process.env.NODE_ENV !== 'production') {
     logger.log(`About to run ${callbacks.size} callbacks to clean up caches.`);
   }
@@ -68,6 +68,6 @@ async function executeCallbacks() {
 }
 
 export {
-  executeCallbacks,
-  registerCallback,
+  executeQuotaErrorCallbacks,
+  registerQuotaErrorCallback,
 };

--- a/packages/workbox-core/package.json
+++ b/packages/workbox-core/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.0",
   "license": "Apache-2.0",
   "author": "Google's Web DevRel Team",
-  "description": "This module is used by a number of the other workboxjs.org modules to share common code.",
+  "description": "This module is used by a number of the other Workbox modules to share common code.",
   "repository": "googlechrome/workbox",
   "bugs": "https://github.com/googlechrome/workbox/issues",
   "homepage": "https://github.com/GoogleChrome/workbox",

--- a/test/workbox-cache-expiration/node/test-Plugin.mjs
+++ b/test/workbox-cache-expiration/node/test-Plugin.mjs
@@ -20,7 +20,7 @@ import {devOnly} from '../../../infra/testing/env-it';
 import {Plugin} from '../../../packages/workbox-cache-expiration/Plugin.mjs';
 import {CacheExpiration} from '../../../packages/workbox-cache-expiration/CacheExpiration.mjs';
 import {cacheNames} from '../../../packages/workbox-core/_private/cacheNames.mjs';
-import {executeCallbacks as executeQuotaErrorCallbacks} from '../../../packages/workbox-core/_private/quota.mjs';
+import {executeQuotaErrorCallbacks} from '../../../packages/workbox-core/_private/quota.mjs';
 
 describe(`[workbox-cache-expiration] Plugin`, function() {
   const sandbox = sinon.createSandbox();

--- a/test/workbox-core/node/_private/test-cacheWrapper.mjs
+++ b/test/workbox-core/node/_private/test-cacheWrapper.mjs
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import expectError from '../../../../infra/testing/expectError';
 import {cacheWrapper} from '../../../../packages/workbox-core/_private/cacheWrapper.mjs';
 import {devOnly} from '../../../../infra/testing/env-it';
-import {registerCallback} from '../../../../packages/workbox-core/_private/quota.mjs';
+import {registerQuotaErrorCallback} from '../../../../packages/workbox-core/_private/quota.mjs';
 
 describe(`workbox-core cacheWrapper`, function() {
   let sandbox;
@@ -178,9 +178,9 @@ describe(`workbox-core cacheWrapper`, function() {
 
     it(`should call the quota exceeded callbacks when there's a QuotaExceeded error`, async function() {
       const callback1 = sandbox.stub();
-      registerCallback(callback1);
+      registerQuotaErrorCallback(callback1);
       const callback2 = sandbox.stub();
-      registerCallback(callback2);
+      registerQuotaErrorCallback(callback2);
 
       const cacheName = 'test-cache';
       const testCache = await caches.open(cacheName);
@@ -199,7 +199,7 @@ describe(`workbox-core cacheWrapper`, function() {
 
     it(`should not call the quota exceeded callbacks when there's a non-QuotaExceeded error`, async function() {
       const callback = sandbox.stub();
-      registerCallback(callback);
+      registerQuotaErrorCallback(callback);
 
       const cacheName = 'test-cache';
       const testCache = await caches.open(cacheName);

--- a/test/workbox-core/node/_private/test-quota.mjs
+++ b/test/workbox-core/node/_private/test-quota.mjs
@@ -2,17 +2,17 @@ import {expect} from 'chai';
 import sinon from 'sinon';
 
 import expectError from '../../../../infra/testing/expectError';
-import {executeCallbacks, registerCallback} from '../../../../packages/workbox-core/_private/quota.mjs';
+import {executeQuotaErrorCallbacks, registerQuotaErrorCallback} from '../../../../packages/workbox-core/_private/quota.mjs';
 import {devOnly} from '../../../../infra/testing/env-it';
 
 describe(`workbox-core quota`, function() {
-  describe(`registerCallback()`, function() {
+  describe(`registerQuotaErrorCallback()`, function() {
     devOnly.it(`should throw when passed a non-function`, async function() {
-      await expectError(() => registerCallback(null), 'incorrect-type');
+      await expectError(() => registerQuotaErrorCallback(null), 'incorrect-type');
     });
   });
 
-  describe(`executeCallbacks()`, function() {
+  describe(`executeQuotaErrorCallbacks()`, function() {
     let sandbox;
 
     before(function() {
@@ -22,13 +22,13 @@ describe(`workbox-core quota`, function() {
     afterEach(function() {
       sandbox.restore();
     });
-    it('should call everything registered with registerCallback()', async function() {
+    it('should call everything registered with registerQuotaErrorCallback()', async function() {
       const callback1 = sandbox.stub();
-      registerCallback(callback1);
+      registerQuotaErrorCallback(callback1);
       const callback2 = sandbox.stub();
-      registerCallback(callback2);
+      registerQuotaErrorCallback(callback2);
 
-      await executeCallbacks();
+      await executeQuotaErrorCallbacks();
 
       expect(callback1.calledOnce).to.be.true;
       expect(callback2.calledOnce).to.be.true;
@@ -36,23 +36,23 @@ describe(`workbox-core quota`, function() {
 
     it(`shouldn't have any effect if called multiple times with the same callback`, async function() {
       const callback1 = sandbox.stub();
-      registerCallback(callback1);
-      registerCallback(callback1);
-      registerCallback(callback1);
+      registerQuotaErrorCallback(callback1);
+      registerQuotaErrorCallback(callback1);
+      registerQuotaErrorCallback(callback1);
 
-      await executeCallbacks();
+      await executeQuotaErrorCallbacks();
 
       expect(callback1.calledOnce).to.be.true;
     });
 
-    it(`should call everything registered with registerCallback(), each time it's called`, async function() {
+    it(`should call everything registered with registerQuotaErrorCallback(), each time it's called`, async function() {
       const callback1 = sandbox.stub();
-      registerCallback(callback1);
+      registerQuotaErrorCallback(callback1);
       const callback2 = sandbox.stub();
-      registerCallback(callback2);
+      registerQuotaErrorCallback(callback2);
 
-      await executeCallbacks();
-      await executeCallbacks();
+      await executeQuotaErrorCallbacks();
+      await executeQuotaErrorCallbacks();
 
       expect(callback1.calledTwice).to.be.true;
       expect(callback2.calledTwice).to.be.true;


### PR DESCRIPTION
R: @philipwalton

We previously had two exports in `quota.mjs` named `registerCallback` and `executeCallbacks`, and `registerCallback` was exposed publicly in `worbox.core` as `worbox.core.registerQuotaExceededCallback`.

As pointed out in https://github.com/GoogleChromeLabs/so-pwa/issues/2, the Rollup-generated bundles don't work nicely due to this aliasing. There's a spot in the codebase that imported `registerCallback` from `workbox-core`, and even though that symbol exists before bundling, it doesn't exist post-bundling, leading to runtime errors.

To avoid this, I'm just explicitly renaming all the symbols to be as verbose as we need, rather than aliasing them after the fact.

(I'm not sure whether this constitutes a bug in Rollup, but I'd like to work around it in our codebase first.)