### PR TITLE
DBWrapper updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16451,8 +16451,8 @@
       "dev": true
     },
     "shelving-mock-indexeddb": {
-      "version": "github:philipwalton/shelving-mock-indexeddb#d2c5e52b6f9903026f5bac31cbe758cbebd98661",
-      "from": "github:philipwalton/shelving-mock-indexeddb#d2c5e52b6f9903026f5bac31cbe758cbebd98661",
+      "version": "github:philipwalton/shelving-mock-indexeddb#4cf22cfcd464cbae648ebbe73268c2a72e110ad6",
+      "from": "github:philipwalton/shelving-mock-indexeddb#4cf22cfcd464cbae648ebbe73268c2a72e110ad6",
       "dev": true,
       "requires": {
         "shelving-mock-event": "^1.0.8"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "semver": "^5.5.1",
     "serve-index": "^1.9.1",
     "service-worker-mock": "^1.9.3",
-    "shelving-mock-indexeddb": "github:philipwalton/shelving-mock-indexeddb#d2c5e52b6f9903026f5bac31cbe758cbebd98661",
+    "shelving-mock-indexeddb": "github:philipwalton/shelving-mock-indexeddb#4cf22cfcd464cbae648ebbe73268c2a72e110ad6",
     "sinon": "^6.3.4",
     "tempy": "^0.2.1",
     "url-search-params": "^1.1.0",

--- a/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
+++ b/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
@@ -7,6 +7,7 @@
 */
 
 import {DBWrapper} from 'workbox-core/_private/DBWrapper.mjs';
+import {deleteDatabase} from 'workbox-core/_private/deleteDatabase.mjs';
 import '../_version.mjs';
 
 const URL_KEY = 'url';
@@ -108,7 +109,7 @@ class CacheTimestampsModel {
    * Removes the underlying IndexedDB object store entirely.
    */
   async delete() {
-    await this._db.deleteDatabase();
+    await deleteDatabase(this._cacheName);
     this._db = null;
   }
 }

--- a/packages/workbox-core/_private.mjs
+++ b/packages/workbox-core/_private.mjs
@@ -8,6 +8,7 @@
 
 // We either expose defaults or we expose every named export.
 import {DBWrapper} from './_private/DBWrapper.mjs';
+import {deleteDatabase} from './_private/deleteDatabase.mjs';
 import {WorkboxError} from './_private/WorkboxError.mjs';
 import {assert} from './_private/assert.mjs';
 import {cacheNames} from './_private/cacheNames.mjs';
@@ -20,6 +21,7 @@ import './_version.mjs';
 
 export {
   DBWrapper,
+  deleteDatabase,
   WorkboxError,
   assert,
   cacheNames,

--- a/packages/workbox-core/_private/deleteDatabase.mjs
+++ b/packages/workbox-core/_private/deleteDatabase.mjs
@@ -1,0 +1,34 @@
+/*
+  Copyright 2018 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import '../_version.mjs';
+
+
+/**
+ * Deletes the database.
+ * Note: this is exported separately from the DBWrapper module because most
+ * usages of IndexedDB in workbox dont need deleting, and this way it can be
+ * reused in tests to delete databases without creating DBWrapper instances.
+ *
+ * @param {string} name The database name.
+ * @private
+ */
+export const deleteDatabase = async (name) => {
+  await new Promise((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onerror = ({target}) => {
+      reject(target.error);
+    };
+    request.onblocked = () => {
+      reject(new Error('Delete blocked'));
+    };
+    request.onsuccess = () => {
+      resolve();
+    };
+  });
+};

--- a/test/workbox-core/node/_private/test-DBWrapper.mjs
+++ b/test/workbox-core/node/_private/test-DBWrapper.mjs
@@ -6,21 +6,40 @@
   https://opensource.org/licenses/MIT.
 */
 
-import {reset} from 'shelving-mock-indexeddb';
 import {expect} from 'chai';
 import sinon from 'sinon';
-
 import {DBWrapper} from '../../../../packages/workbox-core/_private/DBWrapper.mjs';
+import {deleteDatabase} from '../../../../packages/workbox-core/_private/deleteDatabase.mjs';
 
 
 const catchAsyncError = async (promiseOrFn) => {
+  // Hack alert! Since Mocha will fail any test if it sees an uncaughtException,
+  // we have to remove all listeners added to the process if we want to test
+  // that an uncaughtException is thrown.
+  const listeners = process.listeners('uncaughtException');
+  process.removeAllListeners('uncaughtException');
+
+  const uncaughtExceptionPromise = new Promise((resolve, reject) => {
+    process.once('uncaughtException', (error) => reject(error));
+  });
+
+  const asyncErrorPromise = typeof promiseOrFn === 'function' ?
+      promiseOrFn() : promiseOrFn;
+
   try {
-    await (typeof promiseOrFn === 'function' ? promiseOrFn() : promiseOrFn);
-    throw new Error('Expected error never thrown');
-  } catch (err) {
-    return err;
+    await Promise.race([uncaughtExceptionPromise, asyncErrorPromise]);
+    return;
+  } catch (error) {
+    return error;
+  } finally {
+    // Re-add the listeners so everything goes back to normal.
+    for (const listener of listeners) {
+      process.on('uncaughtException', listener);
+    }
   }
 };
+
+const sandbox = sinon.createSandbox();
 
 const data = {
   // keyPath: email, index: email (unique)
@@ -70,7 +89,7 @@ const data = {
 };
 
 const createTestDb = async () => {
-  return await new DBWrapper('db', 1, {
+  const db = new DBWrapper('db', 1, {
     onupgradeneeded: (evt) => {
       const db = evt.target.result;
       db.createObjectStore('users', {keyPath: 'email'});
@@ -84,27 +103,34 @@ const createTestDb = async () => {
       commentsStore.createIndex('postId', 'postId', {unique: false});
     },
   });
+
+  await db.open();
+  return db;
 };
 
 const createAndPopulateTestDb = async () => {
   const db = await createTestDb();
-
-  await db.transaction(Object.keys(data), 'readwrite', (stores) => {
+  await db.transaction(Object.keys(data), 'readwrite', (txn) => {
     for (const [storeName, storeEntries] of Object.entries(data)) {
+      const store = txn.objectStore(storeName);
       for (const entry of storeEntries) {
-        stores[storeName].add(entry);
+        store.add(entry);
       }
     }
   });
   return db;
 };
 
-describe(`DBWrapper`, function() {
-  const sandbox = sinon.createSandbox();
 
-  afterEach(async function() {
+describe(`DBWrapper`, function() {
+  beforeEach(async function() {
+    // This help when re-running the tests manually after a previous failure
+    // where the database didn't get properly closed/deleted.
+    const db = await new DBWrapper('db', 999).open();
+    db.close();
+    await deleteDatabase('db');
+
     sandbox.restore();
-    reset();
   });
 
   describe(`constructor`, function() {
@@ -114,7 +140,8 @@ describe(`DBWrapper`, function() {
       expect(db._name).to.equal('db');
       expect(db._version).to.equal(1);
       expect(db._onupgradeneeded).to.be.undefined;
-      expect(db._onversionchange).to.equal(DBWrapper.prototype._onversionchange);
+      expect(db._onversionchange).to.equal(
+          DBWrapper.prototype._onversionchange);
     });
 
     it('lets you specify callbacks', function() {
@@ -154,75 +181,131 @@ describe(`DBWrapper`, function() {
       }))).to.be.true;
     });
 
+    it(`can upgrade from a lower (non-zero) version`, async function() {
+      const db = await createAndPopulateTestDb();
+      await db.close();
+
+      const dbv2 = new DBWrapper('db', 2, {
+        onupgradeneeded: (evt) => {
+          if (evt.oldVersion === 1 && evt.newVersion === 2) {
+            const db = evt.target.result;
+            const txn = evt.target.transaction;
+
+            const objStore = txn.objectStore('users');
+            objStore.get().onsuccess = (event) => {
+              const firstUser = event.target.result;
+              // Delete the object store and recreate it with new config.
+              db.deleteObjectStore('users');
+              db.createObjectStore('users', {
+                keyPath: 'id',
+                autoIncrement: true,
+              });
+              objStore.add(firstUser);
+            };
+          }
+        },
+      });
+
+      await dbv2.open();
+    });
+
     it(`sets the onversionchange callback`, async function() {
       const onversionchange = () => {};
+
       const db = await new DBWrapper('db', 1, {onversionchange}).open();
 
       expect(db._db.onversionchange).to.equal(db._onversionchange);
+
+      // Make sure to close the DB manually since we're overwriting the
+      // onversionchange callback (which usually closes the DB).
+      db.close();
     });
 
-    // Note: doesn't work in node
-    it.skip(`throws if there's an error opening the connection`, async function() {
+    it(`throws if there's an error opening the connection`, async function() {
       await new DBWrapper('db', 2).open();
 
       // Stop the event from bubbling to the global object
       // and firing the global onerror handler.
       // https://github.com/w3c/IndexedDB/issues/49
-      sandbox.stub(self, 'onerror');
+      if ('onerror' in self) {
+        sandbox.stub(self, 'onerror');
+      }
 
       const err = await catchAsyncError(new DBWrapper('db', 1).open());
-      expect(err.message).to.match(/version/);
+
+      expect(err).to.not.be.undefined;
+      expect(err.name).to.equal('VersionError');
     });
 
-    it(`throws if blocked for more than the timeout period when openning`,
-        async function() {
-          // Lessen the open timeout to make the tests faster.
-          sandbox.stub(DBWrapper.prototype, 'OPEN_TIMEOUT').value(100);
+    it(`throws if blocked for more than the timeout period when openning`, async function() {
+      // Lessen the open timeout to make the tests faster.
+      sandbox.stub(DBWrapper.prototype, 'OPEN_TIMEOUT').value(100);
 
-          // Open a connection and don't close it on version change.
-          await new DBWrapper('db', 1, {onversionchange: () => {}}).open();
+      // Open a connection and don't close it on version change.
+      const db = await new DBWrapper('db', 1, {
+        onversionchange: () => {},
+      }).open();
 
-          // Open a request for a new version with an old version still open.
-          // This will be blocked since the older version is still open.
-          const err = await catchAsyncError(new DBWrapper('db', 2).open());
-          expect(err.message).to.match(/blocked/);
-        });
+      // Open a request for a new version with an old version still open.
+      // This will be blocked since the older version is still open.
+      const err = await catchAsyncError(new DBWrapper('db', 2).open());
+      expect(err.message).to.match(/blocked/);
 
-    it(`times out even in cases where the onblocked handler doesn't file`,
-        async function() {
-          // Lessen the open timeout to make the tests faster.
-          sandbox.stub(DBWrapper.prototype, 'OPEN_TIMEOUT').value(100);
+      // Make sure to close the DB manually since we're overwriting the
+      // onversionchange callback (which usually closes the DB).
+      db.close();
+    });
 
-          // Open a connection and don't close it on version change.
-          await new DBWrapper('db', 1, {onversionchange: () => {}}).open();
+    it(`times out even in cases where the onblocked handler doesn't file`, async function() {
+      // Lessen the open timeout to make the tests faster.
+      sandbox.stub(DBWrapper.prototype, 'OPEN_TIMEOUT').value(100);
 
-          // Open two requests for newer versions while the old version is open.
-          // The first request will received the `blocked` event, but the second
-          // request will not received any event entil the first request is
-          // processed. In the event that the first request never gets unblocked,
-          // the second request will never get an event. This test asserts that
-          // both requests reject after a timeout period.
-          const err1 = await catchAsyncError(new DBWrapper('db', 2).open());
-          const err2 = await catchAsyncError(new DBWrapper('db', 2).open());
-          expect(err1.message).to.match(/blocked/);
-          expect(err2.message).to.match(/blocked/);
-        });
+      // Open a connection and don't close it on version change.
+      const db = await new DBWrapper('db', 1, {
+        onversionchange: () => {},
+      }).open();
+
+      // Open two requests for newer versions while the old version is open.
+      // The first request will received the `blocked` event, but the second
+      // request will not received any event entil the first request is
+      // processed. In the event that the first request never gets unblocked,
+      // the second request will never get an event. This test asserts that
+      // both requests reject after a timeout period.
+      const err1 = await catchAsyncError(new DBWrapper('db', 2).open());
+      const err2 = await catchAsyncError(new DBWrapper('db', 2).open());
+      expect(err1.message).to.match(/blocked/);
+      expect(err2.message).to.match(/blocked/);
+
+      // Make sure to close the DB manually since we're overwriting the
+      // onversionchange callback (which usually closes the DB).
+      db.close();
+    });
+  });
+
+  describe(`get db`, function() {
+    it(`returns the IDBDatabase object (after it's first openned)`, async function() {
+      const db = await createTestDb();
+      await db.open();
+
+      expect(db.db).to.be.an.instanceOf(IDBDatabase);
+      expect(db.db.name).to.equal(db._name);
+      expect(db.db.version).to.equal(db._version);
+    });
   });
 
   describe(`get`, function() {
-    it(`gets an entry from the object store for the passed key`,
-        async function() {
-          const db = await createAndPopulateTestDb();
+    it(`gets an entry from the object store for the passed key`, async function() {
+      const db = await createAndPopulateTestDb();
 
-          const user = await db.get('users', data.users[0].email);
-          expect(user).to.deep.equal(data.users[0]);
+      const user = await db.get('users', data.users[0].email);
+      expect(user).to.deep.equal(data.users[0]);
 
-          const post = await db.get('posts', 1); // From autoIncrement-ed key
-          expect(post).to.deep.equal(data.posts[0]);
+      const post = await db.get('posts', 1); // From autoIncrement-ed key
+      expect(post).to.deep.equal(data.posts[0]);
 
-          const comment = await db.get('comments', 1); // From autoIncrement-ed key
-          expect(comment).to.deep.equal(data.comments[0]);
-        });
+      const comment = await db.get('comments', 1); // From autoIncrement-ed key
+      expect(comment).to.deep.equal(data.comments[0]);
+    });
 
     it(`returns undefined if no entry is found`, async function() {
       const db = await createAndPopulateTestDb();
@@ -233,52 +316,49 @@ describe(`DBWrapper`, function() {
   });
 
   describe(`add`, function() {
-    it(`adds an entry to an object store and returns the key`,
-        async function() {
-          const db = await createTestDb();
+    it(`adds an entry to an object store and returns the key`, async function() {
+      const db = await createTestDb();
 
-          // Test an entry with an explicit key.
-          const userKey = await db.add('users', data.users[0]);
-          expect(userKey).to.equal(data.users[0].email);
+      // Test an entry with an explicit key.
+      const userKey = await db.add('users', data.users[0]);
+      expect(userKey).to.equal(data.users[0].email);
 
-          // Test an entry in a store with auto-incrementing keys.
-          const postKey = await db.add('posts', data.posts[0]);
-          expect(postKey).to.equal(1);
+      // Test an entry in a store with auto-incrementing keys.
+      const postKey = await db.add('posts', data.posts[0]);
+      expect(postKey).to.equal(1);
 
-          // Test adding more than one entry to the same store.
-          const commentKey1 = await db.add('comments', data.comments[0]);
-          const commentKey2 = await db.add('comments', data.comments[1]);
-          expect(commentKey1).to.equal(1);
-          expect(commentKey2).to.equal(2);
-        });
+      // Test adding more than one entry to the same store.
+      const commentKey1 = await db.add('comments', data.comments[0]);
+      const commentKey2 = await db.add('comments', data.comments[1]);
+      expect(commentKey1).to.equal(1);
+      expect(commentKey2).to.equal(2);
+    });
 
-    it(`throws if a value already exists for the specified key`,
-        async function() {
-          const db = await createAndPopulateTestDb();
+    it(`throws if a value already exists for the specified key`, async function() {
+      const db = await createAndPopulateTestDb();
 
-          expect(await catchAsyncError(db.add('users', data.users[0]))).to.be.ok;
-        });
+      expect(await catchAsyncError(db.add('users', data.users[0]))).to.be.ok;
+    });
   });
 
   describe(`put`, function() {
-    it(`puts an entry to an object store and returns the key`,
-        async function() {
-          const db = await createTestDb();
+    it(`puts an entry to an object store and returns the key`, async function() {
+      const db = await createTestDb();
 
-          // Test an entry with an explicit key.
-          const userKey = await db.put('users', data.users[0]);
-          expect(userKey).to.equal(data.users[0].email);
+      // Test an entry with an explicit key.
+      const userKey = await db.put('users', data.users[0]);
+      expect(userKey).to.equal(data.users[0].email);
 
-          // Test an entry in a store with auto-incrementing keys.
-          const postKey = await db.put('posts', data.posts[0]);
-          expect(postKey).to.equal(1);
+      // Test an entry in a store with auto-incrementing keys.
+      const postKey = await db.put('posts', data.posts[0]);
+      expect(postKey).to.equal(1);
 
-          // Test adding more than one entry to the same store.
-          const commentKey1 = await db.put('comments', data.comments[0]);
-          const commentKey2 = await db.put('comments', data.comments[1]);
-          expect(commentKey1).to.equal(1);
-          expect(commentKey2).to.equal(2);
-        });
+      // Test adding more than one entry to the same store.
+      const commentKey1 = await db.put('comments', data.comments[0]);
+      const commentKey2 = await db.put('comments', data.comments[1]);
+      expect(commentKey1).to.equal(1);
+      expect(commentKey2).to.equal(2);
+    });
 
     it(`overrides existing values for the specified key`, async function() {
       const db = await createAndPopulateTestDb();
@@ -305,6 +385,29 @@ describe(`DBWrapper`, function() {
     });
   });
 
+  describe(`count`, function() {
+    it(`returns the number of entries in an object store`, async function() {
+      const db = await createAndPopulateTestDb();
+
+      const count = await db.count('users');
+      expect(count).to.equal(data.users.length);
+    });
+  });
+
+  describe(`clear`, function() {
+    it(`clears all entries from an object store`, async function() {
+      const db = await createAndPopulateTestDb();
+
+      const users = await db.getAll('users');
+      expect(users).to.deep.equal(data.users);
+
+      await db.clear('users');
+
+      const usersLeft = await db.getAll('users');
+      expect(usersLeft).to.deep.equal([]);
+    });
+  });
+
   describe(`delete`, function() {
     it(`deletes an entry from an object store`, async function() {
       const db = await createAndPopulateTestDb();
@@ -316,6 +419,22 @@ describe(`DBWrapper`, function() {
 
       const usersLeft = await db.getAll('users');
       expect(usersLeft).to.deep.equal(data.users.slice(1));
+    });
+  });
+
+  describe(`getKey`, function() {
+    it(`returns the key of the first matching entry for the query`, async function() {
+      const db = await createAndPopulateTestDb();
+
+      const userKey = await db.getKey('users', IDBKeyRange.bound('i', 'k'));
+      expect(userKey).to.deep.equal(data.users[1].email);
+    });
+
+    it(`returns undefined if no key is found`, async function() {
+      const db = await createAndPopulateTestDb();
+
+      const userKey = await db.getKey('users', IDBKeyRange.bound('e', 'e'));
+      expect(userKey).to.deep.equal(undefined);
     });
   });
 
@@ -352,26 +471,47 @@ describe(`DBWrapper`, function() {
       expect(users1).to.deep.equal(data.users.slice(0, 1));
       expect(users2).to.deep.equal(data.users.slice(0, 2));
     });
+  });
 
-    it(`uses a getAll polyfill when the native version isn't supported`,
-        async function() {
-          // Fake a browser without getAll support.
-          const originalGetAll = IDBObjectStore.prototype.getAll;
-          delete IDBObjectStore.prototype.getAll;
+  describe(`getAllKeys`, function() {
+    it(`returns the keys of all entries in an object store`, async function() {
+      const db = await createAndPopulateTestDb();
 
-          const db = await createAndPopulateTestDb();
+      const users = await db.getAllKeys('users');
+      expect(users).to.deep.equal(data.users.map(({email}) => email));
 
-          const users1 = await db.getAll('users', IDBKeyRange.bound('a', 'm'));
-          const users2 = await db.getAll('users', IDBKeyRange.bound('n', 'z'));
+      const posts = await db.getAllKeys('posts');
+      expect(posts).to.deep.equal([1, 2, 3, 4, 5, 6]);
 
-          expect(users1).to.deep.equal(data.users.slice(0, 2));
-          expect(users2).to.deep.equal(data.users.slice(2));
+      const comments = await db.getAllKeys('comments');
+      expect(comments).to.deep.equal([1, 2, 3, 4, 5]);
+    });
 
-          // Restore getAll.
-          if (originalGetAll) {
-            IDBObjectStore.prototype.getAll = originalGetAll;
-          }
-        });
+    it(`supports an optional query parameter`, async function() {
+      const db = await createAndPopulateTestDb();
+
+      const users1 = await db.getAllKeys('users', IDBKeyRange.bound('a', 'm'));
+      const users2 = await db.getAllKeys('users', IDBKeyRange.bound('n', 'z'));
+
+      expect(users1).to.deep.equal(
+          data.users.slice(0, 2).map(({email}) => email));
+      expect(users2).to.deep.equal(
+          data.users.slice(2).map(({email}) => email));
+    });
+
+    it(`supports an optional count parameter`, async function() {
+      const db = await createAndPopulateTestDb();
+
+      const users1 = await db.getAllKeys(
+          'users', IDBKeyRange.bound('a', 'z'), 1);
+      const users2 = await db.getAllKeys(
+          'users', IDBKeyRange.bound('a', 'z'), 2);
+
+      expect(users1).to.deep.equal(
+          data.users.slice(0, 1).map(({email}) => email));
+      expect(users2).to.deep.equal(
+          data.users.slice(0, 2).map(({email}) => email));
+    });
   });
 
   describe(`getAllMatching`, function() {
@@ -424,64 +564,37 @@ describe(`DBWrapper`, function() {
   });
 
   describe(`transaction`, function() {
-    it(`performs a transaction on the specified object stores`,
-        async function() {
-          const db = await createTestDb();
+    it(`performs a transaction on the specified object stores`, async function() {
+      const db = await createTestDb();
 
-          await db.transaction(['users', 'posts'], 'readwrite', (stores) => {
-            stores.users.add(data.users[0]);
-            stores.posts.add(data.posts[0]);
-          });
+      await db.transaction(['users', 'posts'], 'readwrite', (txn) => {
+        txn.objectStore('users').add(data.users[0]);
+        txn.objectStore('posts').add(data.posts[0]);
+      });
 
-          const users = await db.getAll('users');
-          const posts = await db.getAll('posts');
+      const users = await db.getAll('users');
+      const posts = await db.getAll('posts');
 
-          expect(users).to.deep.equal(data.users.slice(0, 1));
-          expect(posts).to.deep.equal(data.posts.slice(0, 1));
-        });
+      expect(users).to.deep.equal(data.users.slice(0, 1));
+      expect(posts).to.deep.equal(data.posts.slice(0, 1));
+    });
 
-    it(`provides a 'complete' function to resolve a transaction with a value`,
-        async function() {
-          const db = await createAndPopulateTestDb();
+    it(`provides a 'done' function to resolve a transaction with a value`, async function() {
+      const db = await createAndPopulateTestDb();
 
-          // Gets the most recent comment from a particular user
-          const comment = await db.transaction(['comments'], 'readwrite',
-              (stores, complete) => {
-                const postIdIndex = stores.comments.index('userEmail');
-                postIdIndex
-                    .openCursor(IDBKeyRange.only(data.users[0].email), 'prev')
-                    .onsuccess = (evt) => {
-                      const cursor = evt.target.result;
-                      complete(cursor ? cursor.value : null);
-                    };
-              });
-          expect(comment).to.deep.equal(data.comments[4]);
-        });
-
-    it(`provides an 'abort' function to manually abort a transaction`,
-        async function() {
-          const db = await createTestDb();
-
-          const err = await catchAsyncError(db.transaction(
-              ['posts', 'comments'], 'readwrite', (stores, complete, abort) => {
-                stores.posts.add(data.posts[0]).onsuccess = (evt) => {
-                  const postId = evt.target.result;
-                  stores.comments.add({postId}).onsuccess = (evt) => {
-                    // Abort if the new key is less than 10 (which should be true).
-                    if (evt.target.result < 10) {
-                      abort();
-                    }
-                  };
+      // Gets the most recent comment from a particular user
+      const comment = await db.transaction(['comments'], 'readwrite',
+          (txn, done) => {
+            const postIdIndex = txn.objectStore('comments').index('userEmail');
+            postIdIndex
+                .openCursor(IDBKeyRange.only(data.users[0].email), 'prev')
+                .onsuccess = (evt) => {
+                  const cursor = evt.target.result;
+                  done(cursor ? cursor.value : null);
                 };
-              }));
-          expect(err.message).to.match(/abort/);
-
-          // Assert the added post and comment were rolled back.
-          const posts = await db.getAll('posts');
-          expect(posts).to.have.lengthOf(0);
-          const comments = await db.getAll('comments');
-          expect(comments).to.have.lengthOf(0);
-        });
+          });
+      expect(comment).to.deep.equal(data.comments[4]);
+    });
 
     it(`throws if the transaction fails`, async function() {
       const db = await createAndPopulateTestDb();
@@ -489,22 +602,21 @@ describe(`DBWrapper`, function() {
       // Stop the event from bubbling to the global object
       // and firing the global onerror handler.
       // https://github.com/w3c/IndexedDB/issues/49
-      // sandbox.stub(self, 'onerror');
+      if ('onerror' in self) {
+        sandbox.stub(self, 'onerror');
+      }
 
       const err = await catchAsyncError(db.transaction(
-          ['users'], 'readwrite', (stores) => {
+          ['users'], 'readwrite', (txn) => {
             // This should fail because the key is already set.
-            stores.users.add(data.users[0]);
+            txn.objectStore('users').add(data.users[0]);
           }));
-      expect(err).to.have.property('message');
+      expect(err).to.not.be.undefined;
     });
   });
 
   describe(`close`, function() {
-    // TODO(philipwalton): shelving-mock-indexeddb doesn't define a prototype
-    // for IDBDatabase, so we can't spy on it here, but this passes in
-    // browser tests.
-    it.skip(`closes a connection to a database`, async function() {
+    it(`closes a connection to a database`, async function() {
       sandbox.spy(IDBDatabase.prototype, 'close');
 
       const db = await createTestDb();
@@ -514,5 +626,34 @@ describe(`DBWrapper`, function() {
 
       expect(IDBDatabase.prototype.close.calledOnce).to.be.true;
     });
+  });
+});
+
+describe(`deleteDatabase`, function() {
+  beforeEach(async function() {
+    sandbox.restore();
+  });
+
+  it(`deletes a database`, async function() {
+    sandbox.spy(indexedDB, 'deleteDatabase');
+
+    await createTestDb();
+    await deleteDatabase('db');
+
+    expect(indexedDB.deleteDatabase.calledOnce).to.be.true;
+  });
+
+  it(`throws when an error occurs`, async function() {
+    const fakeError = new Error();
+    sandbox.stub(indexedDB, 'deleteDatabase').callsFake(() => {
+      const result = {};
+      // Asynchronously call onerror.
+      setTimeout(() => result.onerror({target: {error: fakeError}}), 0);
+      return result;
+    });
+
+    await createTestDb();
+    const err = await catchAsyncError(deleteDatabase('db'));
+    expect(err).to.equal(fakeError);
   });
 });


### PR DESCRIPTION
R: @jeffposnick 

As noted in https://github.com/GoogleChrome/workbox/pull/1510#issuecomment-396643575, the version of `DBWrapper` was slightly behind the version I was working to release separately (which ended up not happening after a decision to merge it with `idb` once the promise issue was resolved).

The up-to-date version has been tested against all browsers (including IE10 and Safari 10.1), and [already included](https://github.com/GoogleChrome/workbox/compare/next...db-wrapper-updates?expand=1#diff-5c1f717d7f769e925ffa201e42c73ce5R151) the fix from #1509.

Making this update required me to also [update to my fork](https://github.com/philipwalton/shelving-mock-indexeddb/commit/4cf22cfcd464cbae648ebbe73268c2a72e110ad6) of our IDB mocking library due to the following issues with the mocks:
- https://github.com/dhoulb/shelving-mock-indexeddb/issues/6
- https://github.com/dhoulb/shelving-mock-indexeddb/issues/7

But overall I'm more comfortable using the updated version of the DBWrapper library since I know it's better tested in real browsers. Also, it includes support for a few more IDB 2 features that are nice to have.