### PR TITLE
Updates to package-lock.json files

### DIFF
--- a/packages/workbox-build/package-lock.json
+++ b/packages/workbox-build/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "workbox-build",
-	"version": "3.6.2",
+	"version": "4.0.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -266,6 +266,107 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+		},
+		"workbox-background-sync": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-xmQmWS1k0k8I429oQZK64/0zhfh5Hm+T/BCjU0HXldT4yfqE8+RkVGuxibcrJN2V4gK5SZ2PA1SWncU1Nosbmg==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-broadcast-cache-update": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-DqPfRUCfHrSg0eLv8bHwXWxooY4S5Fe4xr3yWWg85zQ3Na7GF4LjVzJflWBzLrFZuZ2QnP8BxQz9ojpdm8MBcA==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-cache-expiration": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-gMAk2OL+yF+rCwctJ5mGfUQAnH1KQfSh+8NqkkmLo+Qui9PPdrFpQEg0hG9ErdvpptgVxVwyqMnfmO4dxvxc+w==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-cacheable-response": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-SmvlF0a+uvoil6RH+4r6DOBTffa6zvy4WX9YPM869gzLDXQWMonui4+Wn9kcjuWKjkNz6G1LPtwlxHHV6vDDkA==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-core": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-CH1p9vSwdW9DoAnoEvBLJppFGjh2tBJVCproINKMNEc6NhfVK5XvkCBssOQ6zUf8MXUKbpMSzUlZX8h35jX1XA=="
+		},
+		"workbox-google-analytics": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-qNQsPMEyB5fy3bwprsx69DbpG7qmaTvETD6AxBb4/jvlhdHyGjpKdTxFATpv2IEgFmsei8BqlW3NBTvklHdB+A==",
+			"requires": {
+				"workbox-background-sync": "^4.0.0-alpha.0",
+				"workbox-core": "^4.0.0-alpha.0",
+				"workbox-routing": "^4.0.0-alpha.0",
+				"workbox-strategies": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-navigation-preload": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-kYKmr7Qne6JOrDt33pU91ZDTxhtg1wOkppMGDE1nZ+B5Hc43AfZLWVKQlVM2BZETodPWqEsoB1zWMT0M/AQwlg==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-precaching": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-QXlSxe5RGq83QXjIauP6ZJYtqcqCERa/z2lIzZden4zy7qwDaMDHoj2BR63fJk2nidAgYogAtrVC3E/EcOkShA==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-range-requests": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-yk7jfPdh8HLFhNGRav6SFpOzlmdfI58PAz2CY4UTJIL+eIn3203Mld1nWzLvrJJzZs2SNLZBb4x/FgkzuoHrlg==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-routing": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-WCgeoPZJmnQmBpBA2IjRYhvjpVm8oxRKKdCeTwmvaJmT9K3FJcYiilPtJFHoXTuU9AgGn2RR7l3K8w/rUUWEig==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-strategies": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-NwEGpyYmOzmA36vr8qoKYIqI0/SigSkDjzHtYRooz83pu9Iq8NK73krrckTd+6/zJg73L5bwz7ikkfyJznd9Bw==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-streams": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-MRECOPgpx2tWiXijHToPCYyQ9Oir7ZYcvo2u4+Ox8gIwsN3D8sG9b3+/GW0FSUskeTNlFMzEDdruPYFIBkJcNQ==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-sw": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-hve+36Sg7iFR8T/cgsaQXCrVQUhhT2LsqDhkZv4OuNfmN8q6JLrkWnPBTQTA2HKEjjJCP+i8kUiIwwtR2rFJ/Q=="
 		},
 		"wrappy": {
 			"version": "1.0.2",

--- a/packages/workbox-cli/package-lock.json
+++ b/packages/workbox-cli/package-lock.json
@@ -48,6 +48,49 @@
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
 		},
