### PR TITLE
Expose the event object to plugin methods

### DIFF
--- a/packages/workbox-broadcast-cache-update/Plugin.mjs
+++ b/packages/workbox-broadcast-cache-update/Plugin.mjs
@@ -47,10 +47,10 @@ class Plugin {
    * added to a cache.
    *
    * @private
-   * @param {Object} input The input object to this function.
-   * @param {string} input.cacheName Name of the cache the responses belong to.
-   * @param {Response} [input.oldResponse] The previous cached value, if any.
-   * @param {Response} input.newResponse The new value in the cache.
+   * @param {Object} options The input object to this function.
+   * @param {string} options.cacheName Name of the cache being updated.
+   * @param {Response} [options.oldResponse] The previous cached value, if any.
+   * @param {Response} options.newResponse The new value in the cache.
    */
   cacheDidUpdate({cacheName, oldResponse, newResponse, request}) {
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/workbox-cache-expiration/Plugin.mjs
+++ b/packages/workbox-cache-expiration/Plugin.mjs
@@ -115,12 +115,12 @@ class Plugin {
    * prevents it from being used if the `Response`'s `Date` header value is
    * older than the configured `maxAgeSeconds`.
    *
-   * @param {Object} input
-   * @param {string} input.cacheName Name of the cache the responses belong to.
-   * @param {Response} input.cachedResponse The `Response` object that's been
-   *        read from a cache and whose freshness should be checked.
+   * @param {Object} options
+   * @param {string} options.cacheName Name of the cache the response is in.
+   * @param {Response} options.cachedResponse The `Response` object that's been
+   *     read from a cache and whose freshness should be checked.
    * @return {Response} Either the `cachedResponse`, if it's
-   *         fresh, or `null` if the `Response` is older than `maxAgeSeconds`.
+   *     fresh, or `null` if the `Response` is older than `maxAgeSeconds`.
    *
    * @private
    */
@@ -197,9 +197,9 @@ class Plugin {
    * A "lifecycle" callback that will be triggered automatically by the
    * `workbox.runtimeCaching` handlers when an entry is added to a cache.
    *
-   * @param {Object} input
-   * @param {string} input.cacheName Name of the cache the responses belong to.
-   * @param {string} input.request The Request for the cached entry.
+   * @param {Object} options
+   * @param {string} options.cacheName Name of the cache that was updated.
+   * @param {string} options.request The Request for the cached entry.
    *
    * @private
    */

--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -29,15 +29,23 @@ import '../_version.mjs';
  *
  * Will call `cacheDidUpdate` on plugins if the cache was updated.
  *
- * @param {string} cacheName
- * @param {Request} request
- * @param {Response} response
- * @param {Array<Object>} [plugins]
+ * @param {Object} options
+ * @param {string} options.cacheName
+ * @param {Request} options.request
+ * @param {Response} options.response
+ * @param {Event} [options.event]
+ * @param {Array} [options.plugins=[]]
  *
  * @private
  * @memberof module:workbox-core
  */
-const putWrapper = async (cacheName, request, response, plugins = []) => {
+const putWrapper = async ({
+    cacheName,
+    request,
+    response,
+    event,
+    plugins = [],
+  } = {}) => {
   if (!response) {
     if (process.env.NODE_ENV !== 'production') {
       logger.error(`Cannot cache non-existent response for ` +
@@ -49,8 +57,8 @@ const putWrapper = async (cacheName, request, response, plugins = []) => {
     });
   }
 
-  let responseToCache = await _isResponseSafeToCache(
-    request, response, plugins);
+  let responseToCache =
+      await _isResponseSafeToCache({request, response, event, plugins});
 
   if (!responseToCache) {
     if (process.env.NODE_ENV !== 'production') {
@@ -75,7 +83,7 @@ const putWrapper = async (cacheName, request, response, plugins = []) => {
     plugins, pluginEvents.CACHE_DID_UPDATE);
 
   let oldResponse = updatePlugins.length > 0 ?
-    await matchWrapper(cacheName, request) : null;
+    await matchWrapper({cacheName, request}) : null;
 
   if (process.env.NODE_ENV !== 'production') {
     logger.debug(`Updating the '${cacheName}' cache with a new Response for ` +
@@ -96,6 +104,7 @@ const putWrapper = async (cacheName, request, response, plugins = []) => {
     await plugin[pluginEvents.CACHE_DID_UPDATE].call(plugin, {
       cacheName,
       request,
+      event,
       oldResponse,
       newResponse: responseToCache,
     });
@@ -105,17 +114,24 @@ const putWrapper = async (cacheName, request, response, plugins = []) => {
 /**
  * This is a wrapper around cache.match().
  *
- * @param {string} cacheName Name of the cache to match against.
- * @param {Request} request The Request that will be used to look up cache
- * entries.
- * @param {Object} matchOptions Options passed to cache.match().
- * @param {Array<Object>} [plugins] Array of plugins.
+ * @param {Object} options
+ * @param {string} options.cacheName Name of the cache to match against.
+ * @param {Request} options.request The Request that will be used to look up
+ *.    cache entries.
+ * @param {Event} [options.event] The event that propted the action.
+ * @param {Object} [options.matchOptions] Options passed to cache.match().
+ * @param {Array<Object>} [options.plugins=[]] Array of plugins.
  * @return {Response} A cached response if available.
  *
  * @private
  * @memberof module:workbox-core
  */
-const matchWrapper = async (cacheName, request, matchOptions, plugins = []) => {
+const matchWrapper = async ({
+    cacheName,
+    request,
+    event,
+    matchOptions,
+    plugins = []}) => {
   const cache = await caches.open(cacheName);
   let cachedResponse = await cache.match(request, matchOptions);
   if (process.env.NODE_ENV !== 'production') {
@@ -131,6 +147,7 @@ const matchWrapper = async (cacheName, request, matchOptions, plugins = []) => {
         .call(plugin, {
           cacheName,
           request,
+          event,
           matchOptions,
           cachedResponse,
         });
@@ -152,15 +169,17 @@ const matchWrapper = async (cacheName, request, matchOptions, plugins = []) => {
  * This method will call cacheWillUpdate on the available plugins (or use
  * response.ok) to determine if the Response is safe and valid to cache.
  *
- * @param {Request} request
- * @param {Response} response
- * @param {Array<Object>} plugins
+ * @param {Object} options
+ * @param {Request} options.request
+ * @param {Response} options.response
+ * @param {Event} [options.event]
+ * @param {Array<Object>} [options.plugins=[]]
  * @return {Promise<Response>}
  *
  * @private
  * @memberof module:workbox-core
  */
-const _isResponseSafeToCache = async (request, response, plugins) => {
+const _isResponseSafeToCache = async ({request, response, event, plugins}) => {
   let responseToCache = response;
   let pluginsUsed = false;
   for (let plugin of plugins) {
@@ -170,6 +189,7 @@ const _isResponseSafeToCache = async (request, response, plugins) => {
         .call(plugin, {
           request,
           response: responseToCache,
+          event,
         });
 
       if (process.env.NODE_ENV !== 'production') {

--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -34,7 +34,7 @@ import '../_version.mjs';
  * @param {Request} options.request
  * @param {Response} options.response
  * @param {Event} [options.event]
- * @param {Array} [options.plugins=[]]
+ * @param {Array<Object>} [options.plugins=[]]
  *
  * @private
  * @memberof module:workbox-core

--- a/packages/workbox-core/_private/fetchWrapper.mjs
+++ b/packages/workbox-core/_private/fetchWrapper.mjs
@@ -39,9 +39,8 @@ import '../_version.mjs';
  */
 const wrappedFetch = async ({
     request,
-    event,
     fetchOptions,
-    preloadResponse,
+    event,
     plugins = []}) => {
   // We *should* be able to call `await event.preloadResponse` even if it's
   // undefined, but for some reason, doing so leads to errors in our Node unit

--- a/packages/workbox-core/_private/fetchWrapper.mjs
+++ b/packages/workbox-core/_private/fetchWrapper.mjs
@@ -27,24 +27,27 @@ import '../_version.mjs';
  *
  * Will call requestWillFetch on available plugins.
  *
- * @param {Request|string} request
- * @param {Object} fetchOptions
- * @param {Array<Object>} [plugins]
- * @param {Promise<Response>} [preloadResponse]
+ * @param {Object} options
+ * @param {Request|string} options.request
+ * @param {Object} [options.fetchOptions]
+ * @param {Event} [options.event]
+ * @param {Array<Object>} [options.plugins=[]]
  * @return {Promise<Response>}
  *
  * @private
  * @memberof module:workbox-core
  */
-const wrappedFetch = async (request,
-                            fetchOptions,
-                            plugins = [],
-                            preloadResponse) => {
-  // We *should* be able to call `await preloadResponse` even if it's undefined,
-  // but for some reason, doing so leads to errors in our Node unit tests.
-  // To work around that, explicitly check preloadResponse's value first.
-  if (preloadResponse) {
-    const possiblePreloadResponse = await preloadResponse;
+const wrappedFetch = async ({
+    request,
+    event,
+    fetchOptions,
+    preloadResponse,
+    plugins = []}) => {
+  // We *should* be able to call `await event.preloadResponse` even if it's
+  // undefined, but for some reason, doing so leads to errors in our Node unit
+  // tests. To work around that, explicitly check preloadResponse's value first.
+  if (event && event.preloadResponse) {
+    const possiblePreloadResponse = await event.preloadResponse;
     if (possiblePreloadResponse) {
       if (process.env.NODE_ENV !== 'production') {
         logger.log(`Using a preloaded navigation response for ` +
@@ -82,6 +85,7 @@ const wrappedFetch = async (request,
       if (pluginEvents.REQUEST_WILL_FETCH in plugin) {
         request = await plugin[pluginEvents.REQUEST_WILL_FETCH].call(plugin, {
           request: request.clone(),
+          event,
         });
 
         if (process.env.NODE_ENV !== 'production') {
@@ -123,6 +127,7 @@ const wrappedFetch = async (request,
     for (let plugin of failedFetchPlugins) {
       await plugin[pluginEvents.FETCH_DID_FAIL].call(plugin, {
         error,
+        event,
         originalRequest: originalRequest.clone(),
         request: pluginFilteredRequest.clone(),
       });

--- a/packages/workbox-precaching/_default.mjs
+++ b/packages/workbox-precaching/_default.mjs
@@ -160,12 +160,14 @@ moduleExports.precache = (entries) => {
   installActivateListenersAdded = true;
   self.addEventListener('install', (event) => {
     event.waitUntil(precacheController.install({
-      suppressWarnings,
+      event,
       plugins,
+      suppressWarnings,
     }));
   });
   self.addEventListener('activate', (event) => {
     event.waitUntil(precacheController.activate({
+      event,
       plugins,
     }));
   });

--- a/packages/workbox-routing/NavigationRoute.mjs
+++ b/packages/workbox-routing/NavigationRoute.mjs
@@ -78,9 +78,9 @@ class NavigationRoute extends Route {
   /**
    * Routes match handler.
    *
-   * @param {Object} input
-   * @param {FetchEvent} input.event
-   * @param {URL} input.url
+   * @param {Object} options
+   * @param {FetchEvent} options.event
+   * @param {URL} options.url
    * @return {boolean}
    *
    * @private

--- a/packages/workbox-strategies/CacheFirst.mjs
+++ b/packages/workbox-strategies/CacheFirst.mjs
@@ -58,8 +58,8 @@ class CacheFirst {
    * will work with the
    * [Workbox Router]{@link workbox.routing.Router}.
    *
-   * @param {Object} input
-   * @param {FetchEvent} input.event The fetch event to run this strategy
+   * @param {Object} options
+   * @param {FetchEvent} options.event The fetch event to run this strategy
    * against.
    * @return {Promise<Response>}
    */
@@ -86,12 +86,12 @@ class CacheFirst {
    * See "[Advanced Recipes](https://developers.google.com/web/tools/workbox/guides/advanced-recipes#make-requests)"
    * for more usage information.
    *
-   * @param {Object} input
-   * @param {Request|string} input.request Either a
-   * [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
-   * object, or a string URL, corresponding to the request to be made.
-   * @param {FetchEvent} [input.event] If provided, `event.waitUntil()` will be
-   * called automatically to extend the service worker's lifetime.
+   * @param {Object} options
+   * @param {Request|string} options.request Either a
+   *     [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
+   *     object, or a string URL, corresponding to the request to be made.
+   * @param {FetchEvent} [options.event] If provided, `event.waitUntil()` will
+         be called automatically to extend the service worker's lifetime.
    * @return {Promise<Response>}
    */
   async makeRequest({event, request}) {

--- a/packages/workbox-strategies/CacheFirst.mjs
+++ b/packages/workbox-strategies/CacheFirst.mjs
@@ -110,12 +110,13 @@ class CacheFirst {
       });
     }
 
-    let response = await cacheWrapper.match(
-      this._cacheName,
+    let response = await cacheWrapper.match({
+      cacheName: this._cacheName,
       request,
-      this._matchOptions,
-      this._plugins
-    );
+      event,
+      matchOptions: this._matchOptions,
+      plugins: this._plugins,
+    });
 
     let error;
     if (!response) {
@@ -173,21 +174,22 @@ class CacheFirst {
    * @private
    */
   async _getFromNetwork(request, event) {
-    const response = await fetchWrapper.fetch(
+    const response = await fetchWrapper.fetch({
       request,
-      this._fetchOptions,
-      this._plugins,
-      event ? event.preloadResponse : undefined
-    );
+      event,
+      fetchOptions: this._fetchOptions,
+      plugins: this._plugins,
+    });
 
     // Keep the service worker while we put the request to the cache
     const responseClone = response.clone();
-    const cachePutPromise = cacheWrapper.put(
-      this._cacheName,
+    const cachePutPromise = cacheWrapper.put({
+      cacheName: this._cacheName,
       request,
-      responseClone,
-      this._plugins
-    );
+      response: responseClone,
+      event,
+      plugins: this._plugins,
+    });
 
     if (event) {
       try {

--- a/packages/workbox-strategies/CacheOnly.mjs
+++ b/packages/workbox-strategies/CacheOnly.mjs
@@ -52,8 +52,8 @@ class CacheOnly {
    * will work with the
    * [Workbox Router]{@link workbox.routing.Router}.
    *
-   * @param {Object} input
-   * @param {FetchEvent} input.event The fetch event to run this strategy
+   * @param {Object} options
+   * @param {FetchEvent} options.event The fetch event to run this strategy
    * against.
    * @return {Promise<Response>}
    */
@@ -80,12 +80,12 @@ class CacheOnly {
    * See "[Advanced Recipes](https://developers.google.com/web/tools/workbox/guides/advanced-recipes#make-requests)"
    * for more usage information.
    *
-   * @param {Object} input
-   * @param {Request|string} input.request Either a
-   * [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
-   * object, or a string URL, corresponding to the request to be made.
-   * @param {FetchEvent} [input.event] If provided, `event.waitUntil()` will be
-   * called automatically to extend the service worker's lifetime.
+   * @param {Object} options
+   * @param {Request|string} options.request Either a
+   *     [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
+   *     object, or a string URL, corresponding to the request to be made.
+   * @param {FetchEvent} [options.event] If provided, `event.waitUntil()` will
+   *     be called automatically to extend the service worker's lifetime.
    * @return {Promise<Response>}
    */
   async makeRequest({event, request}) {

--- a/packages/workbox-strategies/CacheOnly.mjs
+++ b/packages/workbox-strategies/CacheOnly.mjs
@@ -102,12 +102,13 @@ class CacheOnly {
       });
     }
 
-    const response = await cacheWrapper.match(
-      this._cacheName,
+    const response = await cacheWrapper.match({
+      cacheName: this._cacheName,
       request,
-      this._matchOptions,
-      this._plugins
-    );
+      event,
+      matchOptions: this._matchOptions,
+      plugins: this._plugins,
+    });
 
     if (process.env.NODE_ENV !== 'production') {
       logger.groupCollapsed(

--- a/packages/workbox-strategies/NetworkFirst.mjs
+++ b/packages/workbox-strategies/NetworkFirst.mjs
@@ -89,8 +89,8 @@ class NetworkFirst {
    * will work with the
    * [Workbox Router]{@link workbox.routing.Router}.
    *
-   * @param {Object} input
-   * @param {FetchEvent} input.event The fetch event to run this strategy
+   * @param {Object} options
+   * @param {FetchEvent} options.event The fetch event to run this strategy
    * against.
    * @return {Promise<Response>}
    */
@@ -117,12 +117,12 @@ class NetworkFirst {
    * See "[Advanced Recipes](https://developers.google.com/web/tools/workbox/guides/advanced-recipes#make-requests)"
    * for more usage information.
    *
-   * @param {Object} input
-   * @param {Request|string} input.request Either a
-   * [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
-   * object, or a string URL, corresponding to the request to be made.
-   * @param {FetchEvent} [input.event] If provided, `event.waitUntil()` will be
-   * called automatically to extend the service worker's lifetime.
+   * @param {Object} options
+   * @param {Request|string} options.request Either a
+   *     [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
+   *     object, or a string URL, corresponding to the request to be made.
+   * @param {FetchEvent} [options.event] If provided, `event.waitUntil()` will
+   *     be called automatically to extend the service worker's lifetime.
    * @return {Promise<Response>}
    */
   async makeRequest({event, request}) {

--- a/packages/workbox-strategies/NetworkFirst.mjs
+++ b/packages/workbox-strategies/NetworkFirst.mjs
@@ -145,13 +145,13 @@ class NetworkFirst {
     let timeoutId;
 
     if (this._networkTimeoutSeconds) {
-      const {id, promise} = this._getTimeoutPromise(request, logs);
+      const {id, promise} = this._getTimeoutPromise({request, event, logs});
       timeoutId = id;
       promises.push(promise);
     }
 
-    const networkPromise = this._getNetworkPromise(timeoutId, event, request,
-      logs);
+    const networkPromise =
+        this._getNetworkPromise({timeoutId, request, event, logs});
     promises.push(networkPromise);
 
     // Promise.race() will resolve as soon as the first promise resolves.
@@ -179,13 +179,15 @@ class NetworkFirst {
   }
 
   /**
-   * @param {Request} request
-   * @param {Array} logs A reference to the logs array
+   * @param {Object} options
+   * @param {Request} options.request
+   * @param {Array} options.logs A reference to the logs array
+   * @param {Event} [options.event]
    * @return {Promise<Response>}
    *
    * @private
    */
-  _getTimeoutPromise(request, logs) {
+  _getTimeoutPromise({request, logs, event}) {
     let timeoutId;
     const timeoutPromise = new Promise((resolve) => {
       const onNetworkTimeout = async () => {
@@ -194,7 +196,7 @@ class NetworkFirst {
             `${this._networkTimeoutSeconds} seconds.`);
         }
 
-        resolve(await this._respondFromCache(request));
+        resolve(await this._respondFromCache({request, event}));
       };
 
       timeoutId = setTimeout(
@@ -210,24 +212,25 @@ class NetworkFirst {
   }
 
   /**
-   * @param {number} timeoutId
-   * @param {FetchEvent|null} event
-   * @param {Request} request
-   * @param {Array} logs A reference to the logs Array.
+   * @param {Object} options
+   * @param {number|undefined} options.timeoutId
+   * @param {Request} options.request
+   * @param {Array} options.logs A reference to the logs Array.
+   * @param {Event} [options.event]
    * @return {Promise<Response>}
    *
    * @private
    */
-  async _getNetworkPromise(timeoutId, event, request, logs) {
+  async _getNetworkPromise({timeoutId, request, logs, event}) {
     let error;
     let response;
     try {
-      response = await fetchWrapper.fetch(
+      response = await fetchWrapper.fetch({
         request,
-        this._fetchOptions,
-        this._plugins,
-        event ? event.preloadResponse : undefined
-      );
+        event,
+        fetchOptions: this._fetchOptions,
+        plugins: this._plugins,
+      });
     } catch (err) {
       error = err;
     }
@@ -246,7 +249,7 @@ class NetworkFirst {
     }
 
     if (error || !response) {
-      response = await this._respondFromCache(request);
+      response = await this._respondFromCache({request, event});
       if (process.env.NODE_ENV !== 'production') {
         if (response) {
           logs.push(`Found a cached response in the '${this._cacheName}'` +
@@ -258,12 +261,13 @@ class NetworkFirst {
     } else {
       // Keep the service worker alive while we put the request in the cache
       const responseClone = response.clone();
-      const cachePut = cacheWrapper.put(
-        this._cacheName,
+      const cachePut = cacheWrapper.put({
+        cacheName: this._cacheName,
         request,
-        responseClone,
-        this._plugins
-      );
+        response: responseClone,
+        event,
+        plugins: this._plugins,
+      });
 
       if (event) {
         try {
@@ -285,18 +289,21 @@ class NetworkFirst {
   /**
    * Used if the network timeouts or fails to make the request.
    *
-   * @param {Request} request The fetchEvent request to match in the cache
+   * @param {Object} options
+   * @param {Request} request The request to match in the cache
+   * @param {Event} [options.event]
    * @return {Promise<Object>}
    *
    * @private
    */
-  _respondFromCache(request) {
-    return cacheWrapper.match(
-      this._cacheName,
+  _respondFromCache({event, request}) {
+    return cacheWrapper.match({
+      cacheName: this._cacheName,
       request,
-      this._matchOptions,
-      this._plugins
-    );
+      event,
+      matchOptions: this._matchOptions,
+      plugins: this._plugins,
+    });
   }
 }
 

--- a/packages/workbox-strategies/NetworkOnly.mjs
+++ b/packages/workbox-strategies/NetworkOnly.mjs
@@ -52,8 +52,8 @@ class NetworkOnly {
    * will work with the
    * [Workbox Router]{@link workbox.routing.Router}.
    *
-   * @param {Object} input
-   * @param {FetchEvent} input.event The fetch event to run this strategy
+   * @param {Object} options
+   * @param {FetchEvent} options.event The fetch event to run this strategy
    * against.
    * @return {Promise<Response>}
    */
@@ -80,12 +80,12 @@ class NetworkOnly {
    * See "[Advanced Recipes](https://developers.google.com/web/tools/workbox/guides/advanced-recipes#make-requests)"
    * for more usage information.
    *
-   * @param {Object} input
-   * @param {Request|string} input.request Either a
-   * [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
-   * object, or a string URL, corresponding to the request to be made.
-   * @param {FetchEvent} [input.event] If provided, `event.waitUntil()` will be
-   * called automatically to extend the service worker's lifetime.
+   * @param {Object} options
+   * @param {Request|string} options.request Either a
+   *     [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
+   *     object, or a string URL, corresponding to the request to be made.
+   * @param {FetchEvent} [options.event] If provided, `event.waitUntil()` will
+   *     be called automatically to extend the service worker's lifetime.
    * @return {Promise<Response>}
    */
   async makeRequest({event, request}) {

--- a/packages/workbox-strategies/NetworkOnly.mjs
+++ b/packages/workbox-strategies/NetworkOnly.mjs
@@ -105,12 +105,12 @@ class NetworkOnly {
     let error;
     let response;
     try {
-      response = await fetchWrapper.fetch(
+      response = await fetchWrapper.fetch({
         request,
-        this._fetchOptions,
-        this._plugins,
-        event ? event.preloadResponse : undefined
-      );
+        event,
+        fetchOptions: this._fetchOptions,
+        plugins: this._plugins,
+      });
     } catch (err) {
       error = err;
     }

--- a/packages/workbox-strategies/StaleWhileRevalidate.mjs
+++ b/packages/workbox-strategies/StaleWhileRevalidate.mjs
@@ -77,8 +77,8 @@ class StaleWhileRevalidate {
    * will work with the
    * [Workbox Router]{@link workbox.routing.Router}.
    *
-   * @param {Object} input
-   * @param {FetchEvent} input.event The fetch event to run this strategy
+   * @param {Object} options
+   * @param {FetchEvent} options.event The fetch event to run this strategy
    * against.
    * @return {Promise<Response>}
    */
@@ -105,12 +105,12 @@ class StaleWhileRevalidate {
    * See "[Advanced Recipes](https://developers.google.com/web/tools/workbox/guides/advanced-recipes#make-requests)"
    * for more usage information.
    *
-   * @param {Object} input
-   * @param {Request|string} input.request Either a
-   * [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
-   * object, or a string URL, corresponding to the request to be made.
-   * @param {FetchEvent} [input.event] If provided, `event.waitUntil()` will be
-   * called automatically to extend the service worker's lifetime.
+   * @param {Object} options
+   * @param {Request|string} options.request Either a
+   *     [`Request`]{@link https://developer.mozilla.org/en-US/docs/Web/API/Request}
+   *     object, or a string URL, corresponding to the request to be made.
+   * @param {FetchEvent} [options.event] If provided, `event.waitUntil()` will
+   *     be called automatically to extend the service worker's lifetime.
    * @return {Promise<Response>}
    */
   async makeRequest({event, request}) {

--- a/packages/workbox-strategies/StaleWhileRevalidate.mjs
+++ b/packages/workbox-strategies/StaleWhileRevalidate.mjs
@@ -129,14 +129,15 @@ class StaleWhileRevalidate {
       });
     }
 
-    const fetchAndCachePromise = this._getFromNetwork(request, event);
+    const fetchAndCachePromise = this._getFromNetwork({request, event});
 
-    let response = await cacheWrapper.match(
-      this._cacheName,
+    let response = await cacheWrapper.match({
+      cacheName: this._cacheName,
       request,
-      this._matchOptions,
-      this._plugins
-    );
+      event,
+      matchOptions: this._matchOptions,
+      plugins: this._plugins,
+    });
 
     if (response) {
       if (process.env.NODE_ENV !== 'production') {
@@ -176,26 +177,28 @@ class StaleWhileRevalidate {
   }
 
   /**
-   * @param {Request} request
-   * @param {FetchEvent} [event]
+   * @param {Object} options
+   * @param {Request} options.request
+   * @param {Event} [options.event]
    * @return {Promise<Response>}
    *
    * @private
    */
-  async _getFromNetwork(request, event) {
-    const response = await fetchWrapper.fetch(
+  async _getFromNetwork({request, event}) {
+    const response = await fetchWrapper.fetch({
       request,
-      this._fetchOptions,
-      this._plugins,
-      event ? event.preloadResponse : undefined
-    );
+      event,
+      fetchOptions: this._fetchOptions,
+      plugins: this._plugins,
+    });
 
-    const cachePutPromise = cacheWrapper.put(
-      this._cacheName,
+    const cachePutPromise = cacheWrapper.put({
+      cacheName: this._cacheName,
       request,
-      response.clone(),
-      this._plugins
-    );
+      response: response.clone(),
+      event,
+      plugins: this._plugins,
+    });
 
     if (event) {
       try {

--- a/packages/workbox-strategies/plugins/cacheOkAndOpaquePlugin.mjs
+++ b/packages/workbox-strategies/plugins/cacheOkAndOpaquePlugin.mjs
@@ -20,8 +20,8 @@ export default {
    * Return return a response (i.e. allow caching) if the
    * response is ok (i.e. 200) or is opaque.
    *
-   * @param {Object} input
-   * @param {Response} input.response
+   * @param {Object} options
+   * @param {Response} options.response
    * @return {Response|null}
    *
    * @private

--- a/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
@@ -454,14 +454,14 @@ describe(`[workbox-precaching] PrecacheController`, function() {
         plugins: testPlugins,
       });
 
-      expect(fetchWrapper.fetch.args[0][2]).to.equal(testPlugins);
-      expect(cacheWrapper.put.args[0][3]).to.equal(testPlugins);
+      expect(fetchWrapper.fetch.args[0][0].plugins).to.equal(testPlugins);
+      expect(cacheWrapper.put.args[0][0].plugins).to.equal(testPlugins);
 
       await precacheController.activate({
         plugins: testPlugins,
       });
 
-      expect(cacheWrapper.put.args[1][3]).to.equal(testPlugins);
+      expect(cacheWrapper.put.args[1][0].plugins).to.equal(testPlugins);
     });
 
     it(`it should set credentials: 'same-origin' on the precaching requests`, async function() {
@@ -475,7 +475,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
 
       await precacheController.install();
 
-      const request = fetchWrapper.fetch.args[0][0];
+      const {request} = fetchWrapper.fetch.args[0][0];
       expect(request.credentials).to.eql('same-origin');
     });
   });


### PR DESCRIPTION
Fixes #1639. 

This PR implements the proposal in #1639 by updating the fetch and catch wrappers as well as the strategies (and other code) that calls them. It also removes the `preloadResponse` option passed to the fetch wrapper, since that can now be found on the fetch event (@jeffposnick can you confirm that's okay?).

In addition, I noticed we're being inconsistent in how we refer to restructured parameters in our JSDoc comments (`options` vs `input`), so, since I was already updating some, I decided to change all instances of `input` to `options`.
