### PR TITLE
workbox-range-requests will return a 206 response as-is

### DIFF
--- a/test/workbox-range-requests/node/createPartialResponse.mjs
+++ b/test/workbox-range-requests/node/createPartialResponse.mjs
@@ -59,5 +59,13 @@ describe(`[workbox-range-requests] createPartialResponse`, function() {
       const expectedBlob = constructBlob(101);
       expect(responseBlob._text).to.eql(expectedBlob._text);
     });
+
+    it(`should handle being passed a Response with a status of 206 by returning it as-is`, async function() {
+      const originalPartialResponse = new Response('expected text', {status: 206});
+      const createdPartialResponse = await createPartialResponse(VALID_REQUEST, originalPartialResponse);
+
+      // We should get back the exact same response.
+      expect(createdPartialResponse).to.eql(originalPartialResponse);
+    });
   });
 });


### PR DESCRIPTION
R: @philipwalton 
CC: @jakearchibald

Fixes #1720

This doesn't change much right now, but if and when the Cache Storage API starts generating `HTTP 206 Partial Content` responses, it ensures that `workbox-range-requests` usage wouldn't double-slice.