### PR TITLE
Support using a function as urlPattern in runtimeCaching

### DIFF
--- a/infra/testing/validator/service-worker-runtime.js
+++ b/infra/testing/validator/service-worker-runtime.js
@@ -13,6 +13,11 @@ const makeServiceWorkerEnv = require('service-worker-mock');
 const sinon = require('sinon');
 const vm = require('vm');
 
+// See https://github.com/chaijs/chai/issues/697
+function stringifyFunctionsInArray(arr) {
+  return arr.map((item) => typeof item === 'function' ? item.toString() : item);
+}
+
 function setupSpiesAndContext() {
   const cacheableResponsePluginSpy = sinon.spy();
   class CacheableResponsePlugin {
@@ -89,7 +94,9 @@ function setupSpiesAndContext() {
 function validateMethodCalls({methodsToSpies, expectedMethodCalls}) {
   for (const [method, spy] of Object.entries(methodsToSpies)) {
     if (spy.called) {
-      expect(spy.args).to.deep.equal(expectedMethodCalls[method],
+      const args = spy.args.map(
+          (arg) => Array.isArray(arg) ? stringifyFunctionsInArray(arg) : arg);
+      expect(args).to.deep.equal(expectedMethodCalls[method],
           `while testing method calls for ${method}`);
     } else {
       expect(expectedMethodCalls[method],

--- a/packages/workbox-build/src/entry-points/options/common-generate-schema.js
+++ b/packages/workbox-build/src/entry-points/options/common-generate-schema.js
@@ -32,7 +32,7 @@ module.exports = baseSchema.keys({
         'POST',
         'PUT'
     ),
-    urlPattern: [regExpObject, joi.string()],
+    urlPattern: [regExpObject, joi.string(), joi.func()],
     handler: [joi.func(), joi.string().valid(
         'cacheFirst',
         'cacheOnly',

--- a/packages/workbox-build/src/lib/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/runtime-caching-converter.js
@@ -126,9 +126,8 @@ module.exports = (runtimeCaching = []) => {
       throw new Error(errors['invalid-network-timeout-seconds']);
     }
 
-    // urlPattern might be either a string or a RegExp object.
-    // If it's a string, it needs to be quoted. If it's a RegExp, it should
-    // be used as-is.
+    // urlPattern might be a string, a RegExp object, or a function.
+    // If it's a string, it needs to be quoted.
     const matcher = typeof entry.urlPattern === 'string' ?
       JSON.stringify(entry.urlPattern) :
       entry.urlPattern;


### PR DESCRIPTION
R: @philipwalton

Fixes #1764

Pretty straightforward change to allow for functions to be passed in as the `urlPattern` value when using `runtimeCaching`.

The main difficulty was getting this tested, since `chai` isn't happy when using `deep.equal` to compare functions.