### PR TITLE
Precache manifest.json by default when using the webpack plugin

### DIFF
--- a/packages/workbox-webpack-plugin/src/lib/get-default-config.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-default-config.js
@@ -24,8 +24,8 @@ module.exports = () => ({
   exclude: [
     // Exclude source maps.
     /\.map$/,
-    // Exclude anything starting with manifest and ending .js or .json.
-    /^manifest.*\.js(?:on)?$/,
+    // Exclude anything starting with manifest and ending .js.
+    /^manifest.*\.js?$/,
   ],
   excludeChunks: [],
   importsDirectory: '',

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -894,8 +894,8 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
   });
 
   describe(`[workbox-webpack-plugin] Filtering via test/include/exclude`, function() {
-    it(`should exclude .map and manifest.js(on) files by default`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.7ec1d7f443d1e8c881bf93fee037495a.js';
+    it(`should exclude .map and manifest.js files by default`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.6baa7f185013b0f515babaf6ea5f3ec3.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -946,6 +946,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           }, {
             revision: 'aef75af28f6de0771a8d6bae84d9e71d',
             url: 'not-ignored.js',
+          }, {
+            revision: '4b1eb3dc48c4e16d49db5b42298fe654',
+            url: 'manifest.json',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -1054,8 +1054,8 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
   });
 
   describe(`[workbox-webpack-plugin] Filtering via test/include/exclude`, function() {
-    it(`should exclude .map and manifest.js(on) files by default`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.7ec1d7f443d1e8c881bf93fee037495a.js';
+    it(`should exclude .map and manifest.js files by default`, function(done) {
+      const FILE_MANIFEST_NAME = 'precache-manifest.6baa7f185013b0f515babaf6ea5f3ec3.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1108,6 +1108,9 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           }, {
             revision: 'aef75af28f6de0771a8d6bae84d9e71d',
             url: 'not-ignored.js',
+          }, {
+            revision: '4b1eb3dc48c4e16d49db5b42298fe654',
+            url: 'manifest.json',
           }];
           expect(context.self.__precacheManifest).to.eql(expectedEntries);
 


### PR DESCRIPTION
R: @philipwalton

Fixes #1665 

We no longer will match `manifest.json` in `workbox-webpack-plugin`'s default list of patterns to filter out.
