### PR TITLE
Fixes workbox dependencies

### DIFF
--- a/packages/workbox-webpack-plugin/package-lock.json
+++ b/packages/workbox-webpack-plugin/package-lock.json
@@ -1,7 +1,23 @@
 {
-	"requires": true,
+	"name": "workbox-webpack-plugin",
+	"version": "3.6.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"requires": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			}
+		},
+		"core-js": {
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -14,6 +30,11 @@
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
 			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		}
 	}
 }

--- a/packages/workbox-webpack-plugin/package.json
+++ b/packages/workbox-webpack-plugin/package.json
@@ -28,6 +28,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "json-stable-stringify": "^1.0.1",
     "workbox-build": "^3.6.1"
   },


### PR DESCRIPTION
cc @jeffposnick @philipwalton (didn't open an issue since both the problem and fix are relatively straightforwards)

*Description of what's changed/fixed.*
The `workbox-webpack-plugin` is trying to access the `babel-runtime` package, which isn't declared in its dependencies. As a result package managers offer no guarantee as to which version will be provided, or even if `babel-runtime` will be installed at all.

This diff simply adds the dependency that's missing, based on what I found in the `package-lock.json` at the root of the repository.