### PR TITLE
Allow injecting manifests into existing webpack-compiled assets

### DIFF
--- a/packages/workbox-webpack-plugin/package.json
+++ b/packages/workbox-webpack-plugin/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "json-stable-stringify": "^1.0.1",
+    "webpack-sources": "^1.3.0",
     "workbox-build": "^3.6.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
R: @jeffposnick @philipwalton

Fixes #1513

**Description of what's changed/fixed:**

Before this PR, the only way to use InjectManifest was to inject into files totally outside the rest of your webpack compilation process. As in #1513, this causes problems (in my case, it means it's impossible to use InjectManifest in TypeScript).

With this PR, there's now two ways to configure InjectManifest:
* As before: setting `swSrc` to the path of an input file, independent of webpack, and optionally using `swDest` to override the output file.
* New: setting only `swDest`, to specify an existing output file that you'd like to inject into.

This means if my build process already builds a `service-worker.js` file somehow (e.g. via TypeScript), I can now set up workbox by adding the plugin with just:

```js
new InjectManifest({
    swDest: 'update-workers.js'
});
```

I considered creating a third parameter instead (`swExisting`?) so you could inject and use `swDest` as well. I don't think there's any case where you'll want to inject into an existing file and then have both files end up in your output though. I'm fairly sure you always want to totally overwrite an output file, and that's simpler this way. Let me know if you disagree.

I've written this such that all existing configs should keep working fine, and updated the validation in line with these changes to catch any issues. The new behaviour uses ConcatSource instead of bare strings, so it doesn't break source maps etc too. I wasn't sure how to update the docs corresponding to this, so I've left those for now.