+		"babel-extract-comments": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
+			"integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
+			"requires": {
+				"babylon": "^6.18.0"
+			}
+		},
+		"babel-plugin-syntax-object-rest-spread": {
+			"version": "6.13.0",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+		},
+		"babel-plugin-transform-object-rest-spread": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+			"requires": {
+				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
+				"babel-runtime": "^6.26.0"
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"requires": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+				}
+			}
+		},
+		"babylon": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -184,6 +227,11 @@
 				"write-file-atomic": "^2.0.0",
 				"xdg-basedir": "^3.0.0"
 			}
+		},
+		"core-js": {
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 		},
 		"create-error-class": {
 			"version": "3.0.2",
@@ -331,6 +379,11 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
+		"get-own-enumerable-property-symbols": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
+			"integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
+		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -384,6 +437,11 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"hoek": {
+			"version": "4.2.1",
+			"resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
 		},
 		"hosted-git-info": {
 			"version": "2.7.1",
@@ -520,6 +578,11 @@
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
 			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
 		},
+		"is-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
@@ -530,10 +593,28 @@
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
+		"isemail": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+			"integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+			"requires": {
+				"punycode": "2.x.x"
+			}
+		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"joi": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
+			"integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
+			"requires": {
+				"hoek": "4.x.x",
+				"isemail": "3.x.x",
+				"topo": "2.x.x"
+			}
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
@@ -580,6 +661,28 @@
 			"version": "4.17.11",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
 			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+		},
+		"lodash.template": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+			"requires": {
+				"lodash._reinterpolate": "~3.0.0",
+				"lodash.templatesettings": "^4.0.0"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+			"requires": {
+				"lodash._reinterpolate": "~3.0.0"
+			}
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -820,6 +923,11 @@
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+		},
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
@@ -989,6 +1097,16 @@
 				"strip-ansi": "^4.0.0"
 			}
 		},
+		"stringify-object": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+			"requires": {
+				"get-own-enumerable-property-symbols": "^3.0.0",
+				"is-obj": "^1.0.1",
+				"is-regexp": "^1.0.0"
+			}
+		},
 		"strip-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1001,6 +1119,15 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
 			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+		},
