### PR TITLE
Make Router.routes public

### DIFF
--- a/packages/workbox-routing/Router.mjs
+++ b/packages/workbox-routing/Router.mjs
@@ -30,16 +30,22 @@ import './_version.mjs';
  * be used to respond to the request.
  *
  * @memberof workbox.routing
- * @property {Map<string, Array<workbox.routing.Route>>} routes A `Map` of HTTP
- * method name ('GET', etc.) to an array of all the corresponding `Route`
- * instances that are registered.
  */
 class Router {
   /**
    * Initializes a new Router.
    */
   constructor() {
-    this.routes = new Map();
+    this._routes = new Map();
+  }
+
+  /**
+   * @return {Map<string, Array<workbox.routing.Route>>} routes A `Map` of HTTP
+   * method name ('GET', etc.) to an array of all the corresponding `Route`
+   * instances that are registered.
+   */
+  get routes() {
+    return this._routes;
   }
 
   /**
@@ -228,7 +234,7 @@ class Router {
       });
     }
 
-    const routes = this.routes.get(request.method) || [];
+    const routes = this._routes.get(request.method) || [];
     for (const route of routes) {
       let params;
       let matchResult = route.match({url, request, event});
@@ -318,13 +324,13 @@ class Router {
       });
     }
 
-    if (!this.routes.has(route.method)) {
-      this.routes.set(route.method, []);
+    if (!this._routes.has(route.method)) {
+      this._routes.set(route.method, []);
     }
 
     // Give precedence to all of the earlier routes by adding this additional
     // route to the end of the array.
-    this.routes.get(route.method).push(route);
+    this._routes.get(route.method).push(route);
   }
 
   /**
@@ -333,7 +339,7 @@ class Router {
    * @param {workbox.routing.Route} route The route to unregister.
    */
   unregisterRoute(route) {
-    if (!this.routes.has(route.method)) {
+    if (!this._routes.has(route.method)) {
       throw new WorkboxError(
           'unregister-route-but-not-found-with-method', {
             method: route.method,
@@ -341,9 +347,9 @@ class Router {
       );
     }
 
-    const routeIndex = this.routes.get(route.method).indexOf(route);
+    const routeIndex = this._routes.get(route.method).indexOf(route);
     if (routeIndex > -1) {
-      this.routes.get(route.method).splice(routeIndex, 1);
+      this._routes.get(route.method).splice(routeIndex, 1);
     } else {
       throw new WorkboxError('unregister-route-route-not-registered');
     }

--- a/packages/workbox-routing/Router.mjs
+++ b/packages/workbox-routing/Router.mjs
@@ -30,15 +30,16 @@ import './_version.mjs';
  * be used to respond to the request.
  *
  * @memberof workbox.routing
+ * @property {Map<string, Array<workbox.routing.Route>>} routes A `Map` of HTTP
+ * method name ('GET', etc.) to an array of all the corresponding `Route`
+ * instances that are registered.
  */
 class Router {
   /**
    * Initializes a new Router.
    */
   constructor() {
-    // _routes will contain a mapping of HTTP method name ('GET', etc.) to an
-    // array of all the corresponding Route instances that are registered.
-    this._routes = new Map();
+    this.routes = new Map();
   }
 
   /**
@@ -227,7 +228,7 @@ class Router {
       });
     }
 
-    const routes = this._routes.get(request.method) || [];
+    const routes = this.routes.get(request.method) || [];
     for (const route of routes) {
       let params;
       let matchResult = route.match({url, request, event});
@@ -317,13 +318,13 @@ class Router {
       });
     }
 
-    if (!this._routes.has(route.method)) {
-      this._routes.set(route.method, []);
+    if (!this.routes.has(route.method)) {
+      this.routes.set(route.method, []);
     }
 
     // Give precedence to all of the earlier routes by adding this additional
     // route to the end of the array.
-    this._routes.get(route.method).push(route);
+    this.routes.get(route.method).push(route);
   }
 
   /**
@@ -332,7 +333,7 @@ class Router {
    * @param {workbox.routing.Route} route The route to unregister.
    */
   unregisterRoute(route) {
-    if (!this._routes.has(route.method)) {
+    if (!this.routes.has(route.method)) {
       throw new WorkboxError(
           'unregister-route-but-not-found-with-method', {
             method: route.method,
@@ -340,9 +341,9 @@ class Router {
       );
     }
 
-    const routeIndex = this._routes.get(route.method).indexOf(route);
+    const routeIndex = this.routes.get(route.method).indexOf(route);
     if (routeIndex > -1) {
-      this._routes.get(route.method).splice(routeIndex, 1);
+      this.routes.get(route.method).splice(routeIndex, 1);
     } else {
       throw new WorkboxError('unregister-route-route-not-registered');
     }

--- a/test/workbox-routing/node/test-Router.mjs
+++ b/test/workbox-routing/node/test-Router.mjs
@@ -133,9 +133,9 @@ describe(`[workbox-routing] Router`, function() {
         router.registerRoute(route);
       }
 
-      expect(router._routes.get('GET')).to.have.members([getRoute1, getRoute2]);
-      expect(router._routes.get('PUT')).to.have.members([putRoute1, putRoute2]);
-      expect(router._routes.get('POST')).to.have.members([postRoute]);
+      expect(router.routes.get('GET')).to.have.members([getRoute1, getRoute2]);
+      expect(router.routes.get('PUT')).to.have.members([putRoute1, putRoute2]);
+      expect(router.routes.get('POST')).to.have.members([postRoute]);
     });
   });
 
@@ -238,9 +238,9 @@ describe(`[workbox-routing] Router`, function() {
       router.unregisterRoute(getRoute2);
       router.unregisterRoute(putRoute2);
 
-      expect(router._routes.get('GET')).to.have.members([getRoute1]);
-      expect(router._routes.get('PUT')).to.have.members([putRoute1]);
-      expect(router._routes.get('POST')).to.have.members([postRoute]);
+      expect(router.routes.get('GET')).to.have.members([getRoute1]);
+      expect(router.routes.get('PUT')).to.have.members([putRoute1]);
+      expect(router.routes.get('POST')).to.have.members([postRoute]);
     });
 
     it(`should throw when called with a route with a method for which there isn't an array of routes`, function() {

--- a/test/workbox-routing/node/test-interface.mjs
+++ b/test/workbox-routing/node/test-interface.mjs
@@ -52,4 +52,11 @@ describe(`[workbox-routing] Module Interface`, function() {
       ]);
     });
   });
+
+  describe('Router instances', function() {
+    it(`should expose a 'routes' property`, function() {
+      const router = new routingModule.Router();
+      expect(router).to.have.property('routes');
+    });
+  });
 });


### PR DESCRIPTION
R: @philipwalton
CC: @westonruter

This takes a private property and exposes it publicly, as part of v4. There's going to be a (small) hit in bundle size, since that property name can't be mangled anymore.