### PR TITLE
Cleanup publishing for next branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ workbox-*.json
 docs
 local-builds/
 firebase-debug.log
+.firebase

--- a/demos/functions/cdn-details.json
+++ b/demos/functions/cdn-details.json
@@ -1,1 +1,1 @@
-{"latestUrl":"https://storage.googleapis.com/workbox-cdn/releases/3.6.2"}
+{"latestUrl":"https://storage.googleapis.com/workbox-cdn/releases/4.0.0-alpha.0"}

--- a/gulp-tasks/publish-cdn.js
+++ b/gulp-tasks/publish-cdn.js
@@ -46,7 +46,7 @@ const handleCDNUpload = async (tagName, gitBranch) => {
   const publishUrls = await cdnUploadHelper.upload(
       friendlyTagName, buildFilesDir);
 
-  logHelper.log(`The following URLs are now avaiable:`);
+  logHelper.log(`The following URLs are now available:`);
   publishUrls.forEach((url) => {
     // Only print out the js files just for cleaner logs.
     if (path.extname(url) === '.map') {

--- a/gulp-tasks/utils/cdn-helper.js
+++ b/gulp-tasks/utils/cdn-helper.js
@@ -83,7 +83,7 @@ class CDNHelper {
     for (const filePath of filePaths) {
       const destination =
         `${this._getReleaseTagPath(tagName)}/${path.basename(filePath)}`;
-        
+
       try {
         await bucket.upload(filePath, {
           destination,

--- a/gulp-tasks/utils/cdn-helper.js
+++ b/gulp-tasks/utils/cdn-helper.js
@@ -10,7 +10,7 @@ const {oneLine} = require('common-tags');
 const fs = require('fs-extra');
 const glob = require('glob');
 const path = require('path');
-const storage = require('@google-cloud/storage');
+const {Storage} = require('@google-cloud/storage');
 
 const cdnDetails = require('../../cdn-details.json');
 const logHelper = require('../../infra/utils/log-helper');
@@ -44,7 +44,7 @@ class CDNHelper {
         throw new Error(errorMessage);
       }
 
-      this._gcs = storage({
+      this._gcs = new Storage({
         projectId: PROJECT_ID,
         keyFilename: SERVICE_ACCOUNT_PATH,
       });
@@ -83,7 +83,7 @@ class CDNHelper {
     for (const filePath of filePaths) {
       const destination =
         `${this._getReleaseTagPath(tagName)}/${path.basename(filePath)}`;
-
+        
       try {
         await bucket.upload(filePath, {
           destination,

--- a/gulp-tasks/utils/publish-helpers.js
+++ b/gulp-tasks/utils/publish-helpers.js
@@ -13,7 +13,7 @@ const archiver = require('archiver');
 const oneLine = require('common-tags').oneLine;
 
 const constants = require('./constants');
-const {getPackages} = require('./get-packages');
+const {outputFilenameToPkgMap} = require('./output-filename-to-package-map');
 const logHelper = require('../../infra/utils/log-helper');
 const spawn = require('./spawn-promise-wrapper');
 
@@ -106,10 +106,8 @@ const groupBuildFiles = async (tagName, gitBranch) => {
 
     const sourceCodePath = path.join(getBuildPath(tagName), SOURCE_CODE_DIR);
 
-    const browserPackages = getPackages({
-      type: 'browser',
-      root: sourceCodePath,
-    });
+    const browserPackages = Object.values(outputFilenameToPkgMap)
+        .map((item) => item.name);
 
     const pattern = path.posix.join(
         sourceCodePath, 'packages', `{${browserPackages.join(',')}}`,


### PR DESCRIPTION
R: @philipwalton

Fixes some issues with the `gulp publish-assets` command in the `next` branch.