+		"strip-comments": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
+			"integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
+			"requires": {
+				"babel-extract-comments": "^1.0.0",
+				"babel-plugin-transform-object-rest-spread": "^6.26.0"
+			}
 		},
 		"strip-eof": {
 			"version": "1.0.0",
@@ -1049,6 +1176,14 @@
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"requires": {
 				"os-tmpdir": "~1.0.2"
+			}
+		},
+		"topo": {
+			"version": "2.0.2",
+			"resolved": "http://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+			"integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+			"requires": {
+				"hoek": "4.x.x"
 			}
 		},
 		"trim-newlines": {
@@ -1136,6 +1271,153 @@
 			"requires": {
 				"string-width": "^2.1.1"
 			}
+		},
+		"workbox-background-sync": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-xmQmWS1k0k8I429oQZK64/0zhfh5Hm+T/BCjU0HXldT4yfqE8+RkVGuxibcrJN2V4gK5SZ2PA1SWncU1Nosbmg==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-broadcast-cache-update": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-DqPfRUCfHrSg0eLv8bHwXWxooY4S5Fe4xr3yWWg85zQ3Na7GF4LjVzJflWBzLrFZuZ2QnP8BxQz9ojpdm8MBcA==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-build": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-1zrMQMEan8txRvPo4D+QVBsa/ZNT2O9SDDVMUeWOVAtpbnfFZcK2ph4Xv58J0j5k7dJ/b5ChHFgtnWj8qiLzlQ==",
+			"requires": {
+				"@babel/runtime": "^7.0.0",
+				"common-tags": "^1.4.0",
+				"fs-extra": "^4.0.2",
+				"glob": "^7.1.2",
+				"joi": "^11.1.1",
+				"lodash.template": "^4.4.0",
+				"pretty-bytes": "^4.0.2",
+				"stringify-object": "^3.2.2",
+				"strip-comments": "^1.0.2",
+				"workbox-background-sync": "^4.0.0-alpha.0",
+				"workbox-broadcast-cache-update": "^4.0.0-alpha.0",
+				"workbox-cache-expiration": "^4.0.0-alpha.0",
+				"workbox-cacheable-response": "^4.0.0-alpha.0",
+				"workbox-core": "^4.0.0-alpha.0",
+				"workbox-google-analytics": "^4.0.0-alpha.0",
+				"workbox-navigation-preload": "^4.0.0-alpha.0",
+				"workbox-precaching": "^4.0.0-alpha.0",
+				"workbox-range-requests": "^4.0.0-alpha.0",
+				"workbox-routing": "^4.0.0-alpha.0",
+				"workbox-strategies": "^4.0.0-alpha.0",
+				"workbox-streams": "^4.0.0-alpha.0",
+				"workbox-sw": "^4.0.0-alpha.0"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"pretty-bytes": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+					"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+				}
+			}
+		},
+		"workbox-cache-expiration": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-gMAk2OL+yF+rCwctJ5mGfUQAnH1KQfSh+8NqkkmLo+Qui9PPdrFpQEg0hG9ErdvpptgVxVwyqMnfmO4dxvxc+w==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-cacheable-response": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-SmvlF0a+uvoil6RH+4r6DOBTffa6zvy4WX9YPM869gzLDXQWMonui4+Wn9kcjuWKjkNz6G1LPtwlxHHV6vDDkA==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-core": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-CH1p9vSwdW9DoAnoEvBLJppFGjh2tBJVCproINKMNEc6NhfVK5XvkCBssOQ6zUf8MXUKbpMSzUlZX8h35jX1XA=="
+		},
+		"workbox-google-analytics": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-qNQsPMEyB5fy3bwprsx69DbpG7qmaTvETD6AxBb4/jvlhdHyGjpKdTxFATpv2IEgFmsei8BqlW3NBTvklHdB+A==",
+			"requires": {
+				"workbox-background-sync": "^4.0.0-alpha.0",
+				"workbox-core": "^4.0.0-alpha.0",
+				"workbox-routing": "^4.0.0-alpha.0",
+				"workbox-strategies": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-navigation-preload": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-kYKmr7Qne6JOrDt33pU91ZDTxhtg1wOkppMGDE1nZ+B5Hc43AfZLWVKQlVM2BZETodPWqEsoB1zWMT0M/AQwlg==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-precaching": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-QXlSxe5RGq83QXjIauP6ZJYtqcqCERa/z2lIzZden4zy7qwDaMDHoj2BR63fJk2nidAgYogAtrVC3E/EcOkShA==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-range-requests": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-yk7jfPdh8HLFhNGRav6SFpOzlmdfI58PAz2CY4UTJIL+eIn3203Mld1nWzLvrJJzZs2SNLZBb4x/FgkzuoHrlg==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-routing": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-WCgeoPZJmnQmBpBA2IjRYhvjpVm8oxRKKdCeTwmvaJmT9K3FJcYiilPtJFHoXTuU9AgGn2RR7l3K8w/rUUWEig==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-strategies": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-NwEGpyYmOzmA36vr8qoKYIqI0/SigSkDjzHtYRooz83pu9Iq8NK73krrckTd+6/zJg73L5bwz7ikkfyJznd9Bw==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-streams": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-MRECOPgpx2tWiXijHToPCYyQ9Oir7ZYcvo2u4+Ox8gIwsN3D8sG9b3+/GW0FSUskeTNlFMzEDdruPYFIBkJcNQ==",
+			"requires": {
+				"workbox-core": "^4.0.0-alpha.0"
+			}
+		},
+		"workbox-sw": {
+			"version": "4.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-4.0.0-alpha.0.tgz",
+			"integrity": "sha512-hve+36Sg7iFR8T/cgsaQXCrVQUhhT2LsqDhkZv4OuNfmN8q6JLrkWnPBTQTA2HKEjjJCP+i8kUiIwwtR2rFJ/Q=="
 		},
 		"wrappy": {
 			"version": "1.0.2",

--- a/packages/workbox-webpack-plugin/package-lock.json
+++ b/packages/workbox-webpack-plugin/package-lock.json
@@ -12,6 +12,163 @@
         "regenerator-runtime": "^0.12.0"
       }
     },
