### PR TITLE
Fail SW installation when a precaching request results in an error response

### DIFF
--- a/packages/workbox-core/models/messages/messages.mjs
+++ b/packages/workbox-core/models/messages/messages.mjs
@@ -242,4 +242,9 @@ export default {
     }
     return message;
   },
+
+  'bad-precaching-response': ({url, status}) => {
+    return `The precaching request for '${url}' failed with an HTTP ` +
+      `status of ${status}.`;
+  },
 };

--- a/packages/workbox-precaching/_default.mjs
+++ b/packages/workbox-precaching/_default.mjs
@@ -151,17 +151,22 @@ moduleExports.precache = (entries) => {
 
   installActivateListenersAdded = true;
   self.addEventListener('install', (event) => {
-    event.waitUntil(precacheController.install({
-      event,
-      plugins,
-      suppressWarnings,
-    }));
+    event.waitUntil(
+        precacheController.install({event, plugins, suppressWarnings})
+            .catch((error) => {
+              if (process.env.NODE_ENV !== 'production') {
+                logger.error(`Service worker installation failed. It will ` +
+                `be retried automatically during the next navigation.`);
+              }
+              // Re-throw the error to ensure installation fails.
+              throw error;
+            })
+    );
   });
   self.addEventListener('activate', (event) => {
-    event.waitUntil(precacheController.activate({
-      event,
-      plugins,
-    }));
+    event.waitUntil(
+        precacheController.activate({event, plugins})
+    );
   });
 };
 

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -237,8 +237,13 @@ class PrecacheController {
   }
 
   /**
-   * Requests the entry and saves it to the cache if the response
-   * is valid.
+   * Requests the entry and saves it to the cache if the response is valid.
+   * By default, any response with a status code of less than 400 (including
+   * opaque responses) is considered valid.
+   *
+   * If you need to use custom criteria to determine what's valid and what
+   * isn't, then pass in an item in `options.plugins` that implements the
+   * `cacheWillUpdate()` lifecycle event.
    *
    * @private
    * @param {Object} options
@@ -259,11 +264,26 @@ class PrecacheController {
       plugins,
     });
 
+    // Allow developers to override the default logic about what is and isn't
+    // valid by passing in a plugin implementing cacheWillUpdate(), e.g.
+    // a workbox.cacheableResponse.Plugin instance.
+    let cacheWillUpdateCallback;
+    for (const plugin of (plugins || [])) {
+      if ('cacheWillUpdate' in plugin) {
+        cacheWillUpdateCallback = plugin.cacheWillUpdate;
+      }
+    }
+
+    const isValidResponse = cacheWillUpdateCallback ?
+      // Use a callback if provided. It returns a truthy value if valid.
+      cacheWillUpdateCallback({response}) :
+      // Otherwise, default to considering any response status under 400 valid.
+      // This includes, by default, considering opaque responses valid.
+      response.status < 400;
+
     // Consider this a failure, leading to the `install` handler failing, if
-    // we have a clear error. We can't just check response.ok since that will be
-    // false for opaque responses, and (at least for now) we are going to
-    // consider those valid.
-    if (response.status >= 400) {
+    // we get back an invalid response.
+    if (!isValidResponse) {
       throw new WorkboxError('bad-precaching-response', {
         url: precacheEntry._networkRequest.url,
         status: response.status,

--- a/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
@@ -486,6 +486,38 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       const {request} = fetchWrapper.fetch.args[0][0];
       expect(request.credentials).to.eql('same-origin');
     });
+
+    it(`it should fail installation when a 4xx or 5xx response is received`, async function() {
+      sandbox.stub(fetchWrapper, 'fetch').resolves(new Response('', {
+        status: 400,
+      }));
+
+      const precacheController = new PrecacheController();
+      const cacheList = [
+        '/will-fail.html',
+      ];
+      precacheController.addToCacheList(cacheList);
+
+      return expectError(
+          () => precacheController.install(),
+          'bad-precaching-response'
+      );
+    });
+
+    it(`it should successfully install when an opaque response is received`, async function() {
+      sandbox.stub(fetchWrapper, 'fetch').resolves(new Response('', {
+        status: 0,
+      }));
+
+      const precacheController = new PrecacheController();
+      const cacheList = [
+        '/will-be-opaque.html',
+      ];
+      precacheController.addToCacheList(cacheList);
+
+      // This should succeed.
+      await precacheController.install();
+    });
   });
 
   describe(`activate()`, function() {

--- a/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
@@ -487,14 +487,14 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       expect(request.credentials).to.eql('same-origin');
     });
 
-    it(`it should fail installation when a 4xx or 5xx response is received`, async function() {
+    it(`it should fail installation when a response with a status of 400 is received`, async function() {
       sandbox.stub(fetchWrapper, 'fetch').resolves(new Response('', {
         status: 400,
       }));
 
       const precacheController = new PrecacheController();
       const cacheList = [
-        '/will-fail.html',
+        '/will-be-error.html',
       ];
       precacheController.addToCacheList(cacheList);
 
@@ -517,6 +517,30 @@ describe(`[workbox-precaching] PrecacheController`, function() {
 
       // This should succeed.
       await precacheController.install();
+    });
+
+    it(`it should successfully install when a response with a status of 400 is received, if a cacheWillUpdate plugin allows it`, async function() {
+      sandbox.stub(fetchWrapper, 'fetch').resolves(new Response('', {
+        status: 400,
+      }));
+
+      const precacheController = new PrecacheController();
+      const cacheList = [
+        '/will-be-error.html',
+      ];
+      precacheController.addToCacheList(cacheList);
+
+      const plugins = [{
+        cacheWillUpdate: ({response}) => {
+          if (response.status === 400) {
+            return response;
+          }
+          return null;
+        },
+      }];
+
+      // This should succeed.
+      await precacheController.install({plugins});
     });
   });
 


### PR DESCRIPTION
R: @philipwalton
CC: @josephliccini 

Fixes #1711, to be released as part of v4.

Previously, if you precached a URL that resulted in a 4xx or 5xx response, that would not result in a failure to install the service worker, and you could end up with an active service worker that continuously responded to requests with that (potentially transient) original error.

I think the intention had always been to cause this to be a fatal situation that would then trigger another re-installation attempt, and this was an oversight. (Potentially a v3 regression? Not 100% sure.)