### PR TITLE
v4 Background Sync API updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16451,8 +16451,8 @@
       "dev": true
     },
     "shelving-mock-indexeddb": {
-      "version": "github:philipwalton/shelving-mock-indexeddb#4cf22cfcd464cbae648ebbe73268c2a72e110ad6",
-      "from": "github:philipwalton/shelving-mock-indexeddb#4cf22cfcd464cbae648ebbe73268c2a72e110ad6",
+      "version": "github:philipwalton/shelving-mock-indexeddb#621b7a275568051846d20e3e557fa1101418b1d1",
+      "from": "github:philipwalton/shelving-mock-indexeddb#621b7a275568051846d20e3e557fa1101418b1d1",
       "dev": true,
       "requires": {
         "shelving-mock-event": "^1.0.8"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "semver": "^5.5.1",
     "serve-index": "^1.9.1",
     "service-worker-mock": "^1.9.3",
-    "shelving-mock-indexeddb": "github:philipwalton/shelving-mock-indexeddb#4cf22cfcd464cbae648ebbe73268c2a72e110ad6",
+    "shelving-mock-indexeddb": "github:philipwalton/shelving-mock-indexeddb#621b7a275568051846d20e3e557fa1101418b1d1",
     "sinon": "^6.3.4",
     "tempy": "^0.2.1",
     "url-search-params": "^1.1.0",

--- a/packages/workbox-background-sync/Plugin.mjs
+++ b/packages/workbox-background-sync/Plugin.mjs
@@ -32,7 +32,7 @@ class Plugin {
    * @private
    */
   async fetchDidFail({request}) {
-    await this._queue.addRequest(request);
+    await this._queue.pushRequest({request});
   }
 }
 

--- a/packages/workbox-background-sync/Queue.mjs
+++ b/packages/workbox-background-sync/Queue.mjs
@@ -33,28 +33,15 @@ class Queue {
    *     in IndexedDB specific to this instance. An error will be thrown if
    *     a duplicate name is detected.
    * @param {Object} [options]
-   * @param {Object} [options.callbacks] Callbacks to observe the lifecycle of
-   *     queued requests. Use these to respond to or modify the requests
-   *     during the replay process.
-   * @param {function(StorableRequest):undefined}
-   *     [options.callbacks.requestWillEnqueue]
-   *     Invoked immediately before the request is stored to IndexedDB. Use
-   *     this callback to modify request data at store time.
-   * @param {function(StorableRequest):undefined}
-   *     [options.callbacks.requestWillReplay]
-   *     Invoked immediately before the request is re-fetched. Use this
-   *     callback to modify request data at fetch time.
-   * @param {function(Array<StorableRequest>):undefined}
-   *     [options.callbacks.queueDidReplay]
-   *     Invoked after all requests in the queue have successfully replayed.
-   * @param {number} [options.maxRetentionTime = 7 days] The amount of time (in
+   * @param {Function} [options.onSync] A function that gets invoked
+   *     with the queue instance whenever the 'sync' event fires. You can use
+   *     this callback to customize the replay behavior of the queue. When not
+   *     set the `replayRequests()` method is called.
+   * @param {number} [options.maxRetentionTime=7 days] The amount of time (in
    *     minutes) a request may be retried. After this amount of time has
    *     passed, the request will be deleted from the queue.
    */
-  constructor(name, {
-    callbacks = {},
-    maxRetentionTime = MAX_RETENTION_TIME,
-  } = {}) {
+  constructor(name, {onSync, maxRetentionTime} = {}) {
     // Ensure the store name is not already being used
     if (queueNames.has(name)) {
       throw new WorkboxError('duplicate-queue-name', {name});
@@ -63,9 +50,9 @@ class Queue {
     }
 
     this._name = name;
-    this._callbacks = callbacks;
-    this._maxRetentionTime = maxRetentionTime;
-    this._queueStore = new QueueStore(this);
+    this._onSync = onSync || this.replayRequests;
+    this._maxRetentionTime = maxRetentionTime || MAX_RETENTION_TIME;
+    this._queueStore = new QueueStore(this._name);
 
     this._addSyncListener();
   }
@@ -78,103 +65,199 @@ class Queue {
   }
 
   /**
-   * Stores the passed request into IndexedDB. The database used is
-   * `workbox-background-sync` and the object store name is the same as
-   * the name this instance was created with (to guarantee it's unique).
+   * Stores the passed request in IndexedDB (with its timestamp and any
+   * metadata) at the end of the queue.
    *
-   * @param {Request} request The request object to store.
+   * @param {Object} entry
+   * @param {Request} entry.request The request to store in the queue.
+   * @param {Object} [entry.metadata] Any metadata you want associated with the
+   *     stored request. When requests are replayed you'll have access to this
+   *     metadata object in case you need to modify the request beforehand.
+   * @param {number} [entry.timestamp] The timestamp (Epoch time in
+   *     milliseconds) when the request was first added to the queue. This is
+   *     used along with `maxRetentionTime` to remove outdated requests. In
+   *     general you don't need to set this value, as it's automatically set
+   *     for you (defaulting to `Date.now()`), but you can update it if you
+   *     don't want particular requests to expire.
    */
-  async addRequest(request) {
+  async pushRequest(entry) {
     if (process.env.NODE_ENV !== 'production') {
-      assert.isInstance(request, Request, {
+      assert.isType(entry, 'object', {
         moduleName: 'workbox-background-sync',
         className: 'Queue',
-        funcName: 'addRequest',
-        paramName: 'request',
+        funcName: 'pushRequest',
+        paramName: 'entry',
+      });
+      assert.isInstance(entry.request, Request, {
+        moduleName: 'workbox-background-sync',
+        className: 'Queue',
+        funcName: 'pushRequest',
+        paramName: 'entry.request',
       });
     }
 
-    const storableRequest = await StorableRequest.fromRequest(request.clone());
-    await this._runCallback('requestWillEnqueue', storableRequest);
-    await this._queueStore.addEntry(storableRequest);
-    await this._registerSync();
+    await this._addRequest(entry, 'push');
+  }
+
+  /**
+   * Stores the passed request in IndexedDB (with its timestamp and any
+   * metadata) at the beginning of the queue.
+   *
+   * @param {Object} entry
+   * @param {Request} entry.request The request to store in the queue.
+   * @param {Object} [entry.metadata] Any metadata you want associated with the
+   *     stored request. When requests are replayed you'll have access to this
+   *     metadata object in case you need to modify the request beforehand.
+   * @param {number} [entry.timestamp] The timestamp (Epoch time in
+   *     milliseconds) when the request was first added to the queue. This is
+   *     used along with `maxRetentionTime` to remove outdated requests. In
+   *     general you don't need to set this value, as it's automatically set
+   *     for you (defaulting to `Date.now()`), but you can update it if you
+   *     don't want particular requests to expire.
+   */
+  async unshiftRequest(entry) {
     if (process.env.NODE_ENV !== 'production') {
-      logger.log(`Request for '${getFriendlyURL(storableRequest.url)}' has been
-          added to background sync queue '${this._name}'.`);
+      assert.isType(entry, 'object', {
+        moduleName: 'workbox-background-sync',
+        className: 'Queue',
+        funcName: 'unshiftRequest',
+        paramName: 'entry',
+      });
+      assert.isInstance(entry.request, Request, {
+        moduleName: 'workbox-background-sync',
+        className: 'Queue',
+        funcName: 'unshiftRequest',
+        paramName: 'entry.request',
+      });
+    }
+
+    await this._addRequest(entry, 'unshift');
+  }
+
+  /**
+   * Removes and returns the last request in the queue (along with its
+   * timestamp and any metadata). The returned object takes the form:
+   * `{request, timestamp, metadata}`.
+   *
+   * @return {Promise<Object>}
+   */
+  async popRequest() {
+    return this._removeRequest('pop');
+  }
+
+  /**
+   * Removes and returns the first request in the queue (along with its
+   * timestamp and any metadata). The returned object takes the form:
+   * `{request, timestamp, metadata}`.
+   *
+   * @return {Promise<Object>}
+   */
+  async shiftRequest() {
+    return this._removeRequest('shift');
+  }
+
+  /**
+   * Adds the entry to the QueueStore and registers for a sync event.
+   *
+   * @param {Object} entry
+   * @param {Request} entry.request
+   * @param {Object} [entry.metadata]
+   * @param {number} [entry.timestamp=Date.now()]
+   * @param {string} operation ('push' or 'unshift')
+   */
+  async _addRequest(
+      {request, metadata, timestamp = Date.now()}, operation) {
+    const storableRequest = await StorableRequest.fromRequest(request.clone());
+    const entry = {
+      requestData: storableRequest.toObject(),
+      timestamp,
+    };
+
+    // Only include metadata if it's present.
+    if (metadata) {
+      entry.metadata = metadata;
+    }
+
+    await this._queueStore[`${operation}Entry`](entry);
+    await this.registerSync();
+    if (process.env.NODE_ENV !== 'production') {
+      logger.log(`Request for '${getFriendlyURL(storableRequest.url)}' has ` +
+          `been added to background sync queue '${this._name}'.`);
     }
   }
 
   /**
-   * Retrieves all stored requests in IndexedDB and retries them. If the
-   * queue contained requests that were successfully replayed, the
-   * `queueDidReplay` callback is invoked (which implies the queue is
-   * now empty). If any of the requests fail, a new sync registration is
-   * created to retry again later.
+   * Removes and returns the first or last (depending on `operation`) entry
+   * form the QueueStore that's not older than the `maxRetentionTime`.
+   *
+   * @param {string} operation ('pop' or 'shift')
+   * @return {Object|undefined}
+   */
+  async _removeRequest(operation) {
+    const now = Date.now();
+    const entry = await this._queueStore[`${operation}Entry`]();
+
+    if (entry ) {
+      // Ignore requests older than maxRetentionTime. Call this function
+      // recursively until an unexpired request is found.
+      const maxRetentionTimeInMs = this._maxRetentionTime * 60 * 1000;
+      if (now - entry.timestamp > maxRetentionTimeInMs) {
+        return this._removeRequest(operation);
+      }
+
+      entry.request = new StorableRequest(entry.requestData).toRequest();
+      delete entry.requestData;
+
+      return entry;
+    }
+  }
+
+  /**
+   * Loops through each request in the queue and attempts to re-fetch it.
+   * If any request fails to re-fetch, it's put back in the same position in
+   * the queue (which registers a retry for the next sync event).
    */
   async replayRequests() {
-    const now = Date.now();
-    const replayedRequests = [];
-    const failedRequests = [];
-
-    let storableRequest;
-    while (storableRequest = await this._queueStore.getAndRemoveOldestEntry()) {
-      // Make a copy so the unmodified request can be stored
-      // in the event of a replay failure.
-      const storableRequestClone = storableRequest.clone();
-
-      // Ignore requests older than maxRetentionTime.
-      const maxRetentionTimeInMs = this._maxRetentionTime * 60 * 1000;
-      if (now - storableRequest.timestamp > maxRetentionTimeInMs) {
-        continue;
-      }
-
-      await this._runCallback('requestWillReplay', storableRequest);
-
-      const replay = {request: storableRequest.toRequest()};
-
+    let entry;
+    while (entry = await this.shiftRequest()) {
       try {
-        // Clone the request before fetching so callbacks get an unused one.
-        replay.response = await fetch(replay.request.clone());
+        await fetch(entry.request);
+
         if (process.env.NODE_ENV !== 'production') {
-          logger.log(`Request for '${getFriendlyURL(storableRequest.url)}'
-             has been replayed`);
+          logger.log(`Request for '${getFriendlyURL(entry.request.url)}'` +
+             `has been replayed in queue '${this._name}'`);
         }
-      } catch (err) {
+      } catch (error) {
+        await this.unshiftRequest(entry);
+
         if (process.env.NODE_ENV !== 'production') {
-          logger.log(`Request for '${getFriendlyURL(storableRequest.url)}'
-             failed to replay`);
+          logger.log(`Request for '${getFriendlyURL(entry.request.url)}'` +
+             `failed to replay, putting it back in queue '${this._name}'`);
         }
-        replay.error = err;
-        failedRequests.push(storableRequestClone);
+        throw new WorkboxError('queue-replay-failed', {name: this._name});
       }
-
-      replayedRequests.push(replay);
     }
-
-    await this._runCallback('queueDidReplay', replayedRequests);
-
-    // If any requests failed, put the failed requests back in the queue
-    // and rethrow the failed requests count.
-    if (failedRequests.length) {
-      await Promise.all(failedRequests.map((storableRequest) => {
-        return this._queueStore.addEntry(storableRequest);
-      }));
-
-      throw new WorkboxError('queue-replay-failed',
-          {name: this._name, count: failedRequests.length});
+    if (process.env.NODE_ENV !== 'production') {
+      logger.log(`All requests in queue '${this.name}' have successfully ` +
+          `replayed; the queue is now empty!`);
     }
   }
 
   /**
-   * Runs the passed callback if it exists.
-   *
-   * @private
-   * @param {string} name The name of the callback on this._callbacks.
-   * @param {...*} args The arguments to invoke the callback with.
+   * Registers a sync event with a tag unique to this instance.
    */
-  async _runCallback(name, ...args) {
-    if (typeof this._callbacks[name] === 'function') {
-      await this._callbacks[name].apply(null, args);
+  async registerSync() {
+    if ('sync' in registration) {
+      try {
+        await registration.sync.register(`${TAG_PREFIX}:${this._name}`);
+      } catch (err) {
+        // This means the registration failed for some reason, possibly due to
+        // the user disabling it.
+        if (process.env.NODE_ENV !== 'production') {
+          logger.warn(
+              `Unable to register sync event for '${this._name}'.`, err);
+        }
+      }
     }
   }
 
@@ -190,10 +273,10 @@ class Queue {
       self.addEventListener('sync', (event) => {
         if (event.tag === `${TAG_PREFIX}:${this._name}`) {
           if (process.env.NODE_ENV !== 'production') {
-            logger.log(`Background sync for tag '${event.tag}'
-                has been received, starting replay now`);
+            logger.log(`Background sync for tag '${event.tag}'` +
+                `has been received`);
           }
-          event.waitUntil(this.replayRequests());
+          event.waitUntil(this._onSync(this));
         }
       });
     } else {
@@ -202,27 +285,7 @@ class Queue {
       }
       // If the browser doesn't support background sync, retry
       // every time the service worker starts up as a fallback.
-      this.replayRequests();
-    }
-  }
-
-  /**
-   * Registers a sync event with a tag unique to this instance.
-   *
-   * @private
-   */
-  async _registerSync() {
-    if ('sync' in registration) {
-      try {
-        await registration.sync.register(`${TAG_PREFIX}:${this._name}`);
-      } catch (err) {
-        // This means the registration failed for some reason, possibly due to
-        // the user disabling it.
-        if (process.env.NODE_ENV !== 'production') {
-          logger.warn(
-              `Unable to register sync event for '${this._name}'.`, err);
-        }
-      }
+      this._onSync(this);
     }
   }
 

--- a/packages/workbox-background-sync/Queue.mjs
+++ b/packages/workbox-background-sync/Queue.mjs
@@ -33,10 +33,11 @@ class Queue {
    *     in IndexedDB specific to this instance. An error will be thrown if
    *     a duplicate name is detected.
    * @param {Object} [options]
-   * @param {Function} [options.onSync] A function that gets invoked
-   *     with the queue instance whenever the 'sync' event fires. You can use
-   *     this callback to customize the replay behavior of the queue. When not
-   *     set the `replayRequests()` method is called.
+   * @param {Function} [options.onSync] A function that gets invoked whenever
+   *     the 'sync' event fires. The function is invoked with an object
+   *     containing the `queue` property (referencing this instance), and you
+   *     can use the callback to customize the replay behavior of the queue.
+   *.    When not set the `replayRequests()` method is called.
    * @param {number} [options.maxRetentionTime=7 days] The amount of time (in
    *     minutes) a request may be retried. After this amount of time has
    *     passed, the request will be deleted from the queue.
@@ -276,7 +277,7 @@ class Queue {
             logger.log(`Background sync for tag '${event.tag}'` +
                 `has been received`);
           }
-          event.waitUntil(this._onSync(this));
+          event.waitUntil(this._onSync({queue: this}));
         }
       });
     } else {
@@ -285,7 +286,7 @@ class Queue {
       }
       // If the browser doesn't support background sync, retry
       // every time the service worker starts up as a fallback.
-      this._onSync(this);
+      this._onSync({queue: this});
     }
   }
 

--- a/packages/workbox-background-sync/models/QueueStore.mjs
+++ b/packages/workbox-background-sync/models/QueueStore.mjs
@@ -6,10 +6,14 @@
   https://opensource.org/licenses/MIT.
 */
 
+import {assert} from 'workbox-core/_private/assert.mjs';
 import {DBWrapper} from 'workbox-core/_private/DBWrapper.mjs';
-import StorableRequest from './StorableRequest.mjs';
-import {DB_NAME, OBJECT_STORE_NAME, INDEXED_PROP} from '../utils/constants.mjs';
+import {migrateDb} from 'workbox-core/_private/migrateDb.mjs';
+import {DB_NAME, DB_VERSION, OBJECT_STORE_NAME, INDEXED_PROP}
+  from '../utils/constants.mjs';
+
 import '../_version.mjs';
+
 
 /**
  * A class to manage storing requests from a Queue in IndexedbDB,
@@ -22,54 +26,179 @@ export class QueueStore {
    * Associates this instance with a Queue instance, so entries added can be
    * identified by their queue name.
    *
-   * @param {Queue} queue
-   *
+   * @param {string} queueName
    * @private
    */
-  constructor(queue) {
-    this._queue = queue;
-    this._db = new DBWrapper(DB_NAME, 1, {
-      onupgradeneeded: (evt) => evt.target.result
-          .createObjectStore(OBJECT_STORE_NAME, {autoIncrement: true})
-          .createIndex(INDEXED_PROP, INDEXED_PROP, {unique: false}),
+  constructor(queueName) {
+    this._queueName = queueName;
+    this._db = new DBWrapper(DB_NAME, DB_VERSION, {
+      onupgradeneeded: (evt) => this._upgradeDb(evt),
     });
   }
 
   /**
-   * Takes a StorableRequest instance, converts it to an object and adds it
-   * as an entry in the object store.
+   * Append an entry last in the queue.
    *
-   * @param {StorableRequest} storableRequest
-   *
-   * @private
+   * @param {Object} entry
+   * @param {Object} entry.requestData
+   * @param {number} [entry.timestamp]
+   * @param {Object} [entry.metadata]
    */
-  async addEntry(storableRequest) {
-    await this._db.add(OBJECT_STORE_NAME, {
-      queueName: this._queue.name,
-      storableRequest: storableRequest.toObject(),
-    });
+  async pushEntry(entry) {
+    if (process.env.NODE_ENV !== 'production') {
+      assert.isType(entry, 'object', {
+        moduleName: 'workbox-background-sync',
+        className: 'QueueStore',
+        funcName: 'pushEntry',
+        paramName: 'entry',
+      });
+      assert.isType(entry.requestData, 'object', {
+        moduleName: 'workbox-background-sync',
+        className: 'QueueStore',
+        funcName: 'pushEntry',
+        paramName: 'entry.requestData',
+      });
+    }
+
+    // Don't specify an ID since one is automatically generated.
+    delete entry.id;
+    entry.queueName = this._queueName;
+
+    await this._db.add(OBJECT_STORE_NAME, entry);
   }
 
   /**
-   * Gets the oldest entry in the object store, removes it, and returns the
-   * value as a StorableRequest instance. If no entry exists, it returns
-   * undefined.
+   * Preppend an entry first in the queue.
    *
-   * @return {StorableRequest|undefined}
-   *
-   * @private
+   * @param {Object} entry
+   * @param {Object} entry.requestData
+   * @param {number} [entry.timestamp]
+   * @param {Object} [entry.metadata]
    */
-  async getAndRemoveOldestEntry() {
+  async unshiftEntry(entry) {
+    if (process.env.NODE_ENV !== 'production') {
+      assert.isType(entry, 'object', {
+        moduleName: 'workbox-background-sync',
+        className: 'QueueStore',
+        funcName: 'unshiftEntry',
+        paramName: 'entry',
+      });
+      assert.isType(entry.requestData, 'object', {
+        moduleName: 'workbox-background-sync',
+        className: 'QueueStore',
+        funcName: 'unshiftEntry',
+        paramName: 'entry.requestData',
+      });
+    }
+
+    const firstEntry = await this._db.get(OBJECT_STORE_NAME);
+    if (firstEntry) {
+    // Pick an ID one less than the lowest ID in the object store.
+      entry.id = firstEntry.id - 1;
+    } else {
+      delete entry.id;
+    }
+    entry.queueName = this._queueName;
+
+    await this._db.add(OBJECT_STORE_NAME, entry);
+  }
+
+  /**
+   * Removes and returns the last entry in the queue matching the `queueName`.
+   *
+   * @return {Promise<Object>}
+   */
+  async popEntry() {
+    return this._removeEntry({direction: 'prev'});
+  }
+
+  /**
+   * Removes and returns the first entry in the queue matching the `queueName`.
+   *
+   * @return {Promise<Object>}
+   */
+  async shiftEntry() {
+    return this._removeEntry({direction: 'next'});
+  }
+
+  /**
+   * Removes and returns the first or last entry in the queue (based on the
+   * `direction` argument) matching the `queueName`.
+   *
+   * @return {Promise<Object>}
+   */
+  async _removeEntry({direction}) {
     const [entry] = await this._db.getAllMatching(OBJECT_STORE_NAME, {
+      direction,
       index: INDEXED_PROP,
-      query: IDBKeyRange.only(this._queue.name),
+      query: IDBKeyRange.only(this._queueName),
       count: 1,
-      includeKeys: true,
     });
 
     if (entry) {
-      await this._db.delete(OBJECT_STORE_NAME, entry.primaryKey);
-      return new StorableRequest(entry.value.storableRequest);
+      await this._db.delete(OBJECT_STORE_NAME, entry.id);
+
+      // Dont' expose the ID or queueName;
+      delete entry.id;
+      delete entry.queueName;
+      return entry;
     }
+  }
+
+  /**
+   * Upgrades the database given an `upgradeneeded` event.
+   *
+   * @param {Event} event
+   */
+  _upgradeDb(event) {
+    const db = event.target.result;
+    const txn = event.target.transaction;
+    let oldEntries = [];
+
+    migrateDb(event, {
+      v1: (done) => {
+        // When migrating from version 0, this will not exist.
+        if (db.objectStoreNames.contains(OBJECT_STORE_NAME)) {
+          // Get any existing entries in the v1 requests store
+          // and then delete it.
+          const objStore = txn.objectStore(OBJECT_STORE_NAME);
+          objStore.openCursor().onsuccess = ({target}) => {
+            const cursor = target.result;
+            if (cursor) {
+              oldEntries.push(cursor.value);
+              cursor.continue();
+            } else {
+              db.deleteObjectStore(OBJECT_STORE_NAME);
+              done();
+            }
+          };
+        } else {
+          done();
+        }
+      },
+      v2: (done) => {
+        // Creates v2 of the requests store and adds back any existing
+        // entries in the new format.
+        const objStore = db.createObjectStore(OBJECT_STORE_NAME, {
+          autoIncrement: true,
+          keyPath: 'id',
+        });
+        objStore.createIndex(INDEXED_PROP, INDEXED_PROP, {unique: false});
+
+        if (oldEntries.length) {
+          for (const {queueName, storableRequest} of oldEntries) {
+            // Move the timestamp from `storableRequest` to the top level.
+            const timestamp = storableRequest.timestamp;
+
+            // Reformat the storable request data
+            const requestData = Object.assign(
+                storableRequest.requestInit, {url: storableRequest.url});
+
+            objStore.add({queueName, timestamp, requestData});
+          }
+        }
+        done();
+      },
+    });
   }
 }

--- a/packages/workbox-background-sync/models/QueueStore.mjs
+++ b/packages/workbox-background-sync/models/QueueStore.mjs
@@ -156,7 +156,7 @@ export class QueueStore {
     let oldEntries = [];
 
     migrateDb(event, {
-      v1: (done) => {
+      v1: (next) => {
         // When migrating from version 0, this will not exist.
         if (db.objectStoreNames.contains(OBJECT_STORE_NAME)) {
           // Get any existing entries in the v1 requests store
@@ -169,14 +169,14 @@ export class QueueStore {
               cursor.continue();
             } else {
               db.deleteObjectStore(OBJECT_STORE_NAME);
-              done();
+              next();
             }
           };
         } else {
-          done();
+          next();
         }
       },
-      v2: (done) => {
+      v2: (next) => {
         // Creates v2 of the requests store and adds back any existing
         // entries in the new format.
         const objStore = db.createObjectStore(OBJECT_STORE_NAME, {
@@ -197,7 +197,7 @@ export class QueueStore {
             objStore.add({queueName, timestamp, requestData});
           }
         }
-        done();
+        next();
       },
     });
   }

--- a/packages/workbox-background-sync/models/StorableRequest.mjs
+++ b/packages/workbox-background-sync/models/StorableRequest.mjs
@@ -6,7 +6,9 @@
   https://opensource.org/licenses/MIT.
 */
 
+import {assert} from 'workbox-core/_private/assert.mjs';
 import '../_version.mjs';
+
 
 const serializableProperties = [
   'method',
@@ -38,76 +40,76 @@ export default class StorableRequest {
    * @private
    */
   static async fromRequest(request) {
-    const requestInit = {headers: {}};
+    const requestData = {
+      url: request.url,
+      headers: {},
+    };
 
     // Set the body if present.
     if (request.method !== 'GET') {
       // Use blob to support non-text request bodies,
       // and clone first in case the caller still needs the request.
-      requestInit.body = await request.clone().blob();
+      requestData.body = await request.clone().blob();
     }
 
     // Convert the headers from an iterable to an object.
     for (const [key, value] of request.headers.entries()) {
-      requestInit.headers[key] = value;
+      requestData.headers[key] = value;
     }
 
     // Add all other serializable request properties
     for (const prop of serializableProperties) {
       if (request[prop] !== undefined) {
-        requestInit[prop] = request[prop];
+        requestData[prop] = request[prop];
       }
     }
 
-    return new StorableRequest({url: request.url, requestInit});
+    return new StorableRequest(requestData);
   }
 
   /**
-   * Accepts a URL and RequestInit dictionary that can be used to create a
-   * new Request object. A timestamp is also generated so consumers can
-   * reference when the object was created.
+   * Accepts an object of request data that can be used to construct a
+   * `Request` but can also be stored in IndexedDB.
    *
-   * @param {Object} param1
-   * @param {string} param1.url
-   * @param {Object} param1.requestInit
-   *     See: https://fetch.spec.whatwg.org/#requestinit
-   * @param {number} param1.timestamp The time the request was created,
-   *     defaulting to the current time if not specified.
-   *
+   * @param {Object} requestData An object of request data that includes the
+   *     `url` plus any relevant properties of
+   *     [requestInit]{@link https://fetch.spec.whatwg.org/#requestinit}.
    * @private
    */
-  constructor({url, requestInit, timestamp = Date.now()}) {
-    this.url = url;
-    this.requestInit = requestInit;
+  constructor(requestData) {
+    if (process.env.NODE_ENV !== 'production') {
+      assert.isType(requestData, 'object', {
+        moduleName: 'workbox-background-sync',
+        className: 'StorableRequest',
+        funcName: 'constructor',
+        paramName: 'requestData',
+      });
+      assert.isType(requestData.url, 'string', {
+        moduleName: 'workbox-background-sync',
+        className: 'StorableRequest',
+        funcName: 'constructor',
+        paramName: 'requestData.url',
+      });
+    }
 
-    // "Private"
-    this._timestamp = timestamp;
+    this._requestData = requestData;
   }
 
   /**
-   * Gets the private _timestamp property.
-   *
-   * @return {number}
-   *
-   * @private
-   */
-  get timestamp() {
-    return this._timestamp;
-  }
-
-  /**
-   * Coverts this instance to a plain Object.
+   * Returns a deep clone of the instances `_requestData` object.
    *
    * @return {Object}
    *
    * @private
    */
   toObject() {
-    return {
-      url: this.url,
-      timestamp: this.timestamp,
-      requestInit: this.requestInit,
-    };
+    const requestData = Object.assign({}, this._requestData);
+    requestData.headers = Object.assign({}, this._requestData.headers);
+    if (requestData.body) {
+      requestData.body = requestData.body.slice();
+    }
+
+    return requestData;
   }
 
   /**
@@ -118,7 +120,7 @@ export default class StorableRequest {
    * @private
    */
   toRequest() {
-    return new Request(this.url, this.requestInit);
+    return new Request(this._requestData.url, this._requestData);
   }
 
   /**
@@ -129,16 +131,6 @@ export default class StorableRequest {
    * @private
    */
   clone() {
-    const requestInit = Object.assign({}, this.requestInit);
-    requestInit.headers = Object.assign({}, this.requestInit.headers);
-    if (this.requestInit.body) {
-      requestInit.body = this.requestInit.body.slice();
-    }
-
-    return new StorableRequest({
-      url: this.url,
-      timestamp: this.timestamp,
-      requestInit,
-    });
+    return new StorableRequest(this.toObject());
   }
 }

--- a/packages/workbox-background-sync/utils/constants.mjs
+++ b/packages/workbox-background-sync/utils/constants.mjs
@@ -8,6 +8,7 @@
 
 import '../_version.mjs';
 
+export const DB_VERSION = 2;
 export const DB_NAME = 'workbox-background-sync';
 export const OBJECT_STORE_NAME = 'requests';
 export const INDEXED_PROP = 'queueName';

--- a/packages/workbox-core/_private.mjs
+++ b/packages/workbox-core/_private.mjs
@@ -9,6 +9,7 @@
 // We either expose defaults or we expose every named export.
 import {DBWrapper} from './_private/DBWrapper.mjs';
 import {deleteDatabase} from './_private/deleteDatabase.mjs';
+import {migrateDb} from './_private/migrateDb.mjs';
 import {WorkboxError} from './_private/WorkboxError.mjs';
 import {assert} from './_private/assert.mjs';
 import {cacheNames} from './_private/cacheNames.mjs';
@@ -22,6 +23,7 @@ import './_version.mjs';
 export {
   DBWrapper,
   deleteDatabase,
+  migrateDb,
   WorkboxError,
   assert,
   cacheNames,

--- a/packages/workbox-core/_private/migrateDb.mjs
+++ b/packages/workbox-core/_private/migrateDb.mjs
@@ -1,0 +1,39 @@
+/*
+  Copyright 2018 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import '../_version.mjs';
+
+
+/**
+ * Handles running a series of migration functions to upgrade an IndexedDB
+ * database in a `versionchange` event.
+ *
+ * @private
+ * @param {IDBVersionChangeEvent} event
+ * @param {Object<string, Function>} migrationFunctions
+ */
+export const migrateDb = (event, migrationFunctions) => {
+  let {oldVersion, newVersion} = event;
+
+  // Call all `migrationFunctions` values between oldVersion and newVersion.
+  const migrate = (oldVersion) => {
+    const next = () => {
+      ++oldVersion;
+      if (oldVersion <= newVersion) {
+        migrate(oldVersion);
+      }
+    };
+    const migrationFunction = migrationFunctions[`v${oldVersion}`];
+    if (typeof migrationFunction === 'function') {
+      migrationFunction(next);
+    } else {
+      next();
+    }
+  };
+  migrate(oldVersion);
+};

--- a/packages/workbox-core/models/messages/messages.mjs
+++ b/packages/workbox-core/models/messages/messages.mjs
@@ -127,8 +127,8 @@ export default {
       `registered.`;
   },
 
-  'queue-replay-failed': ({name, count}) => {
-    return `${count} requests failed, while trying to replay Queue: ${name}.`;
+  'queue-replay-failed': ({name}) => {
+    return `Replaying the background sync queue '${name}' failed.`;
   },
 
   'duplicate-queue-name': ({name}) => {

--- a/packages/workbox-google-analytics/initialize.mjs
+++ b/packages/workbox-google-analytics/initialize.mjs
@@ -37,7 +37,7 @@ import './_version.mjs';
  * @private
  */
 const createOnSyncCallback = (config) => {
-  return async (queue) => {
+  return async ({queue}) => {
     let entry;
     while (entry = await queue.shiftRequest()) {
       const {request, timestamp} = entry;

--- a/test/workbox-background-sync/node/lib/test-QueueStore.mjs
+++ b/test/workbox-background-sync/node/lib/test-QueueStore.mjs
@@ -7,11 +7,12 @@
 */
 
 import {expect} from 'chai';
-import {reset as iDBReset} from 'shelving-mock-indexeddb';
-import {DB_NAME, OBJECT_STORE_NAME} from
+import {reset} from 'shelving-mock-indexeddb';
+import expectError from '../../../../infra/testing/expectError';
+import {devOnly} from '../../../../infra/testing/env-it';
+
+import {DB_NAME, DB_VERSION, OBJECT_STORE_NAME, INDEXED_PROP} from
   '../../../../packages/workbox-background-sync/utils/constants.mjs';
-import {Queue} from
-  '../../../../packages/workbox-background-sync/Queue.mjs';
 import {QueueStore} from
   '../../../../packages/workbox-background-sync/models/QueueStore.mjs';
 import {DBWrapper} from
@@ -19,16 +20,11 @@ import {DBWrapper} from
 import StorableRequest from
   '../../../../packages/workbox-background-sync/models/StorableRequest.mjs';
 
-const getObjectStoreEntries = async () => {
-  return await new DBWrapper(DB_NAME, 1).getAll(OBJECT_STORE_NAME);
+const getObjectStoreEntries = async (version = DB_VERSION) => {
+  return await new DBWrapper(DB_NAME, version).getAll(OBJECT_STORE_NAME);
 };
 
 describe(`[workbox-background-sync] QueueStore`, function() {
-  const reset = () => {
-    Queue._queueNames.clear();
-    iDBReset();
-  };
-
   beforeEach(function() {
     reset();
   });
@@ -38,79 +34,421 @@ describe(`[workbox-background-sync] QueueStore`, function() {
   });
 
   describe(`constructor`, function() {
-    it(`should associate the queue store with a Queue instance`, function() {
-      const queue = new Queue('foo');
-      const queueStore = new QueueStore(queue);
-
-      expect(queueStore._queue).to.equal(queue);
+    it(`should associate the queue name with a Queue instance`, function() {
+      const queueStore = new QueueStore('foo');
+      expect(queueStore._queueName).to.equal('foo');
     });
   });
 
-  describe(`addEntry`, function() {
-    it(`should add a StorableRequest to an IDB object store with the ` +
-        `right queue name`, async function() {
-      const queue = new Queue('foo');
-      const queueStore = new QueueStore(queue);
+  describe(`_upgradeDb`, function() {
+    it(`should handle upgrading from no previous version`, async function() {
+      const queueStore = new QueueStore('a');
 
       const sr1 = await StorableRequest.fromRequest(new Request('/one'));
       const sr2 = await StorableRequest.fromRequest(new Request('/two'));
 
-      await queueStore.addEntry(sr1);
-      await queueStore.addEntry(sr2);
+      await queueStore.pushEntry({
+        requestData: sr1.toObject(),
+      });
+      await queueStore.pushEntry({
+        requestData: sr2.toObject(),
+      });
+
+      const entries = await getObjectStoreEntries();
+      expect(entries).to.have.lengthOf(2);
+      expect(entries[0].id).to.equal(1);
+      expect(entries[0].queueName).to.equal('a');
+      expect(entries[0].requestData.url).to.equal('/one');
+      expect(entries[1].id).to.equal(2);
+      expect(entries[1].queueName).to.equal('a');
+      expect(entries[1].requestData.url).to.equal('/two');
+    });
+
+    it(`should handle upgrading from version 1 to 2`, async function() {
+      const dbv1 = new DBWrapper(DB_NAME, 1, {
+        onupgradeneeded: (event) => event.target.result
+            .createObjectStore(OBJECT_STORE_NAME, {autoIncrement: true})
+            .createIndex(INDEXED_PROP, INDEXED_PROP, {unique: false}),
+      });
+
+      await dbv1.add(OBJECT_STORE_NAME, {
+        queueName: 'a',
+        storableRequest: {
+          url: '/one',
+          timestamp: 123,
+          requestInit: {
+            method: 'POST',
+            mode: 'no-cors',
+            headers: {
+              'x-foo': 'bar',
+              'x-qux': 'baz',
+            },
+          },
+        },
+      });
+
+      await dbv1.add(OBJECT_STORE_NAME, {
+        queueName: 'b',
+        storableRequest: {
+          url: '/two',
+          timestamp: 234,
+          requestInit: {
+            mode: 'cors',
+          },
+        },
+      });
+
+      await dbv1.add(OBJECT_STORE_NAME, {
+        queueName: 'a',
+        storableRequest: {
+          url: '/three',
+          timestamp: 345,
+          requestInit: {},
+        },
+      });
+
+      // Creating the new `QueueStore` should register the upgrade logic.
+      new QueueStore('a');
+      const queueStore2 = new QueueStore('b');
+      const sr = await StorableRequest.fromRequest(new Request('/four'));
+      const requestData = sr.toObject();
+      const timestamp = Date.now();
+      const metadata = {a: '1'};
+
+      // Pushing an entry should trigger the database open (and the upgrade).
+      queueStore2.pushEntry({requestData, timestamp, metadata});
+
+      const entries = await getObjectStoreEntries();
+      expect(entries).to.have.lengthOf(4);
+      expect(entries[0].id).to.equal(1);
+      expect(entries[0].timestamp).to.equal(123);
+      expect(entries[0].queueName).to.equal('a');
+      expect(entries[0].requestData.url).to.equal('/one');
+      expect(entries[1].id).to.equal(2);
+      expect(entries[1].timestamp).to.equal(234);
+      expect(entries[1].queueName).to.equal('b');
+      expect(entries[1].requestData.url).to.equal('/two');
+      expect(entries[2].id).to.equal(3);
+      expect(entries[2].timestamp).to.equal(345);
+      expect(entries[2].queueName).to.equal('a');
+      expect(entries[2].requestData.url).to.equal('/three');
+      expect(entries[3].id).to.equal(4);
+      expect(entries[3].timestamp).to.equal(timestamp);
+      expect(entries[3].metadata).to.deep.equal(metadata);
+      expect(entries[3].queueName).to.equal('b');
+      expect(entries[3].requestData.url).to.equal('/four');
+    });
+  });
+
+  describe(`pushEntry`, function() {
+    it(`should append an entry to IDB with the right queue name`, async function() {
+      const queueStore1 = new QueueStore('a');
+      const queueStore2 = new QueueStore('b');
+
+      const sr1 = await StorableRequest.fromRequest(new Request('/one'));
+      const sr2 = await StorableRequest.fromRequest(new Request('/two'));
+      const sr3 = await StorableRequest.fromRequest(new Request('/three'));
+      const sr4 = await StorableRequest.fromRequest(new Request('/four'));
+      const sr5 = await StorableRequest.fromRequest(new Request('/five'));
+
+      await queueStore1.pushEntry({
+        requestData: sr1.toObject(),
+        timestamp: 1000,
+        metadata: {name: 'meta1'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr2.toObject(),
+        timestamp: 2000,
+        metadata: {name: 'meta2'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr3.toObject(),
+        timestamp: 3000,
+        metadata: {name: 'meta3'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr4.toObject(),
+        timestamp: 4000,
+        metadata: {name: 'meta4'},
+      });
+      await queueStore1.pushEntry({
+        requestData: sr5.toObject(),
+        timestamp: 5000,
+        metadata: {name: 'meta5'},
+      });
 
       const entries = await getObjectStoreEntries();
 
-      expect(entries).to.have.lengthOf(2);
-      expect(entries[0].queueName).to.equal('foo');
-      expect(entries[0].storableRequest.url).to.equal('/one');
-      expect(entries[1].queueName).to.equal('foo');
-      expect(entries[1].storableRequest.url).to.equal('/two');
+      expect(entries).to.have.lengthOf(5);
+      expect(entries[0].id).to.equal(1);
+      expect(entries[0].queueName).to.equal('a');
+      expect(entries[0].requestData.url).to.equal('/one');
+      expect(entries[0].timestamp).to.equal(1000);
+      expect(entries[0].metadata).to.deep.equal({name: 'meta1'});
+      expect(entries[1].id).to.equal(2);
+      expect(entries[1].queueName).to.equal('b');
+      expect(entries[1].requestData.url).to.equal('/two');
+      expect(entries[1].timestamp).to.equal(2000);
+      expect(entries[1].metadata).to.deep.equal({name: 'meta2'});
+      expect(entries[2].id).to.equal(3);
+      expect(entries[2].queueName).to.equal('b');
+      expect(entries[2].requestData.url).to.equal('/three');
+      expect(entries[2].timestamp).to.equal(3000);
+      expect(entries[2].metadata).to.deep.equal({name: 'meta3'});
+      expect(entries[3].id).to.equal(4);
+      expect(entries[3].queueName).to.equal('b');
+      expect(entries[3].requestData.url).to.equal('/four');
+      expect(entries[3].timestamp).to.equal(4000);
+      expect(entries[3].metadata).to.deep.equal({name: 'meta4'});
+      expect(entries[4].id).to.equal(5);
+      expect(entries[4].queueName).to.equal('a');
+      expect(entries[4].requestData.url).to.equal('/five');
+      expect(entries[4].timestamp).to.equal(5000);
+      expect(entries[4].metadata).to.deep.equal({name: 'meta5'});
+    });
+
+    devOnly.it(`throws if not given an entry object`, function() {
+      return expectError(async () => {
+        const queueStore = new QueueStore('a');
+        await queueStore.pushEntry();
+      }, 'incorrect-type');
+    });
+
+    devOnly.it(`throws if not given an entry object with requestData`, function() {
+      return expectError(async () => {
+        const queueStore = new QueueStore('a');
+        await queueStore.pushEntry({});
+      }, 'incorrect-type');
     });
   });
 
-  describe(`getAndRemoveOldestEntry`, function() {
-    it(`should remove the first entry added to the store`, async function() {
-      const queue = new Queue('foo');
-      const queueStore = new QueueStore(queue);
+  describe(`unshiftEntry`, function() {
+    it(`should prepend an entry to IDB with the right queue name and ID`, async function() {
+      const queueStore1 = new QueueStore('a');
+      const queueStore2 = new QueueStore('b');
 
       const sr1 = await StorableRequest.fromRequest(new Request('/one'));
       const sr2 = await StorableRequest.fromRequest(new Request('/two'));
+      const sr3 = await StorableRequest.fromRequest(new Request('/three'));
+      const sr4 = await StorableRequest.fromRequest(new Request('/four'));
+      const sr5 = await StorableRequest.fromRequest(new Request('/five'));
 
-      await queueStore.addEntry(sr1);
-      await queueStore.addEntry(sr2);
-
-      let entries = await getObjectStoreEntries();
-      expect(entries).to.have.lengthOf(2);
-
-      const sr3 = await queueStore.getAndRemoveOldestEntry();
-      expect(sr3.url).to.equal('/one');
-
-      entries = await getObjectStoreEntries();
-      expect(entries).to.have.lengthOf(1);
-      expect(entries[0].queueName).to.equal('foo');
-      expect(entries[0].storableRequest.url).to.equal('/two');
+      await queueStore1.unshiftEntry({
+        requestData: sr1.toObject(),
+        timestamp: 1000,
+        metadata: {name: 'meta1'},
+      });
+      await queueStore2.unshiftEntry({
+        requestData: sr2.toObject(),
+        timestamp: 2000,
+        metadata: {name: 'meta2'},
+      });
+      await queueStore2.unshiftEntry({
+        requestData: sr3.toObject(),
+        timestamp: 3000,
+        metadata: {name: 'meta3'},
+      });
+      await queueStore2.unshiftEntry({
+        requestData: sr4.toObject(),
+        timestamp: 4000,
+        metadata: {name: 'meta4'},
+      });
+      await queueStore1.unshiftEntry({
+        requestData: sr5.toObject(),
+        timestamp: 5000,
+        metadata: {name: 'meta5'},
+      });
+      const entries = await getObjectStoreEntries();
+      expect(entries).to.have.lengthOf(5);
+      expect(entries[0].id).to.equal(-3);
+      expect(entries[0].timestamp).to.equal(5000);
+      expect(entries[0].metadata).to.deep.equal({name: 'meta5'});
+      expect(entries[0].queueName).to.equal('a');
+      expect(entries[0].requestData.url).to.equal('/five');
+      expect(entries[1].id).to.equal(-2);
+      expect(entries[1].timestamp).to.equal(4000);
+      expect(entries[1].metadata).to.deep.equal({name: 'meta4'});
+      expect(entries[1].queueName).to.equal('b');
+      expect(entries[1].requestData.url).to.equal('/four');
+      expect(entries[2].id).to.equal(-1);
+      expect(entries[2].timestamp).to.equal(3000);
+      expect(entries[2].metadata).to.deep.equal({name: 'meta3'});
+      expect(entries[2].queueName).to.equal('b');
+      expect(entries[2].requestData.url).to.equal('/three');
+      expect(entries[3].id).to.equal(0);
+      expect(entries[3].timestamp).to.equal(2000);
+      expect(entries[3].metadata).to.deep.equal({name: 'meta2'});
+      expect(entries[3].queueName).to.equal('b');
+      expect(entries[3].requestData.url).to.equal('/two');
+      expect(entries[4].id).to.equal(1);
+      expect(entries[4].timestamp).to.equal(1000);
+      expect(entries[4].metadata).to.deep.equal({name: 'meta1'});
+      expect(entries[4].queueName).to.equal('a');
+      expect(entries[4].requestData.url).to.equal('/one');
     });
 
-    it(`should return undefined when no entries exist`, async function() {
-      const queue = new Queue('foo');
-      const queueStore = new QueueStore(queue);
+    devOnly.it(`throws if not given an entry object`, function() {
+      return expectError(async () => {
+        const queueStore = new QueueStore('a');
+        await queueStore.unshiftEntry();
+      }, 'incorrect-type');
+    });
+
+    devOnly.it(`throws if not given an entry object with requestData`, function() {
+      return expectError(async () => {
+        const queueStore = new QueueStore('a');
+        await queueStore.unshiftEntry({});
+      }, 'incorrect-type');
+    });
+  });
+
+  describe(`shiftEntry`, function() {
+    it(`should remove and return the first entry in IDB with the matching queue name`, async function() {
+      const queueStore1 = new QueueStore('a');
+      const queueStore2 = new QueueStore('b');
 
       const sr1 = await StorableRequest.fromRequest(new Request('/one'));
       const sr2 = await StorableRequest.fromRequest(new Request('/two'));
+      const sr3 = await StorableRequest.fromRequest(new Request('/three'));
+      const sr4 = await StorableRequest.fromRequest(new Request('/four'));
+      const sr5 = await StorableRequest.fromRequest(new Request('/five'));
 
-      await queueStore.addEntry(sr1);
-      await queueStore.addEntry(sr2);
+      await queueStore1.pushEntry({
+        requestData: sr1.toObject(),
+        timestamp: 1000,
+        metadata: {name: 'meta1'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr2.toObject(),
+        timestamp: 2000,
+        metadata: {name: 'meta2'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr3.toObject(),
+        timestamp: 3000,
+        metadata: {name: 'meta3'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr4.toObject(),
+        timestamp: 4000,
+        metadata: {name: 'meta4'},
+      });
+      await queueStore1.pushEntry({
+        requestData: sr5.toObject(),
+        timestamp: 5000,
+        metadata: {name: 'meta5'},
+      });
 
       let entries = await getObjectStoreEntries();
-      expect(entries).to.have.lengthOf(2);
+      expect(entries).to.have.lengthOf(5);
 
-      const sr3 = await queueStore.getAndRemoveOldestEntry();
-      const sr4 = await queueStore.getAndRemoveOldestEntry();
-      expect(sr3.url).to.equal('/one');
-      expect(sr4.url).to.equal('/two');
+      const sr2a = await queueStore2.shiftEntry();
+      expect(sr2a.requestData).to.deep.equal(sr2.toObject());
+      expect(sr2a.timestamp).to.equal(2000);
+      expect(sr2a.metadata).to.deep.equal({name: 'meta2'});
+      // It should not return the ID or queue name.
+      expect(sr2a.id).to.be.undefined;
+      expect(sr2a.queueName).to.be.undefined;
 
-      // No more entries should exist.
-      expect(await queueStore.getAndRemoveOldestEntry()).to.be.undefined;
+      entries = await getObjectStoreEntries();
+      expect(entries).to.have.lengthOf(4);
+      expect(entries[0].id).to.equal(1);
+      expect(entries[1].id).to.equal(3);
+      expect(entries[2].id).to.equal(4);
+      expect(entries[3].id).to.equal(5);
+
+      const sr1a = await queueStore1.shiftEntry();
+      expect(sr1a.requestData).to.deep.equal(sr1.toObject());
+      expect(sr1a.timestamp).to.equal(1000);
+      expect(sr1a.metadata).to.deep.equal({name: 'meta1'});
+      // It should not return the ID or queue name.
+      expect(sr1a.id).to.be.undefined;
+      expect(sr1a.queueName).to.be.undefined;
+
+      entries = await getObjectStoreEntries();
+      expect(entries).to.have.lengthOf(3);
+      expect(entries[0].id).to.equal(3);
+      expect(entries[1].id).to.equal(4);
+      expect(entries[2].id).to.equal(5);
+    });
+  });
+
+  describe(`popEntry`, function() {
+    it(`should remove and return the last entry in IDB with the matching queue name`, async function() {
+      const queueStore1 = new QueueStore('a');
+      const queueStore2 = new QueueStore('b');
+
+      const sr1 = await StorableRequest.fromRequest(new Request('/one'));
+      const sr2 = await StorableRequest.fromRequest(new Request('/two'));
+      const sr3 = await StorableRequest.fromRequest(new Request('/three'));
+      const sr4 = await StorableRequest.fromRequest(new Request('/four'));
+      const sr5 = await StorableRequest.fromRequest(new Request('/five'));
+
+      await queueStore1.pushEntry({
+        requestData: sr1.toObject(),
+        timestamp: 1000,
+        metadata: {name: 'meta1'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr2.toObject(),
+        timestamp: 2000,
+        metadata: {name: 'meta2'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr3.toObject(),
+        timestamp: 3000,
+        metadata: {name: 'meta3'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr4.toObject(),
+        timestamp: 4000,
+        metadata: {name: 'meta4'},
+      });
+      await queueStore1.pushEntry({
+        requestData: sr5.toObject(),
+        timestamp: 5000,
+        metadata: {name: 'meta5'},
+      });
+
+      let entries = await getObjectStoreEntries();
+      expect(entries).to.have.lengthOf(5);
+
+      const sr4a = await queueStore2.popEntry();
+      expect(sr4a.requestData).to.deep.equal(sr4.toObject());
+      expect(sr4a.timestamp).to.equal(4000);
+      expect(sr4a.metadata).to.deep.equal({name: 'meta4'});
+      // It should not return the ID or queue name.
+      expect(sr4a.id).to.be.undefined;
+      expect(sr4a.queueName).to.be.undefined;
+
+      entries = await getObjectStoreEntries();
+      expect(entries).to.have.lengthOf(4);
+      expect(entries[0].id).to.equal(1);
+      expect(entries[0].queueName).to.equal('a');
+      expect(entries[0].requestData.url).to.equal('/one');
+      expect(entries[1].id).to.equal(2);
+      expect(entries[1].queueName).to.equal('b');
+      expect(entries[1].requestData.url).to.equal('/two');
+      expect(entries[2].id).to.equal(3);
+      expect(entries[2].queueName).to.equal('b');
+      expect(entries[2].requestData.url).to.equal('/three');
+      expect(entries[3].id).to.equal(5);
+      expect(entries[3].queueName).to.equal('a');
+      expect(entries[3].requestData.url).to.equal('/five');
+
+      const sr5a = await queueStore1.popEntry();
+      expect(sr5a.requestData).to.deep.equal(sr5.toObject());
+      expect(sr5a.timestamp).to.equal(5000);
+      expect(sr5a.metadata).to.deep.equal({name: 'meta5'});
+      // It should not return the ID or queue name.
+      expect(sr5a.id).to.be.undefined;
+      expect(sr5a.queueName).to.be.undefined;
+
+      entries = await getObjectStoreEntries();
+      expect(entries).to.have.lengthOf(3);
+      expect(entries[0].id).to.equal(1);
+      expect(entries[1].id).to.equal(2);
+      expect(entries[2].id).to.equal(3);
     });
   });
 });

--- a/test/workbox-background-sync/node/lib/test-StorableRequest.mjs
+++ b/test/workbox-background-sync/node/lib/test-StorableRequest.mjs
@@ -7,7 +7,8 @@
 */
 
 import {expect} from 'chai';
-import sinon from 'sinon';
+import expectError from '../../../../infra/testing/expectError';
+import {devOnly} from '../../../../infra/testing/env-it';
 import StorableRequest from
   '../../../../packages/workbox-background-sync/models/StorableRequest.mjs';
 
@@ -27,20 +28,20 @@ describe(`[workbox-background-sync] StorableRequest`, function() {
 
       const storableRequest = await StorableRequest.fromRequest(request);
 
-      expect(storableRequest.url).to.equal('/foo');
-      expect(storableRequest.requestInit.method).to.equal('POST');
-      expect(storableRequest.requestInit.body).to.be.instanceOf(Blob);
-      expect(storableRequest.requestInit.body.size).to.equal(10);
-      expect(storableRequest.requestInit.mode).to.equal('no-cors');
-      expect(storableRequest.requestInit.headers['x-foo']).to.equal('bar');
-      expect(storableRequest.requestInit.headers['x-qux']).to.equal('baz');
+      expect(storableRequest._requestData.url).to.equal('/foo');
+      expect(storableRequest._requestData.method).to.equal('POST');
+      expect(storableRequest._requestData.body).to.be.instanceOf(Blob);
+      expect(storableRequest._requestData.body.size).to.equal(10);
+      expect(storableRequest._requestData.mode).to.equal('no-cors');
+      expect(storableRequest._requestData.headers['x-foo']).to.equal('bar');
+      expect(storableRequest._requestData.headers['x-qux']).to.equal('baz');
     });
   });
 
   describe(`constructor`, function() {
     it(`sets the passed properties on the instance`, function() {
-      const url = '/foo';
-      const requestInit = {
+      const requestData = {
+        url: '/foo',
         method: 'POST',
         body: 'it worked!',
         mode: 'no-cors',
@@ -50,39 +51,25 @@ describe(`[workbox-background-sync] StorableRequest`, function() {
         },
       };
 
-      const storableRequest = new StorableRequest({url, requestInit});
-
-      expect(storableRequest.url).to.equal(url);
-      expect(storableRequest.requestInit).to.equal(requestInit);
-      expect(storableRequest.timestamp).not.to.be.undefined;
-    });
-  });
-
-  describe(`get timestamp`, function() {
-    it(`returns the time when the instance was created`, async function() {
-      const clock = sinon.useFakeTimers({now: Date.now()});
-      const storableRequest =
-          await StorableRequest.fromRequest(new Request('/foo'));
-
-      expect(storableRequest.timestamp).to.equal(Date.now());
-
-      clock.restore();
+      const storableRequest = new StorableRequest(requestData);
+      expect(storableRequest._requestData).to.deep.equal(requestData);
     });
 
-    it(`uses the passed timestamp if specified`, function() {
-      const storableRequest = new StorableRequest({
-        url: '/foo',
-        requestInit: {},
-        timestamp: 1234,
-      });
+    devOnly.it(`throws if not given a requestData object`, function() {
+      return expectError(() => {
+        new StorableRequest();
+      }, 'incorrect-type');
+    });
 
-      expect(storableRequest.timestamp).to.equal(1234);
+    devOnly.it(`throws if not given a URL in the requestData object`, function() {
+      return expectError(() => {
+        new StorableRequest({});
+      }, 'incorrect-type');
     });
   });
 
   describe(`toObject`, function() {
     it(`converts the instance to a plain object`, async function() {
-      const clock = sinon.useFakeTimers({now: Date.now()});
       const storableRequest = await StorableRequest.fromRequest(
           new Request('/foo', {
             method: 'POST',
@@ -94,19 +81,16 @@ describe(`[workbox-background-sync] StorableRequest`, function() {
             },
           }));
 
-      const requestObj = storableRequest.toObject();
+      const requestData = storableRequest.toObject();
 
-      expect(Object.getPrototypeOf(requestObj)).to.equal(Object.prototype);
-      expect(requestObj.url).to.equal('/foo');
-      expect(requestObj.requestInit.method).to.equal('POST');
-      expect(requestObj.requestInit.body).to.be.instanceOf(Blob);
-      expect(requestObj.requestInit.body.size).to.equal(10);
-      expect(requestObj.requestInit.mode).to.equal('no-cors');
-      expect(requestObj.requestInit.headers['x-foo']).to.equal('bar');
-      expect(requestObj.requestInit.headers['x-qux']).to.equal('baz');
-      expect(requestObj.timestamp).to.equal(Date.now());
-
-      clock.restore();
+      expect(Object.getPrototypeOf(requestData)).to.equal(Object.prototype);
+      expect(requestData.url).to.equal('/foo');
+      expect(requestData.method).to.equal('POST');
+      expect(requestData.body).to.be.instanceOf(Blob);
+      expect(requestData.body.size).to.equal(10);
+      expect(requestData.mode).to.equal('no-cors');
+      expect(requestData.headers['x-foo']).to.equal('bar');
+      expect(requestData.headers['x-qux']).to.equal('baz');
     });
   });
 
@@ -138,28 +122,23 @@ describe(`[workbox-background-sync] StorableRequest`, function() {
   describe(`clone`, function() {
     it(`creates a new instance with the same values`, async function() {
       const original = new StorableRequest({
-        timestamp: 123456,
         url: '/foo',
-        requestInit: {
-          body: new Blob(['it worked!']),
-          method: 'POST',
-          mode: 'no-cors',
-          headers: {
-            'x-foo': 'bar',
-            'x-qux': 'baz',
-          },
+        body: new Blob(['it worked!']),
+        method: 'POST',
+        mode: 'no-cors',
+        headers: {
+          'x-foo': 'bar',
+          'x-qux': 'baz',
         },
       });
       const clone = original.clone();
 
-      expect(original.url).to.equal(clone.url);
-      expect(original.timestamp).to.equal(clone.timestamp);
-      expect(original.requestInit).to.deep.equal(clone.requestInit);
+      expect(original._requestData).to.deep.equal(clone._requestData);
 
       // Ensure clone was not shallow.
-      expect(original.requestInit.body).to.not.equal(clone.requestInit.body);
-      expect(original.requestInit.headers).to.not.equal(
-          clone.requestInit.headers);
+      expect(original._requestData.body).to.not.equal(clone._requestData.body);
+      expect(original._requestData.headers).to.not.equal(
+          clone._requestData.headers);
     });
   });
 });

--- a/test/workbox-background-sync/node/test-Plugin.mjs
+++ b/test/workbox-background-sync/node/test-Plugin.mjs
@@ -35,15 +35,14 @@ describe(`[workbox-background-sync] Plugin`, function() {
       expect(queuePlugin._queue).to.be.instanceOf(Queue);
     });
 
-    it(`should implement fetchDidFail and add requests to the queue`,
-        async function() {
-          sandbox.stub(Queue.prototype, 'addRequest');
-          const queuePlugin = new Plugin('foo');
+    it(`should implement fetchDidFail and add requests to the queue`, async function() {
+      const stub = sandbox.stub(Queue.prototype, 'pushRequest');
+      const queuePlugin = new Plugin('foo');
 
-          queuePlugin.fetchDidFail({request: new Request('/')});
-          expect(Queue.prototype.addRequest.calledOnce).to.be.true;
-          expect(Queue.prototype.addRequest.calledWith(
-              sinon.match.instanceOf(Request))).to.be.true;
-        });
+      queuePlugin.fetchDidFail({request: new Request('/one')});
+      expect(stub.callCount).to.equal(1);
+      expect(stub.args[0][0].request.url).to.equal('/one');
+      expect(stub.args[0][0].request).to.be.instanceOf(Request);
+    });
   });
 });

--- a/test/workbox-background-sync/node/test-Queue.mjs
+++ b/test/workbox-background-sync/node/test-Queue.mjs
@@ -13,7 +13,7 @@ import expectError from '../../../infra/testing/expectError';
 import {Queue} from '../../../packages/workbox-background-sync/Queue.mjs';
 import {QueueStore} from
   '../../../packages/workbox-background-sync/models/QueueStore.mjs';
-import {DB_NAME, OBJECT_STORE_NAME} from
+import {DB_NAME, DB_VERSION, OBJECT_STORE_NAME} from
   '../../../packages/workbox-background-sync/utils/constants.mjs';
 import {DBWrapper} from '../../../packages/workbox-core/_private/DBWrapper.mjs';
 import {resetEventListeners} from
@@ -22,7 +22,7 @@ import {resetEventListeners} from
 const MINUTES = 60 * 1000;
 
 const getObjectStoreEntries = async () => {
-  return await new DBWrapper(DB_NAME, 1).getAll(OBJECT_STORE_NAME);
+  return await new DBWrapper(DB_NAME, DB_VERSION).getAll(OBJECT_STORE_NAME);
 };
 
 describe(`[workbox-background-sync] Queue`, function() {
@@ -44,28 +44,26 @@ describe(`[workbox-background-sync] Queue`, function() {
   });
 
   describe(`constructor`, function() {
-    it(`should throw if two queues are created with the same name`,
-        async function() {
-          expect(() => {
-            new Queue('foo');
-            new Queue('bar');
-          }).not.to.throw();
+    it(`throws if two queues are created with the same name`, async function() {
+      expect(() => {
+        new Queue('foo');
+        new Queue('bar');
+      }).not.to.throw();
 
-          await expectError(() => {
-            new Queue('foo');
-          }, 'duplicate-queue-name');
+      await expectError(() => {
+        new Queue('foo');
+      }, 'duplicate-queue-name');
 
-          expect(() => {
-            new Queue('baz');
-          }).not.to.throw();
-        });
+      expect(() => {
+        new Queue('baz');
+      }).not.to.throw();
+    });
 
-    it(`should add a sync event listener that replays the queue when the ` +
-        `event is dispatched`, async function() {
+    it(`adds a sync event listener runs the onSync function when a sync event is dispatched`, async function() {
       sandbox.spy(self, 'addEventListener');
-      sandbox.stub(Queue.prototype, 'replayRequests');
+      const onSync = sandbox.spy();
 
-      new Queue('foo');
+      const queue = new Queue('foo', {onSync});
 
       expect(self.addEventListener.calledOnce).to.be.true;
       expect(self.addEventListener.calledWith('sync')).to.be.true;
@@ -79,111 +77,318 @@ describe(`[workbox-background-sync] Queue`, function() {
         tag: 'workbox-background-sync:bar',
       }));
 
-      expect(Queue.prototype.replayRequests.calledOnce).to.be.true;
+      expect(onSync.callCount).to.equal(1);
+      expect(onSync.firstCall.args[0]).to.equal(queue);
     });
 
-    it(`should try to replay the queue on SW startup in browsers that ` +
-        `don't support the sync event`, async function() {
+    it(`defaults to calling replayRequests when no onSync function is passed`, async function() {
+      sandbox.spy(self, 'addEventListener');
+      sandbox.stub(Queue.prototype, 'replayRequests');
+
+      const queue = new Queue('foo');
+
+      expect(self.addEventListener.calledOnce).to.be.true;
+      expect(self.addEventListener.calledWith('sync')).to.be.true;
+
+      self.dispatchEvent(new SyncEvent('sync', {
+        tag: 'workbox-background-sync:foo',
+      }));
+
+      // replayRequests should not be called for this due to incorrect tag name
+      self.dispatchEvent(new SyncEvent('sync', {
+        tag: 'workbox-background-sync:bar',
+      }));
+
+      expect(Queue.prototype.replayRequests.callCount).to.equal(1);
+      expect(Queue.prototype.replayRequests.firstCall.args[0]).to.equal(queue);
+    });
+
+    it(`tries to run the sync logic on instantiation in browsers that don't support the sync event`, async function() {
       // Delete the SyncManager interface to mock a non-supporting browser.
       const originalSyncManager = registration.sync;
       delete registration.sync;
 
-      sandbox.stub(Queue.prototype, 'replayRequests');
+      const onSync = sandbox.spy();
 
-      new Queue('foo');
-
-      expect(Queue.prototype.replayRequests.calledOnce).to.be.true;
-
+      new Queue('foo', {onSync});
       registration.sync = originalSyncManager;
+
+      expect(onSync.calledOnce).to.be.true;
     });
   });
 
-  describe(`addRequest`, function() {
-    it(`should serialize the request and store it in IndexedDB`,
-        async function() {
-          const now = Date.now();
-          const queue = new Queue('foo');
-          const requestUrl = 'https://example.com';
-          const requestInit = {
-            method: 'POST',
-            body: 'testing...',
-            headers: {'x-foo': 'bar'},
-            mode: 'cors',
-          };
-          const request = new Request(requestUrl, requestInit);
+  describe(`pushRequest`, function() {
+    it(`should add the request to the end QueueStore instance`, async function() {
+      sandbox.spy(QueueStore.prototype, 'pushEntry');
 
-          await queue.addRequest(request);
+      const queue = new Queue('a');
+      const requestUrl = 'https://example.com';
+      const requestInit = {
+        method: 'POST',
+        body: 'testing...',
+        headers: {'x-foo': 'bar'},
+        mode: 'cors',
+      };
+      const request = new Request(requestUrl, requestInit);
+      const timestamp = 1234;
+      const metadata = {meta: 'data'};
 
-          const entries = await getObjectStoreEntries();
-          expect(entries).to.have.lengthOf(1);
-          expect(entries[0].storableRequest.url).to.equal(requestUrl);
-          expect(entries[0].storableRequest.timestamp).to.be.at.least(now);
-          expect(entries[0].storableRequest.requestInit).to.have.keys([
-            'method',
-            'body',
-            'headers',
-            'mode',
-            'credentials',
-          ]);
-        });
+      await queue.pushRequest({request, timestamp, metadata});
 
-    it(`should register to receive sync events for a unique tag`,
-        async function() {
-          sandbox.stub(self.registration, 'sync').value({
-            register: sinon.stub().resolves(),
-          });
+      expect(QueueStore.prototype.pushEntry.callCount).to.equal(1);
 
-          const queue = new Queue('foo');
-          const requestUrl = 'https://example.com';
-          const requestInit = {
-            method: 'POST',
-            body: 'testing...',
-            headers: {'x-foo': 'bar'},
-            mode: 'cors',
-          };
-          const request = new Request(requestUrl, requestInit);
-
-          await queue.addRequest(request);
-
-          expect(self.registration.sync.register.calledOnce).to.be.true;
-          expect(self.registration.sync.register.calledWith(
-              'workbox-background-sync:foo')).to.be.true;
-        });
-
-    it(`should invoke the requestWillEnqueue callback`, async function() {
-      const queue = new Queue('foo', {
-        callbacks: {
-          requestWillEnqueue: (storableRequest) => {
-            storableRequest.url += '?q=foo';
-          },
-        },
-      });
-
-      const request = new Request('/');
-      await queue.addRequest(request);
-
-      const entries = await getObjectStoreEntries();
-      expect(entries).to.have.lengthOf(1);
-      expect(entries[0].storableRequest.url).to.equal('/?q=foo');
+      const args = QueueStore.prototype.pushEntry.firstCall.args;
+      expect(args[0].requestData.url).to.equal(requestUrl);
+      expect(args[0].requestData.method).to.equal(requestInit.method);
+      expect(args[0].requestData.headers).to.deep.equal(requestInit.headers);
+      expect(args[0].requestData.mode).to.deep.equal(requestInit.mode);
+      expect(args[0].requestData.body).to.be.instanceOf(Blob);
+      expect(args[0].timestamp).to.equal(timestamp);
+      expect(args[0].metadata).to.deep.equal(metadata);
     });
 
-    it(`should support modifying the stored request via requestWillEnqueue`,
-        async function() {
-          const requestWillEnqueue = sinon.spy();
-          const queue = new Queue('foo', {
-            callbacks: {requestWillEnqueue},
-          });
+    it(`should not require metadata`, async function() {
+      sandbox.spy(QueueStore.prototype, 'pushEntry');
 
-          const request = new Request('/');
-          await queue.addRequest(request);
+      const queue = new Queue('a');
+      const request = new Request('https://example.com');
 
-          expect(requestWillEnqueue.calledOnce).to.be.true;
-          expect(requestWillEnqueue.calledWith(sinon.match({
-            url: '/',
-            timestamp: sinon.match.number,
-            requestInit: sinon.match.object,
-          }))).to.be.true;
-        });
+      await queue.pushRequest({request});
+
+      expect(QueueStore.prototype.pushEntry.callCount).to.equal(1);
+
+      const args = QueueStore.prototype.pushEntry.firstCall.args;
+      expect(args[0].metadata).to.be.undefined;
+    });
+
+    it(`should use the current time as the timestamp when not specified`, async function() {
+      sandbox.spy(QueueStore.prototype, 'pushEntry');
+
+      sandbox.useFakeTimers({
+        toFake: ['Date'],
+        now: 1234,
+      });
+
+      const queue = new Queue('a');
+      const request = new Request('https://example.com');
+
+      await queue.pushRequest({request});
+
+      expect(QueueStore.prototype.pushEntry.callCount).to.equal(1);
+
+      const args = QueueStore.prototype.pushEntry.firstCall.args;
+      expect(args[0].timestamp).to.equal(1234);
+    });
+
+    it(`should register to receive sync events for a unique tag`, async function() {
+      sandbox.stub(self.registration, 'sync').value({
+        register: sinon.stub().resolves(),
+      });
+
+      const queue = new Queue('foo');
+
+      await queue.pushRequest({request: new Request('/')});
+
+      expect(self.registration.sync.register.calledOnce).to.be.true;
+      expect(self.registration.sync.register.calledWith(
+          'workbox-background-sync:foo')).to.be.true;
+    });
+  });
+
+  describe(`unshiftRequest`, function() {
+    it(`should add the request to the beginning of the QueueStore`, async function() {
+      sandbox.spy(QueueStore.prototype, 'unshiftEntry');
+
+      const queue = new Queue('a');
+      const requestUrl = 'https://example.com';
+      const requestInit = {
+        method: 'POST',
+        body: 'testing...',
+        headers: {'x-foo': 'bar'},
+        mode: 'cors',
+      };
+      const request = new Request(requestUrl, requestInit);
+      const timestamp = 1234;
+      const metadata = {meta: 'data'};
+
+      await queue.unshiftRequest({request, timestamp, metadata});
+
+      expect(QueueStore.prototype.unshiftEntry.callCount).to.equal(1);
+
+      const args = QueueStore.prototype.unshiftEntry.firstCall.args;
+      expect(args[0].requestData.url).to.equal(requestUrl);
+      expect(args[0].requestData.method).to.equal(requestInit.method);
+      expect(args[0].requestData.headers).to.deep.equal(requestInit.headers);
+      expect(args[0].requestData.mode).to.deep.equal(requestInit.mode);
+      expect(args[0].requestData.body).to.be.instanceOf(Blob);
+      expect(args[0].timestamp).to.equal(timestamp);
+      expect(args[0].metadata).to.deep.equal(metadata);
+    });
+
+    it(`should not require metadata`, async function() {
+      sandbox.spy(QueueStore.prototype, 'unshiftEntry');
+
+      const queue = new Queue('a');
+      const request = new Request('https://example.com');
+
+      await queue.unshiftRequest({request});
+
+      expect(QueueStore.prototype.unshiftEntry.callCount).to.equal(1);
+
+      const args = QueueStore.prototype.unshiftEntry.firstCall.args;
+      expect(args[0].metadata).to.be.undefined;
+    });
+
+    it(`should use the current time as the timestamp when not specified`, async function() {
+      sandbox.spy(QueueStore.prototype, 'unshiftEntry');
+
+      const queue = new Queue('a');
+      const request = new Request('https://example.com');
+
+      const startTime = Date.now();
+      await queue.unshiftRequest({request});
+      const endTime = Date.now();
+
+      expect(QueueStore.prototype.unshiftEntry.callCount).to.equal(1);
+
+      const args = QueueStore.prototype.unshiftEntry.firstCall.args;
+      expect(args[0].timestamp >= startTime).to.be.ok;
+      expect(args[0].timestamp <= endTime).to.be.ok;
+    });
+
+    it(`should register to receive sync events for a unique tag`, async function() {
+      sandbox.stub(self.registration, 'sync').value({
+        register: sinon.stub().resolves(),
+      });
+
+      const queue = new Queue('foo');
+
+      await queue.unshiftRequest({request: new Request('/')});
+
+      expect(self.registration.sync.register.calledOnce).to.be.true;
+      expect(self.registration.sync.register.calledWith(
+          'workbox-background-sync:foo')).to.be.true;
+    });
+  });
+
+  describe(`shiftRequest`, function() {
+    it(`gets and removes the first request in the QueueStore instance`, async function() {
+      sandbox.spy(QueueStore.prototype, 'shiftEntry');
+
+      const queue = new Queue('a');
+      const requestUrl = 'https://example.com';
+      const requestInit = {
+        method: 'POST',
+        body: 'testing...',
+        headers: {'x-foo': 'bar'},
+        mode: 'cors',
+      };
+
+      await queue.pushRequest({request: new Request(requestUrl, requestInit)});
+      // Add a second request to ensure the first one is returned.
+      await queue.pushRequest({request: new Request('/two')});
+
+      const {request} = await queue.shiftRequest();
+
+      expect(QueueStore.prototype.shiftEntry.callCount).to.equal(1);
+      expect(request.url).to.equal(requestUrl);
+      expect(request.method).to.equal(requestInit.method);
+      expect(request.mode).to.deep.equal(requestInit.mode);
+      expect(await request.text()).to.equal(requestInit.body);
+      expect(request.headers.get('x-foo')).to.equal(
+          requestInit.headers['x-foo']);
+    });
+
+    it(`returns the timestamp and any passed metadata along with the request`, async function() {
+      const queue = new Queue('a');
+
+      await queue.pushRequest({
+        metadata: {meta: 'data'},
+        request: new Request('/one'),
+      });
+
+      const {request, metadata} = await queue.shiftRequest();
+
+      expect(request.url).to.equal('/one');
+      expect(metadata).to.deep.equal({meta: 'data'});
+    });
+
+    it(`does not return requests that have expired`, async function() {
+      const queue = new Queue('a');
+
+      await queue.pushRequest({request: new Request('/one'), timestamp: 12});
+      await queue.pushRequest({request: new Request('/two')});
+      await queue.pushRequest({request: new Request('/three'), timestamp: 34});
+      await queue.pushRequest({request: new Request('/four')});
+
+      const entry1 = await queue.shiftRequest();
+      const entry2 = await queue.shiftRequest();
+      const entry3 = await queue.shiftRequest();
+
+      expect(entry1.request.url).to.equal('/two');
+      expect(entry2.request.url).to.equal('/four');
+      expect(entry3).to.be.undefined;
+    });
+  });
+
+  describe(`popRequest`, function() {
+    it(`gets and removes the last request in the QueueStore instance`, async function() {
+      sandbox.spy(QueueStore.prototype, 'popEntry');
+
+      const queue = new Queue('a');
+      const requestUrl = 'https://example.com';
+      const requestInit = {
+        method: 'POST',
+        body: 'testing...',
+        headers: {'x-foo': 'bar'},
+        mode: 'cors',
+      };
+
+      // Add a second request to ensure the last one is returned.
+      await queue.pushRequest({request: new Request('/two')});
+      await queue.pushRequest({request: new Request(requestUrl, requestInit)});
+
+      const {request} = await queue.popRequest();
+
+      expect(QueueStore.prototype.popEntry.callCount).to.equal(1);
+      expect(request.url).to.equal(requestUrl);
+      expect(request.method).to.equal(requestInit.method);
+      expect(request.mode).to.deep.equal(requestInit.mode);
+      expect(await request.text()).to.equal(requestInit.body);
+      expect(request.headers.get('x-foo')).to.equal(
+          requestInit.headers['x-foo']);
+    });
+
+    it(`returns the timestamp and any passed metadata along with the request`, async function() {
+      const queue = new Queue('a');
+
+      await queue.pushRequest({
+        metadata: {meta: 'data'},
+        request: new Request('/one'),
+      });
+
+      const {request, metadata} = await queue.popRequest();
+
+      expect(request.url).to.equal('/one');
+      expect(metadata).to.deep.equal({meta: 'data'});
+    });
+
+    it(`does not return requests that have expired`, async function() {
+      const queue = new Queue('a');
+
+      await queue.pushRequest({request: new Request('/one'), timestamp: 12});
+      await queue.pushRequest({request: new Request('/two')});
+      await queue.pushRequest({request: new Request('/three'), timestamp: 34});
+      await queue.pushRequest({request: new Request('/four')});
+
+      const entry1 = await queue.popRequest();
+      const entry2 = await queue.popRequest();
+      const entry3 = await queue.popRequest();
+
+      expect(entry1.request.url).to.equal('/four');
+      expect(entry2.request.url).to.equal('/two');
+      expect(entry3).to.be.undefined;
+    });
   });
 
   describe(`replayRequests`, function() {
@@ -195,11 +400,11 @@ describe(`[workbox-background-sync] Queue`, function() {
 
       // Add requests for both queues to ensure only the requests from
       // the matching queue are replayed.
-      await queue1.addRequest(new Request('/one'));
-      await queue2.addRequest(new Request('/two'));
-      await queue1.addRequest(new Request('/three'));
-      await queue2.addRequest(new Request('/four'));
-      await queue1.addRequest(new Request('/five'));
+      await queue1.pushRequest({request: new Request('/one')});
+      await queue2.pushRequest({request: new Request('/two')});
+      await queue1.pushRequest({request: new Request('/three')});
+      await queue2.pushRequest({request: new Request('/four')});
+      await queue1.pushRequest({request: new Request('/five')});
 
       await queue1.replayRequests();
 
@@ -237,234 +442,105 @@ describe(`[workbox-background-sync] Queue`, function() {
 
       // Add requests for both queues to ensure only the requests from
       // the matching queue are replayed.
-      await queue1.addRequest(new Request('/one'));
-      await queue2.addRequest(new Request('/two'));
-      await queue1.addRequest(new Request('/three'));
-      await queue2.addRequest(new Request('/four'));
-      await queue1.addRequest(new Request('/five'));
+      await queue1.pushRequest({request: new Request('/one')});
+      await queue2.pushRequest({request: new Request('/two')});
+      await queue1.pushRequest({request: new Request('/three')});
+      await queue2.pushRequest({request: new Request('/four')});
+      await queue1.pushRequest({request: new Request('/five')});
 
       await queue1.replayRequests();
       expect(self.fetch.callCount).to.equal(3);
 
       const entries = await getObjectStoreEntries();
       expect(entries.length).to.equal(2);
-      expect(entries[0].storableRequest.url).to.equal('/two');
-      expect(entries[1].storableRequest.url).to.equal('/four');
+      expect(entries[0].requestData.url).to.equal('/two');
+      expect(entries[1].requestData.url).to.equal('/four');
     });
 
-    it(`should ignore (and remove) requests if maxRetentionTime has passed`,
-        async function() {
-          sandbox.spy(self, 'fetch');
-          const clock = sandbox.useFakeTimers({
-            now: Date.now(),
-            toFake: ['Date'],
-          });
-
-          const queue = new Queue('foo', {
-            maxRetentionTime: 1,
-          });
-
-          await queue.addRequest(new Request('/one'));
-          await queue.addRequest(new Request('/two'));
-
-          clock.tick(1 * MINUTES + 1); // One minute and 1ms.
-
-          await queue.addRequest(new Request('/three'));
-          await queue.replayRequests();
-
-          expect(self.fetch.calledOnce).to.be.true;
-          expect(self.fetch.calledWith(sinon.match({
-            url: '/three',
-          }))).to.be.true;
-
-          const entries = await getObjectStoreEntries();
-          // Assert that the two requests not replayed were deleted.
-          expect(entries.length).to.equal(0);
-        });
-
-    it(`should keep a request in the queue if re-fetching fails`,
-        async function() {
-          sandbox.stub(self, 'fetch')
-              .onCall(1).rejects(new Error())
-              .onCall(3).rejects(new Error())
-              .callThrough();
-
-          const queue = new Queue('foo');
-
-          await queue.addRequest(new Request('/one'));
-          await queue.addRequest(new Request('/two'));
-          await queue.addRequest(new Request('/three'));
-          await queue.addRequest(new Request('/four'));
-          await queue.addRequest(new Request('/five'));
-
-          await expectError(() => {
-            return queue.replayRequests(); // The 2nd and 4th requests should fail.
-          }, 'queue-replay-failed');
-
-          const entries = await getObjectStoreEntries();
-          expect(entries.length).to.equal(2);
-          expect(entries[0].storableRequest.url).to.equal('/two');
-          expect(entries[1].storableRequest.url).to.equal('/four');
-        });
-
-    it(`should throw WorkboxError if re-fetching fails`,
-        async function() {
-          sandbox.stub(self, 'fetch')
-              .onCall(1).rejects(new Error())
-              .callThrough();
-
-          const failureURL = '/two';
-          const queue = new Queue('foo');
-
-          // Add requests for both queues to ensure only the requests from
-          // the matching queue are replayed.
-          await queue.addRequest(new Request('/one'));
-          await queue.addRequest(new Request(failureURL));
-
-          await expectError(() => {
-            return queue.replayRequests();
-          }, 'queue-replay-failed');
-        });
-
-    it(`should invoke all replay callbacks`, async function() {
-      const requestWillReplay = sinon.spy();
-      const queueDidReplay = sinon.spy();
-
-      const queue = new Queue('foo', {
-        callbacks: {
-          requestWillReplay,
-          queueDidReplay,
-        },
+    it(`should ignore (and remove) requests if maxRetentionTime has passed`, async function() {
+      sandbox.spy(self, 'fetch');
+      const clock = sandbox.useFakeTimers({
+        now: Date.now(),
+        toFake: ['Date'],
       });
 
-      await queue.addRequest(new Request('/one'));
-      await queue.addRequest(new Request('/two'));
+      const queue = new Queue('foo', {
+        maxRetentionTime: 1,
+      });
+
+      await queue.pushRequest({request: new Request('/one')});
+      await queue.pushRequest({request: new Request('/two')});
+
+      clock.tick(1 * MINUTES + 1); // One minute and 1ms.
+
+      await queue.pushRequest({request: new Request('/three')});
       await queue.replayRequests();
 
-      expect(requestWillReplay.calledTwice).to.be.true;
-      expect(requestWillReplay.getCall(0).calledWith(sinon.match({
-        url: '/one',
-        timestamp: sinon.match.number,
-        requestInit: sinon.match.object,
-      }))).to.be.true;
-      expect(requestWillReplay.getCall(1).calledWith(sinon.match({
-        url: '/two',
-        timestamp: sinon.match.number,
-        requestInit: sinon.match.object,
+      expect(self.fetch.calledOnce).to.be.true;
+      expect(self.fetch.calledWith(sinon.match({
+        url: '/three',
       }))).to.be.true;
 
-      expect(queueDidReplay.calledOnce).to.be.true;
-      expect(queueDidReplay.calledWith(sinon.match([
-        sinon.match({
-          request: sinon.match.instanceOf(Request).and(
-              sinon.match({url: '/one'})),
-          response: sinon.match.instanceOf(Response),
-        }),
-        sinon.match({
-          request: sinon.match.instanceOf(Request).and(
-              sinon.match({url: '/two'})),
-          response: sinon.match.instanceOf(Response),
-        }),
-      ]))).to.be.true;
+      const entries = await getObjectStoreEntries();
+      // Assert that the two requests not replayed were deleted.
+      expect(entries.length).to.equal(0);
+    });
 
-      requestWillReplay.resetHistory();
-      queueDidReplay.resetHistory();
+    it(`should stop replaying if a request fails`, async function() {
+      sandbox.stub(self, 'fetch')
+          .onCall(3).rejects(new Error())
+          .callThrough();
 
+      const queue = new Queue('foo');
+
+      await queue.pushRequest({request: new Request('/one')});
+      await queue.pushRequest({request: new Request('/two')});
+      await queue.pushRequest({request: new Request('/three')});
+      await queue.pushRequest({request: new Request('/four')});
+      await queue.pushRequest({request: new Request('/five')});
+
+      await expectError(() => {
+        return queue.replayRequests(); // The 4th requests should fail.
+      }, 'queue-replay-failed');
+
+      const entries = await getObjectStoreEntries();
+      expect(entries.length).to.equal(2);
+      expect(entries[0].requestData.url).to.equal('/four');
+      expect(entries[1].requestData.url).to.equal('/five');
+    });
+
+    it(`should throw WorkboxError if re-fetching fails`, async function() {
       sandbox.stub(self, 'fetch')
           .onCall(1).rejects(new Error())
           .callThrough();
 
-      await queue.addRequest(new Request('/three'));
-      await queue.addRequest(new Request('/four'));
+      const failureURL = '/two';
+      const queue = new Queue('foo');
+
+      // Add requests for both queues to ensure only the requests from
+      // the matching queue are replayed.
+      await queue.pushRequest({request: new Request('/one')});
+      await queue.pushRequest({request: new Request(failureURL)});
+
       await expectError(() => {
         return queue.replayRequests();
       }, 'queue-replay-failed');
-
-      expect(requestWillReplay.calledTwice).to.be.true;
-
-      expect(queueDidReplay.calledOnce).to.be.true;
-      expect(queueDidReplay.calledWith(sinon.match([
-        sinon.match({
-          request: sinon.match.instanceOf(Request).and(
-              sinon.match({url: '/three'})),
-          response: sinon.match.instanceOf(Response),
-        }),
-        sinon.match({
-          request: sinon.match.instanceOf(Request).and(
-              sinon.match({url: '/four'})),
-          error: sinon.match.instanceOf(Error),
-        }),
-      ]))).to.be.true;
     });
-
-    it(`should support modifying the request via the requestWillReplay`,
-        async function() {
-          sandbox.spy(self, 'fetch');
-
-          const requestWillReplay = (storableRequest) => {
-            storableRequest.url += '?q=foo';
-          };
-
-          const queue = new Queue('foo', {
-            callbacks: {requestWillReplay},
-          });
-
-          await queue.addRequest(new Request('/one'));
-          await queue.addRequest(new Request('/two'));
-          await queue.replayRequests();
-
-          expect(self.fetch.calledTwice).to.be.true;
-          expect(self.fetch.getCall(0).calledWith(sinon.match({
-            url: '/one?q=foo',
-          }))).to.be.true;
-          expect(self.fetch.getCall(1).calledWith(sinon.match({
-            url: '/two?q=foo',
-          }))).to.be.true;
-        });
-
-    it(`should store the original request if a modified request replay fails`,
-        async function() {
-          sandbox.stub(self, 'fetch').rejects();
-          sandbox.spy(QueueStore.prototype, 'addEntry');
-
-          const requestWillReplay = (storableRequest) => {
-            storableRequest.url += '?q=foo';
-            storableRequest.requestInit.headers['x-foo'] = 'bar';
-          };
-
-          const queue = new Queue('foo', {
-            callbacks: {requestWillReplay},
-          });
-
-          await queue.addRequest(new Request('/one'));
-          await queue.addRequest(new Request('/two'));
-
-
-          await expectError(() => {
-            return queue.replayRequests();
-          }, 'queue-replay-failed');
-
-          // Ensure the re-enqueued requests are the same as the originals.
-          expect(QueueStore.prototype.addEntry.getCall(0).args).to.deep.equal(
-              QueueStore.prototype.addEntry.getCall(2).args);
-          expect(QueueStore.prototype.addEntry.getCall(1).args).to.deep.equal(
-              QueueStore.prototype.addEntry.getCall(3).args);
-        });
   });
 
-  describe(`_registerSync()`, function() {
-    it(`should support _registerSync() in supporting browsers`, async function() {
+  describe(`registerSync()`, function() {
+    it(`should support registerSync() in supporting browsers`, async function() {
       const queue = new Queue('foo');
-      await queue._registerSync();
+      await queue.registerSync();
     });
 
-    it(`should support _registerSync() in non-supporting browsers`, async function() {
+    it(`should support registerSync() in non-supporting browsers`, async function() {
       // Delete the SyncManager interface to mock a non-supporting browser.
       const originalSyncManager = registration.sync;
       delete registration.sync;
 
       const queue = new Queue('foo');
-      await queue._registerSync();
+      await queue.registerSync();
 
       registration.sync = originalSyncManager;
     });
@@ -475,7 +551,7 @@ describe(`[workbox-background-sync] Queue`, function() {
       });
 
       const queue = new Queue('foo');
-      await queue._registerSync();
+      await queue.registerSync();
     });
   });
 });

--- a/test/workbox-background-sync/node/test-Queue.mjs
+++ b/test/workbox-background-sync/node/test-Queue.mjs
@@ -78,7 +78,7 @@ describe(`[workbox-background-sync] Queue`, function() {
       }));
 
       expect(onSync.callCount).to.equal(1);
-      expect(onSync.firstCall.args[0]).to.equal(queue);
+      expect(onSync.firstCall.args[0].queue).to.equal(queue);
     });
 
     it(`defaults to calling replayRequests when no onSync function is passed`, async function() {
@@ -100,7 +100,8 @@ describe(`[workbox-background-sync] Queue`, function() {
       }));
 
       expect(Queue.prototype.replayRequests.callCount).to.equal(1);
-      expect(Queue.prototype.replayRequests.firstCall.args[0]).to.equal(queue);
+      expect(Queue.prototype.replayRequests.firstCall.args[0].queue)
+          .to.equal(queue);
     });
 
     it(`tries to run the sync logic on instantiation in browsers that don't support the sync event`, async function() {

--- a/test/workbox-background-sync/static/basic-example/sw.js
+++ b/test/workbox-background-sync/static/basic-example/sw.js
@@ -6,8 +6,10 @@
   https://opensource.org/licenses/MIT.
 */
 
-importScripts('/__WORKBOX/buildFile/workbox-core');
-importScripts('/__WORKBOX/buildFile/workbox-background-sync');
+importScripts('/__WORKBOX/buildFile/workbox-sw');
+importScripts('/infra/testing/comlink/sw-interface.js');
+
+workbox.setConfig({modulePathPrefix: '/__WORKBOX/buildFile/'});
 
 /* globals workbox */
 
@@ -17,7 +19,7 @@ self.addEventListener('fetch', (event) => {
   const pathname = new URL(event.request.url).pathname;
   if (pathname === '/test/workbox-background-sync/static/basic-example/example.txt') {
     const queuePromise = (async () => {
-      await queue.addRequest(event.request);
+      await queue.pushRequest({request: event.request});
       // This is a horrible hack :(
       // In non-sync supporting browsers we only replay requests when the SW starts up
       // but there is no API to force close a service worker, so just force a replay in

--- a/test/workbox-core/node/_private/test-DBWrapper.mjs
+++ b/test/workbox-core/node/_private/test-DBWrapper.mjs
@@ -690,7 +690,7 @@ describe(`migrateDb`, function() {
         expect(v1Spy.callCount).to.equal(1);
         next();
         done();
-      }
+      },
     };
 
     migrateDb({oldVersion: 0, newVersion: 2}, migrationFunctions);
@@ -720,7 +720,7 @@ describe(`migrateDb`, function() {
         expect(v1Spy.callCount).to.equal(1);
         next();
         done();
-      }
+      },
     };
 
     migrateDb({oldVersion: 1, newVersion: 2}, migrationFunctions);

--- a/test/workbox-core/node/_private/test-DBWrapper.mjs
+++ b/test/workbox-core/node/_private/test-DBWrapper.mjs
@@ -10,6 +10,7 @@ import {expect} from 'chai';
 import sinon from 'sinon';
 import {DBWrapper} from '../../../../packages/workbox-core/_private/DBWrapper.mjs';
 import {deleteDatabase} from '../../../../packages/workbox-core/_private/deleteDatabase.mjs';
+import {migrateDb} from '../../../../packages/workbox-core/_private/migrateDb.mjs';
 
 
 const catchAsyncError = async (promiseOrFn) => {
@@ -122,7 +123,7 @@ const createAndPopulateTestDb = async () => {
 };
 
 
-describe(`DBWrapper`, function() {
+xdescribe(`DBWrapper`, function() {
   beforeEach(async function() {
     // This help when re-running the tests manually after a previous failure
     // where the database didn't get properly closed/deleted.
@@ -655,5 +656,73 @@ describe(`deleteDatabase`, function() {
     await createTestDb();
     const err = await catchAsyncError(deleteDatabase('db'));
     expect(err).to.equal(fakeError);
+  });
+});
+
+describe(`migrateDb`, function() {
+  beforeEach(async function() {
+    sandbox.restore();
+  });
+
+  it(`calls a series of versioned functions in order based on the event data`, function(done) {
+    const v0Spy = sandbox.spy();
+    const v1Spy = sandbox.spy();
+    const v2Spy = sandbox.spy();
+
+    const migrationFunctions = {
+      v0: (next) => {
+        v0Spy();
+        expect(v1Spy.callCount).to.equal(0);
+        expect(v2Spy.callCount).to.equal(0);
+        next();
+      },
+      v1: (next) => {
+        setTimeout(() => {
+          v1Spy();
+          expect(v0Spy.callCount).to.equal(1);
+          expect(v2Spy.callCount).to.equal(0);
+          next();
+        }, 0);
+      },
+      v2: (next) => {
+        v2Spy();
+        expect(v0Spy.callCount).to.equal(1);
+        expect(v1Spy.callCount).to.equal(1);
+        next();
+        done();
+      }
+    };
+
+    migrateDb({oldVersion: 0, newVersion: 2}, migrationFunctions);
+  });
+
+  it(`only calls the migration functions for the relevant versions`, function(done) {
+    const v0Spy = sandbox.spy();
+    const v1Spy = sandbox.spy();
+    const v2Spy = sandbox.spy();
+
+    const migrationFunctions = {
+      v0: (next) => {
+        v0Spy();
+        next();
+      },
+      v1: (next) => {
+        setTimeout(() => {
+          v1Spy();
+          expect(v0Spy.callCount).to.equal(0);
+          expect(v2Spy.callCount).to.equal(0);
+          next();
+        }, 0);
+      },
+      v2: (next) => {
+        v2Spy();
+        expect(v0Spy.callCount).to.equal(0);
+        expect(v1Spy.callCount).to.equal(1);
+        next();
+        done();
+      }
+    };
+
+    migrateDb({oldVersion: 1, newVersion: 2}, migrationFunctions);
   });
 });

--- a/test/workbox-google-analytics/integration/basic-example.js
+++ b/test/workbox-google-analytics/integration/basic-example.js
@@ -11,15 +11,13 @@ const qs = require('qs');
 const {By} = require('selenium-webdriver');
 const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 
-describe(`[workbox-google-analytics] Load and use Google Analytics`,
-    function() {
-      const driver = global.__workbox.webdriver;
-      const testServerAddress = global.__workbox.server.getAddress();
-      const testingUrl =
-    `${testServerAddress}/test/workbox-google-analytics/static/basic-example/`;
-      const swUrl = `${testingUrl}sw.js`;
+describe(`[workbox-google-analytics] Load and use Google Analytics`, function() {
+  const driver = global.__workbox.webdriver;
+  const testServerAddress = global.__workbox.server.getAddress();
+  const testingUrl = `${testServerAddress}/test/workbox-google-analytics/static/basic-example/`;
+  const swUrl = `${testingUrl}sw.js`;
 
-      /**
+  /**
    * Sends a mesage to the service worker via postMessage and invokes the
    * `done()` callback when the service worker responds, with any data value
    * passed to the event.
@@ -28,119 +26,120 @@ describe(`[workbox-google-analytics] Load and use Google Analytics`,
    * @param {Function} done The callback automatically passed via webdriver's
    *     `executeAsyncScript()` method.
    */
-      const messageSw = (data, done) => {
-        let messageChannel = new MessageChannel();
-        messageChannel.port1.onmessage = (evt) => done(evt.data);
-        navigator.serviceWorker.controller.postMessage(
-            data, [messageChannel.port2]);
-      };
+  const messageSw = (data, done) => {
+    let messageChannel = new MessageChannel();
+    messageChannel.port1.onmessage = (evt) => done(evt.data);
+    navigator.serviceWorker.controller.postMessage(
+        data, [messageChannel.port2]);
+  };
 
-      before(async function() {
-        // Load the page and wait for the first service worker to activate.
-        await driver.get(testingUrl);
+  before(async function() {
+    // Load the page and wait for the first service worker to activate.
+    await driver.get(testingUrl);
 
-        await activateAndControlSW(swUrl);
-      });
+    await activateAndControlSW(swUrl);
+  });
 
-      beforeEach(async function() {
-        // Reset the spied requests array.
-        await driver.executeAsyncScript(messageSw, {
-          action: 'clear-spied-requests',
-        });
-      });
+  beforeEach(async function() {
+    // Reset the spied requests array.
+    await driver.executeAsyncScript(messageSw, {
+      action: 'clear-spied-requests',
+    });
+  });
 
-      it(`should load a page with service worker`, async function() {
-        const err = await driver.executeAsyncScript((done) => {
-          fetch('https://www.google-analytics.com/analytics.js', {mode: 'no-cors'})
-              .then(() => done(), (err) => done(err.message));
-        });
+  it(`should load a page with service worker`, async function() {
+    const err = await driver.executeAsyncScript((done) => {
+      fetch('https://www.google-analytics.com/analytics.js', {mode: 'no-cors'})
+          .then(() => done(), (err) => done(err.message));
+    });
 
-        expect(err).to.not.exist;
-      });
+    expect(err).to.not.exist;
+  });
 
-      it(`replay failed Google Analytics hits`, async function() {
-        // Skip this test in browsers that don't support background sync.
-        // TODO(philipwalton): figure out a way to work around this.
-        const browserSuppotsSync = await driver.executeScript(() => {
-          return 'SyncManager' in window;
-        });
-        if (!browserSuppotsSync) this.skip();
+  it(`replay failed Google Analytics hits`, async function() {
+    // Skip this test in browsers that don't support background sync.
+    // TODO(philipwalton): figure out a way to work around this.
+    const browserSupportsSync = await driver.executeScript(() => {
+      return 'SyncManager' in window;
+    });
+    if (!browserSupportsSync) this.skip();
 
-        const simulateOfflineEl =
+    const simulateOfflineEl =
         await driver.findElement(By.id('simulate-offline'));
 
-        // Send a hit while online to ensure regular requests work.
-        await driver.executeAsyncScript((done) => {
-          window.gtag('event', 'beacon', {
-            transport_type: 'beacon',
-            event_callback: () => done(),
-          });
-        });
-
-        let requests = await driver.executeAsyncScript(messageSw, {
-          action: 'get-spied-requests',
-        });
-        expect(requests).to.have.lengthOf(1);
-
-        // Reset the spied requests array.
-        await driver.executeAsyncScript(messageSw, {
-          action: 'clear-spied-requests',
-        });
-
-        // Check the "simulate offline" checkbox and make some requests.
-        await simulateOfflineEl.click();
-        await driver.executeAsyncScript((done) => {
-          window.gtag('event', 'beacon', {
-            transport_type: 'beacon',
-            event_label: Date.now(),
-            event_callback: () => done(),
-          });
-        });
-        await driver.executeAsyncScript((done) => {
-          window.gtag('event', 'pixel', {
-            transport_type: 'image',
-            event_label: Date.now(),
-            event_callback: () => done(),
-          });
-        });
-        await driver.executeAsyncScript((done) => {
-          fetch('https://httpbin.org/get').then(() => done());
-        });
-
-        // Get all spied requests and ensure there haven't been any (since we're
-        // offline).
-        requests = await driver.executeAsyncScript(messageSw, {
-          action: 'get-spied-requests',
-        });
-        expect(requests).to.have.lengthOf(0);
-
-        // Uncheck the "simulate offline" checkbox and then trigger a sync.
-        await simulateOfflineEl.click();
-        await driver.executeAsyncScript(messageSw, {
-          action: 'dispatch-sync-event',
-        });
-
-        // Ensure only 2 requests have replayed, since only 2 of them were to GA.
-        requests = await driver.executeAsyncScript(messageSw, {
-          action: 'get-spied-requests',
-        });
-        expect(requests).to.have.lengthOf(2);
-
-        // Parse the request bodies to set the params as an object and convert the
-        // qt param to a number.
-        for (const request of requests) {
-          request.params = qs.parse(request.body);
-          request.params.qt = Number(request.params.qt);
-          request.originalTime = request.timestamp - request.params.qt;
-        }
-
-        expect(requests[0].params.ea).to.equal('beacon');
-        expect(requests[1].params.ea).to.equal('pixel');
-
-        // Ensure the hit's qt params were present and greater than 0,
-        // and ensure those values reflect the original order of the hits.
-        expect(requests[0].params.qt > 0).to.be.true;
-        expect(requests[0].params.qt > 0).to.be.true;
-        expect(requests[0].originalTime < requests[1].originalTime).to.be.true;
+    // Send a hit while online to ensure regular requests work.
+    await driver.executeAsyncScript((done) => {
+      window.gtag('event', 'beacon', {
+        transport_type: 'beacon',
+        event_callback: () => done(),
       });
     });
+
+    let requests = await driver.executeAsyncScript(messageSw, {
+      action: 'get-spied-requests',
+    });
+    expect(requests).to.have.lengthOf(1);
+
+    // Reset the spied requests array.
+    await driver.executeAsyncScript(messageSw, {
+      action: 'clear-spied-requests',
+    });
+
+    // Check the "simulate offline" checkbox and make some requests.
+    await simulateOfflineEl.click();
+    await driver.executeAsyncScript((done) => {
+      window.gtag('event', 'beacon', {
+        transport_type: 'beacon',
+        event_label: Date.now(),
+        event_callback: () => done(),
+      });
+    });
+    await driver.executeAsyncScript((done) => {
+      window.gtag('event', 'pixel', {
+        transport_type: 'image',
+        event_label: Date.now(),
+        event_callback: () => done(),
+      });
+    });
+    await driver.executeAsyncScript((done) => {
+      fetch('https://httpbin.org/get').then(() => done());
+    });
+
+    // Get all spied requests and ensure there haven't been any (since we're
+    // offline).
+    requests = await driver.executeAsyncScript(messageSw, {
+      action: 'get-spied-requests',
+    });
+    expect(requests).to.have.lengthOf(0);
+
+    // Uncheck the "simulate offline" checkbox and then trigger a sync.
+    await simulateOfflineEl.click();
+    await driver.executeAsyncScript(messageSw, {
+      action: 'dispatch-sync-event',
+    });
+
+    // Ensure only 2 requests have replayed, since only 2 of them were to GA.
+    requests = await driver.executeAsyncScript(messageSw, {
+      action: 'get-spied-requests',
+    });
+    expect(requests).to.have.lengthOf(2);
+
+    // Parse the request bodies to set the params as an object and convert the
+    // qt param to a number.
+    for (const request of requests) {
+      request.params = qs.parse(request.body);
+      request.params.qt = Number(request.params.qt);
+      request.originalTime = request.timestamp - request.params.qt;
+    }
+
+
+    expect(requests[0].params.ea).to.equal('beacon');
+    expect(requests[1].params.ea).to.equal('pixel');
+
+    // Ensure the hit's qt params were present and greater than 0,
+    // and ensure those values reflect the original order of the hits.
+    expect(requests[0].params.qt > 0).to.be.true;
+    expect(requests[0].params.qt > 0).to.be.true;
+    expect(requests[0].originalTime < requests[1].originalTime).to.be.true;
+  });
+});


### PR DESCRIPTION
R: @jeffposnick

Addresses #1424, #1502, #1503, #1637, and #1695.

Based on lots of feedback in the above issues/PRs, its clear that the callbacks provided in `workbox.backgroundSync.Queue` are not sufficient to handle many real-world background sync needs.

This PR attempts to solve this issue by exposing more low-level features of the queue, which should give developers all the flexibility they need; the downside is it may make very simple replay modifications a bit more complicated. Hopefully (due to the complex nature of background sync in general), this downside will affect very few people.

## Current API:

In Workbox v3, the `workbox.backgroundSync.Queue` class had the following public methods:

- `addRequest()`
- `replayRequests()`

And the following replay callbacks that allowed you modify requests as the queue was replaying:

- `requestWillEnqueue`
- `requestWillReplay`
- `queueDidReplay`

But if you wanted to do something other than simply replay every single request, it was very difficult if not impossible. For example, you couldn't easily:

- Update a request based on the response from the previous request.
- Remove an individual request from the queue or otherwise prevent it from sending.
- Send the queued requests in a different order.

## Proposed changes:

To support the above use cases, the changes in this PR remove the `callbacks` object and replace it with a single `onSync` callback. The `onSync` callback will be invoked whenever the queue receives a `sync` event (or at SW startup in non-sync browsers), and if you don't specify an `onSync` callback, the default behavior is to run `replayRequests()` like in v3 (but without invoking the v3 callbacks).

The `onSync` callback is invoked with the `queue` instance as its only argument, allowing you to handle the queue however you want in response to a `sync` event.

In addition, the `workbox.backgroundSync.Queue` class has removed the `addRequest()` method, and replaced it with four array-like methods to make it easier to manage queued requests manually.

- `pushRequest()`
- `popRequests()`
- `shiftRequest()`
- `unshiftRequests()`

The `push` and `unshift` methods take an object in the form `{request, [metadata], [timestamp]}` (only `request` is required), and the `shift` and `pop` methods return an object in exactly the same form.

The optional `metadata` property allows you to store data associated with the request in the queue that may be relevant when re-fetching the request later.

The optional `timestamp` property defaults to the current time, and it affects when requests expire. Normally you don't need to pass this, but it can be useful if you want to explicitly reset the expiry time for a particular request in order to keep it in the queue longer.

### Example `onSync` callback

To replay all requests in the queue after a sync event, you could do the following:

```js
const queue = new workbox.backgroundSync.Queue('my-queue-name', {
  onSync: async (queue) => {
    let entry;
    while (entry = await this.shiftRequest()) {
      try {
        await fetch(entry.request);
      } catch (error) {
        console.error('Replay failed for request', entry.request, error);
        await this.unshiftRequest(entry);
        return;
      }
    }
    console.log('Replay complete!');
  }
});
```

Note: when using an `async` function for the `onSync` callback (recommended) the `sync` event automatically waits for the function to complete, so you don't have to manually call `event.waitUntil()`.

### Using the `Plugin` class

Since the plugin class mostly just shadows the `Queue` class, you can pass the `onSync` callback to plugin instances in exactly the same way.

Note that when using the plugin, the `onSync` callback is still invoked with a `Queue` instance, so you don't have to create a reference to the queue yourself.

```js
new workbox.backgroundSync.Plugin('my-queue-name', {
  onSync: async (queue) => {
    // queue is an instance of `Queue` not `Plugin`.
  }
});
```

### Open questions

By removing the `callback` object in favor of a single `onSync` callback, one thing that is harder to accomplish is notifying of a successful queue replay in situations where you don't want to modify the replay logic.

With the changes in this PR, it's still possible, it's just perhaps not as intuative as before. Here's what you'd have to do:

```js
const queue = new workbox.backgroundSync.Queue('my-queue-name', {
  onSync: async (queue) => {
    await queue.replayRequests();

    // The replay was successful! Notification logic can go here.
    console.log('Replay complete!');
  }
});
```

If you want to notify of success *and* failure, you can use a try/catch block:

```js
const queue = new workbox.backgroundSync.Queue('my-queue-name', {
  onSync: async (queue) => {
    try {
      await queue.replayRequests();
      
      // The replay was successful! Notification logic can go here.
      console.log('Replay complete!');
    } catch (error) {
      // The replay failed...
      console.log(error);
    }
  }
});
```

Since the above examples are both pretty simple, I'm leaning toward not having onsuccess or onfailure callbacks like before, but if enough people want them, I could be persuaded otherwise.