+    "babel-extract-comments": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
+      "integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
+      "requires": {
+        "babylon": "^6.18.0"
+      }
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "core-js": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+    },
+    "fs-extra": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
+      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+    },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "requires": {
+        "punycode": "2.x.x"
+      }
+    },
+    "joi": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
+      "integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
+      "requires": {
+        "hoek": "4.x.x",
+        "isemail": "3.x.x",
+        "topo": "2.x.x"
+      }
+    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -20,15 +177,243 @@
         "jsonify": "~0.0.0"
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pretty-bytes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
     "regenerator-runtime": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
       "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+    },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      }
+    },
+    "strip-comments": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
+      "integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
+      "requires": {
+        "babel-extract-comments": "^1.0.0",
+        "babel-plugin-transform-object-rest-spread": "^6.26.0"
+      }
+    },
+    "topo": {
+      "version": "2.0.2",
+      "resolved": "http://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "requires": {
+        "hoek": "4.x.x"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "workbox-background-sync": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-xmQmWS1k0k8I429oQZK64/0zhfh5Hm+T/BCjU0HXldT4yfqE8+RkVGuxibcrJN2V4gK5SZ2PA1SWncU1Nosbmg==",
+      "requires": {
+        "workbox-core": "^4.0.0-alpha.0"
+      }
+    },
+    "workbox-broadcast-cache-update": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-DqPfRUCfHrSg0eLv8bHwXWxooY4S5Fe4xr3yWWg85zQ3Na7GF4LjVzJflWBzLrFZuZ2QnP8BxQz9ojpdm8MBcA==",
+      "requires": {
+        "workbox-core": "^4.0.0-alpha.0"
+      }
+    },
+    "workbox-build": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-1zrMQMEan8txRvPo4D+QVBsa/ZNT2O9SDDVMUeWOVAtpbnfFZcK2ph4Xv58J0j5k7dJ/b5ChHFgtnWj8qiLzlQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "common-tags": "^1.4.0",
+        "fs-extra": "^4.0.2",
+        "glob": "^7.1.2",
+        "joi": "^11.1.1",
+        "lodash.template": "^4.4.0",
+        "pretty-bytes": "^4.0.2",
+        "stringify-object": "^3.2.2",
+        "strip-comments": "^1.0.2",
+        "workbox-background-sync": "^4.0.0-alpha.0",
+        "workbox-broadcast-cache-update": "^4.0.0-alpha.0",
+        "workbox-cache-expiration": "^4.0.0-alpha.0",
+        "workbox-cacheable-response": "^4.0.0-alpha.0",
+        "workbox-core": "^4.0.0-alpha.0",
+        "workbox-google-analytics": "^4.0.0-alpha.0",
+        "workbox-navigation-preload": "^4.0.0-alpha.0",
+        "workbox-precaching": "^4.0.0-alpha.0",
+        "workbox-range-requests": "^4.0.0-alpha.0",
+        "workbox-routing": "^4.0.0-alpha.0",
+        "workbox-strategies": "^4.0.0-alpha.0",
+        "workbox-streams": "^4.0.0-alpha.0",
+        "workbox-sw": "^4.0.0-alpha.0"
+      }
+    },
+    "workbox-cache-expiration": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-gMAk2OL+yF+rCwctJ5mGfUQAnH1KQfSh+8NqkkmLo+Qui9PPdrFpQEg0hG9ErdvpptgVxVwyqMnfmO4dxvxc+w==",
+      "requires": {
+        "workbox-core": "^4.0.0-alpha.0"
+      }
+    },
+    "workbox-cacheable-response": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-SmvlF0a+uvoil6RH+4r6DOBTffa6zvy4WX9YPM869gzLDXQWMonui4+Wn9kcjuWKjkNz6G1LPtwlxHHV6vDDkA==",
+      "requires": {
+        "workbox-core": "^4.0.0-alpha.0"
+      }
+    },
+    "workbox-core": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-CH1p9vSwdW9DoAnoEvBLJppFGjh2tBJVCproINKMNEc6NhfVK5XvkCBssOQ6zUf8MXUKbpMSzUlZX8h35jX1XA=="
+    },
+    "workbox-google-analytics": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-qNQsPMEyB5fy3bwprsx69DbpG7qmaTvETD6AxBb4/jvlhdHyGjpKdTxFATpv2IEgFmsei8BqlW3NBTvklHdB+A==",
+      "requires": {
+        "workbox-background-sync": "^4.0.0-alpha.0",
+        "workbox-core": "^4.0.0-alpha.0",
+        "workbox-routing": "^4.0.0-alpha.0",
+        "workbox-strategies": "^4.0.0-alpha.0"
+      }
+    },
+    "workbox-navigation-preload": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-kYKmr7Qne6JOrDt33pU91ZDTxhtg1wOkppMGDE1nZ+B5Hc43AfZLWVKQlVM2BZETodPWqEsoB1zWMT0M/AQwlg==",
+      "requires": {
+        "workbox-core": "^4.0.0-alpha.0"
+      }
+    },
+    "workbox-precaching": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-QXlSxe5RGq83QXjIauP6ZJYtqcqCERa/z2lIzZden4zy7qwDaMDHoj2BR63fJk2nidAgYogAtrVC3E/EcOkShA==",
+      "requires": {
+        "workbox-core": "^4.0.0-alpha.0"
+      }
+    },
+    "workbox-range-requests": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-yk7jfPdh8HLFhNGRav6SFpOzlmdfI58PAz2CY4UTJIL+eIn3203Mld1nWzLvrJJzZs2SNLZBb4x/FgkzuoHrlg==",
+      "requires": {
+        "workbox-core": "^4.0.0-alpha.0"
+      }
+    },
+    "workbox-routing": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-WCgeoPZJmnQmBpBA2IjRYhvjpVm8oxRKKdCeTwmvaJmT9K3FJcYiilPtJFHoXTuU9AgGn2RR7l3K8w/rUUWEig==",
+      "requires": {
+        "workbox-core": "^4.0.0-alpha.0"
+      }
+    },
+    "workbox-strategies": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-NwEGpyYmOzmA36vr8qoKYIqI0/SigSkDjzHtYRooz83pu9Iq8NK73krrckTd+6/zJg73L5bwz7ikkfyJznd9Bw==",
+      "requires": {
+        "workbox-core": "^4.0.0-alpha.0"
+      }
+    },
+    "workbox-streams": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-MRECOPgpx2tWiXijHToPCYyQ9Oir7ZYcvo2u4+Ox8gIwsN3D8sG9b3+/GW0FSUskeTNlFMzEDdruPYFIBkJcNQ==",
+      "requires": {
+        "workbox-core": "^4.0.0-alpha.0"
+      }
+    },
+    "workbox-sw": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-hve+36Sg7iFR8T/cgsaQXCrVQUhhT2LsqDhkZv4OuNfmN8q6JLrkWnPBTQTA2HKEjjJCP+i8kUiIwwtR2rFJ/Q=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }


### PR DESCRIPTION
R: @philipwalton 

Let's see if this makes the Travis CI test happy? In particular, the `workbox-webpack-plugin` tests on my local machine are fine, and perhaps pinning the versions to what's in the updated lockfiles will lead to that being okay in Travis, too.