### PR TITLE
Link to the class constructors' docs instead of StrategyOptions

### DIFF
--- a/packages/workbox-strategies/_default.mjs
+++ b/packages/workbox-strategies/_default.mjs
@@ -23,27 +23,32 @@ import './_version.mjs';
 
 /**
  * @function workbox.strategies.cacheFirst
- * @param {workbox.strategies.StrategyOptions} options
+ * @param {Object} options See the {@link workbox.strategies.CacheFirst}
+ * constructor for more info.
  */
 
 /**
  * @function workbox.strategies.cacheOnly
- * @param {workbox.strategies.StrategyOptions} options
+ * @param {Object} options See the {@link workbox.strategies.CacheOnly}
+ * constructor for more info.
  */
 
 /**
  * @function workbox.strategies.networkFirst
- * @param {workbox.strategies.StrategyOptions} options
+ * @param {Object} options See the {@link workbox.strategies.NetworkFirst}
+ * constructor for more info.
  */
 
 /**
  * @function workbox.strategies.networkOnly
- * @param {workbox.strategies.StrategyOptions} options
+ * @param {Object} options See the {@link workbox.strategies.NetworkOnly}
+ * constructor for more info.
  */
 
 /**
  * @function workbox.strategies.staleWhileRevalidate
- * @param {workbox.strategies.StrategyOptions} options
+ * @param {Object} options See the
+ * {@link workbox.strategies.StaleWhileRevalidate} constructor for more info.
  */
 
 const mapping = {


### PR DESCRIPTION
R: @philipwalton
CC: @surma 

Fixes #1587 

We were referencing a `workbox.strategies.StrategyOptions` definition that no longer exists. This change points folks to the corresponding documentation for the equivalent class constructor.
