### PR TITLE
Add support for fetchOptions/matchOptions in runtimeCachingConverter

### DIFF
--- a/packages/workbox-build/src/entry-points/options/common-generate-schema.js
+++ b/packages/workbox-build/src/entry-points/options/common-generate-schema.js
@@ -59,6 +59,8 @@ module.exports = baseSchema.keys({
       }).or('maxEntries', 'maxAgeSeconds'),
       networkTimeoutSeconds: joi.number().min(1),
       plugins: joi.array().items(joi.object()),
+      fetchOptions: joi.object(),
+      matchOptions: joi.object(),
     }).with('expiration', 'cacheName'),
   }).requiredKeys('urlPattern', 'handler')),
   skipWaiting: joi.boolean().default(defaults.skipWaiting),

--- a/test/workbox-build/node/entry-points/generate-sw-string.js
+++ b/test/workbox-build/node/entry-points/generate-sw-string.js
@@ -379,6 +379,8 @@ describe(`[workbox-build] entry-points/generate-sw-string.js (End to End)`, func
           },
           statuses: [0, 200],
         },
+        fetchOptions: {},
+        matchOptions: {},
       };
       const runtimeCaching = [{
         urlPattern: REGEXP_URL_PATTERN,
@@ -395,6 +397,8 @@ describe(`[workbox-build] entry-points/generate-sw-string.js (End to End)`, func
           plugins: runtimeCachingOptions.plugins.concat([
             {}, {},
           ]),
+          fetchOptions: {},
+          matchOptions: {},
         }]],
         cacheableResponsePlugin: [[runtimeCachingOptions.cacheableResponse]],
         cacheExpirationPlugin: [[runtimeCachingOptions.expiration]],

--- a/test/workbox-build/node/lib/runtime-caching-converter.js
+++ b/test/workbox-build/node/lib/runtime-caching-converter.js
@@ -75,6 +75,14 @@ function validate(runtimeCachingOptions, convertedOptions) {
         expect(options.cacheName).to.eql(strategiesOptions.cacheName);
       }
 
+      if (options.fetchOptions) {
+        expect(options.fetchOptions).to.deep.eql(strategiesOptions.fetchOptions);
+      }
+
+      if (options.matchOptions) {
+        expect(options.matchOptions).to.deep.eql(strategiesOptions.matchOptions);
+      }
+
       if (Object.keys(options.expiration).length > 0) {
         expect(globalScope.workbox.expiration.Plugin.calledWith(options.expiration)).to.be.true;
       }
@@ -169,6 +177,11 @@ describe(`[workbox-build] src/lib/utils/runtime-caching-converter.js`, function(
         backgroundSync: {
           name: 'test',
         },
+        fetchOptions: {
+          headers: {
+            'Custom': 'Header',
+          },
+        },
       },
     }, {
       urlPattern: '/test',
@@ -191,6 +204,9 @@ describe(`[workbox-build] src/lib/utils/runtime-caching-converter.js`, function(
           options: {
             maxRetentionTime: 123,
           },
+        },
+        matchOptions: {
+          ignoreSearch: true,
         },
       },
     }];


### PR DESCRIPTION
R: @jeffposnick @philipwalton

Fixes #1607

Caching strategies support taking objects for `fetchOptions` and `matchOptions`, but `runtimeCachingConverter` has no support for taking them as input.

I've left both as `joi.object()` in the schema, as I'm not sure how to specify a DOM interface as the type/if it's possible, and I don't think it makes sense to duplicate browser specs in the schema.