### PR TITLE
Use purgeOnQuotaError in integration test

### DIFF
--- a/test/workbox-cache-expiration/static/expiration-plugin/sw-deletion.js
+++ b/test/workbox-cache-expiration/static/expiration-plugin/sw-deletion.js
@@ -6,6 +6,7 @@ importScripts('/infra/testing/comlink/sw-interface.js');
 
 const expirationPlugin = new workbox.expiration.Plugin({
   maxEntries: 1,
+  purgeOnQuotaError: true,
 });
 
 const cacheName = 'expiration-plugin-deletion';


### PR DESCRIPTION
R: @philipwalton 

This would catch https://github.com/GoogleChrome/workbox/issues/1642 the next time around by making sure we use that export in the final bundle in an integration test.

(The actual behavior for `purgeOnQuotaError` is tested in the unit tests.)