### PR TITLE
README badge update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![AppVeyor Build status][appveyor-image]][appveyor-url]
 [![Dependency Status][dependency-image]][dependency-url]
 [![Dev Dependency Status][dev-dependency-image]][dev-dependency-url]
+[![TypeScript definitions on DefinitelyTyped](https://definitelytyped.org/badges/standard.svg)](https://www.npmjs.com/package/@types/workbox-sw)
 
 <img src='https://user-images.githubusercontent.com/110953/28352645-7a8a66d8-6c0c-11e7-83af-752609e7e072.png' width='500px'/>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Travis Build Status][travis-image]][travis-url]
 [![AppVeyor Build status][appveyor-image]][appveyor-url]
-[![Dependency Status][dependency-image]][dependency-url]
 [![Dev Dependency Status][dev-dependency-image]][dev-dependency-url]
 [![TypeScript definitions on DefinitelyTyped](https://definitelytyped.org/badges/standard-flat.svg)](https://www.npmjs.com/package/@types/workbox-sw)
 
@@ -91,7 +90,5 @@ limitations under the License.
 [travis-image]: https://travis-ci.org/GoogleChrome/workbox.svg?branch=master
 [appveyor-image]: https://ci.appveyor.com/api/projects/status/4ct8ph4d34c5ifnw?svg=true
 [appveyor-url]: https://ci.appveyor.com/project/gauntface/workbox
-[dependency-url]: https://david-dm.org/GoogleChrome/workbox/
-[dependency-image]: https://david-dm.org/GoogleChrome/workbox/status.svg
 [dev-dependency-url]: https://david-dm.org/GoogleChrome/workbox?type=dev
 [dev-dependency-image]: https://david-dm.org/GoogleChrome/workbox/dev-status.svg

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![AppVeyor Build status][appveyor-image]][appveyor-url]
 [![Dependency Status][dependency-image]][dependency-url]
 [![Dev Dependency Status][dev-dependency-image]][dev-dependency-url]
-[![TypeScript definitions on DefinitelyTyped](https://definitelytyped.org/badges/standard.svg)](https://www.npmjs.com/package/@types/workbox-sw)
+[![TypeScript definitions on DefinitelyTyped](https://definitelytyped.org/badges/standard-flat.svg)](https://www.npmjs.com/package/@types/workbox-sw)
 
 <img src='https://user-images.githubusercontent.com/110953/28352645-7a8a66d8-6c0c-11e7-83af-752609e7e072.png' width='500px'/>
 


### PR DESCRIPTION
R: @philipwalton

Fixes #1410

Adds a badge linking to the TypeScript definitions (and drops the `dependencies` freshness badge, since the main package in the monorepo doesn't have any dependencies).
