### PR TITLE
Expose workbox.core.registerQuotaErrorCallback

### DIFF
--- a/packages/workbox-core/_private.mjs
+++ b/packages/workbox-core/_private.mjs
@@ -23,7 +23,6 @@ import {cacheWrapper} from './_private/cacheWrapper.mjs';
 import {fetchWrapper} from './_private/fetchWrapper.mjs';
 import {getFriendlyURL} from './_private/getFriendlyURL.mjs';
 import {logger} from './_private/logger.mjs';
-import {registerQuotaErrorCallback} from './_private/quota.mjs';
 
 import './_version.mjs';
 
@@ -36,5 +35,4 @@ export {
   fetchWrapper,
   getFriendlyURL,
   logger,
-  registerQuotaErrorCallback,
 };

--- a/packages/workbox-core/browser.mjs
+++ b/packages/workbox-core/browser.mjs
@@ -14,14 +14,17 @@
   limitations under the License.
 */
 
+import {registerQuotaErrorCallback} from './_private/quota.mjs';
+import * as _private from './_private.mjs';
 import defaultExport from './_default.mjs';
 import LOG_LEVELS from './models/LogLevels.mjs';
-import * as _private from './_private.mjs';
+
 import './_version.mjs';
 
 const finalExports = Object.assign(defaultExport, {
-  LOG_LEVELS,
   _private,
+  LOG_LEVELS,
+  registerQuotaErrorCallback,
 });
 
 export default finalExports;

--- a/packages/workbox-core/index.mjs
+++ b/packages/workbox-core/index.mjs
@@ -14,9 +14,11 @@
   limitations under the License.
 */
 
+import {registerQuotaErrorCallback} from './_private/quota.mjs';
+import * as _private from './_private.mjs';
 import defaultExport from './_default.mjs';
 import LOG_LEVELS from './models/LogLevels.mjs';
-import * as _private from './_private.mjs';
+
 import './_version.mjs';
 
 /**
@@ -35,8 +37,9 @@ import './_version.mjs';
  */
 
 export {
-  LOG_LEVELS,
   _private,
+  LOG_LEVELS,
+  registerQuotaErrorCallback,
 };
 
 export default defaultExport;

--- a/test/workbox-core/node/test-exports.mjs
+++ b/test/workbox-core/node/test-exports.mjs
@@ -8,6 +8,7 @@ describe('workbox-core Exports', function() {
         'LOG_LEVELS',
         '_private',
         'default',
+        'registerQuotaErrorCallback',
       ]);
     });
   });


### PR DESCRIPTION
R: @philipwalton

Fixes #1616

This renames `workbox.core._private.reigsterQuotaErrorCallback` to `workbox.core.reigsterQuotaErrorCallback`, matching the docs and the intended interface.

It's a change to our interface, but since it amounts to removing something that was under `_private` (and is likely not to be widely used directly as-is), I'm inclined to say that we can get this in outside of a major semver release, as long as we document the change in the release notes.