### PR TITLE
Backporting the 301 redirect fix to v3 branch

### DIFF
--- a/infra/testing/sw-env-mocks/Headers.js
+++ b/infra/testing/sw-env-mocks/Headers.js
@@ -17,8 +17,12 @@
 // Stub missing/broken Headers API methods in `service-worker-mock`.
 // https://fetch.spec.whatwg.org/#headers-class
 class Headers {
-  constructor(obj = {}) {
-    this.obj = Object.assign({}, obj);
+  constructor(init = {}) {
+    if (init instanceof Headers) {
+      this.obj = Object.assign({}, init.obj);
+    } else {
+      this.obj = Object.assign({}, init);
+    }
   }
 
   has(key) {

--- a/packages/workbox-precaching/utils/cleanRedirect.mjs
+++ b/packages/workbox-precaching/utils/cleanRedirect.mjs
@@ -21,7 +21,7 @@ import '../_version.mjs';
  * @return {Response}
  *
  * @private
- * @memberof module:workbox-precachig
+ * @memberof module:workbox-precaching
  */
 const cleanRedirect = async (response) => {
   const clonedResponse = response.clone();
@@ -35,10 +35,11 @@ const cleanRedirect = async (response) => {
   const body = await bodyPromise;
 
   // new Response() is happy when passed either a stream or a Blob.
-  return new Response(body, ['headers', 'status', 'statusText'].map((key) => {
-      return clonedResponse[key];
-    })
-  );
+  return new Response(body, {
+    headers: clonedResponse.headers,
+    status: clonedResponse.status,
+    statusText: clonedResponse.statusText,
+  });
 };
 
 export default cleanRedirect;

--- a/test/workbox-precaching/node/utils/test-cleanRedirect.mjs
+++ b/test/workbox-precaching/node/utils/test-cleanRedirect.mjs
@@ -29,4 +29,19 @@ describe(`[workbox-precaching] cleanRedirect()`, function() {
     const cleanedResponseBody = await cleanedResponse.text();
     expect(cleanedResponseBody).to.equal('Blob Body');
   });
+
+  it(`should use the statusText, status, and headers from the original response`, async function() {
+    const headers = {
+      'x-test': 1,
+    };
+    const statusText = 'Non-Authoritative';
+    const status = 203;
+
+    const response = new Response('', {headers, statusText, status});
+    const clonedResponse = await cleanRedirect(response);
+
+    expect(response.headers).to.eql(clonedResponse.headers);
+    expect(response.status).to.eql(clonedResponse.status);
+    expect(response.statusText).to.eql(clonedResponse.statusText);
+  });
 });


### PR DESCRIPTION
R: @philipwalton

Fixes #1677

This takes the v4 change from #1678 and backports it to the v3 branch.

After doing some `git` digging, the change that introduced the issue turned out to be https://github.com/GoogleChrome/workbox/pull/828/files#diff-37d7dc9fcc2f99bebe79d4b453e132fe, i.e. it looks inadvertant, so I can't think of a reason why we wouldn't want this code to be in v3.x.