### PR TITLE
Move the stategy function into its own file

### DIFF
--- a/packages/workbox-streams/_public.mjs
+++ b/packages/workbox-streams/_public.mjs
@@ -17,6 +17,7 @@
 import {concatenate} from './concatenate.mjs';
 import {concatenateToResponse} from './concatenateToResponse.mjs';
 import {isSupported} from './isSupported.mjs';
+import {strategy} from './strategy.mjs';
 
 import './_version.mjs';
 
@@ -24,4 +25,5 @@ export {
   concatenate,
   concatenateToResponse,
   isSupported,
+  strategy,
 };

--- a/packages/workbox-streams/browser.mjs
+++ b/packages/workbox-streams/browser.mjs
@@ -14,10 +14,6 @@
   limitations under the License.
 */
 
-import * as publicAPI from './_public.mjs';
-import defaultExport from './_default.mjs';
 import './_version.mjs';
 
-const finalExport = Object.assign(defaultExport, publicAPI);
-
-export default finalExport;
+export * from './_public.mjs';

--- a/packages/workbox-streams/index.mjs
+++ b/packages/workbox-streams/index.mjs
@@ -14,12 +14,10 @@
   limitations under the License.
 */
 
+import './_version.mjs';
+
 /**
  * @namespace workbox.streams
  */
 
-import defaultExport from './_default.mjs';
-import './_version.mjs';
-
-export default defaultExport;
 export * from './_public.mjs';

--- a/packages/workbox-streams/strategy.mjs
+++ b/packages/workbox-streams/strategy.mjs
@@ -16,7 +16,6 @@
 import {logger} from 'workbox-core/_private/logger.mjs';
 
 import {createHeaders} from './utils/createHeaders.mjs';
-import {concatenate} from './concatenate.mjs';
 import {concatenateToResponse} from './concatenateToResponse.mjs';
 import {isSupported} from './isSupported.mjs';
 
@@ -39,7 +38,7 @@ import './_version.mjs';
  *
  * @memberof workbox.streams
  */
-function strategy(sourceFunctions, headersInit) {
+export function strategy(sourceFunctions, headersInit) {
   return async ({event, url, params}) => {
     if (isSupported()) {
       const {done, response} = concatenateToResponse(sourceFunctions.map(
@@ -76,10 +75,3 @@ function strategy(sourceFunctions, headersInit) {
     return new Response(new Blob(parts), {headers});
   };
 }
-
-export default {
-  concatenate,
-  concatenateToResponse,
-  isSupported,
-  strategy,
-};


### PR DESCRIPTION
This PR:

- Moves the `strategy()` function form `_default.mjs` into it's own file, so it can be imported on it's own (e.g. `import {strategy} from 'workbox-streams/strategy.mjs'`).
- Removes the `_default.mjs` file as there's no "special" default export outside of what's already in `_public.mjs`.

R: @jeffposnick
