### PR TITLE
Add workbox-routing PATCH method support

### DIFF
--- a/packages/workbox-routing/utils/constants.mjs
+++ b/packages/workbox-routing/utils/constants.mjs
@@ -36,6 +36,7 @@ export const validMethods = [
   'DELETE',
   'GET',
   'HEAD',
+  'PATCH',
   'POST',
   'PUT',
 ];


### PR DESCRIPTION
R: @jeffposnick @philipwalton

Fixes #1617

Added PATCH as a valid method for workbox-routing.
