### PR TITLE
Adds a fetchDidSucceed callback

### DIFF
--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -133,7 +133,8 @@ const matchWrapper = async ({
       logger.debug(`No cached response found in '${cacheName}'.`);
     }
   }
-  for (let plugin of plugins) {
+
+  for (const plugin of plugins) {
     if (pluginEvents.CACHED_RESPONSE_WILL_BE_USED in plugin) {
       cachedResponse = await plugin[pluginEvents.CACHED_RESPONSE_WILL_BE_USED]
           .call(plugin, {
@@ -154,6 +155,7 @@ const matchWrapper = async ({
       }
     }
   }
+
   return cachedResponse;
 };
 

--- a/packages/workbox-core/_private/fetchWrapper.mjs
+++ b/packages/workbox-core/_private/fetchWrapper.mjs
@@ -113,6 +113,7 @@ const wrappedFetch = async ({
       if (pluginEvents.FETCH_DID_SUCCEED in plugin) {
         fetchResponse = await plugin[pluginEvents.FETCH_DID_SUCCEED]
             .call(plugin, {
+              event,
               request: pluginFilteredRequest,
               response: fetchResponse,
             });

--- a/packages/workbox-core/_private/fetchWrapper.mjs
+++ b/packages/workbox-core/_private/fetchWrapper.mjs
@@ -102,12 +102,33 @@ const wrappedFetch = async ({
   const pluginFilteredRequest = request.clone();
 
   try {
-    const fetchResponse = await fetch(request, fetchOptions);
+    let fetchResponse = await fetch(request, fetchOptions);
     if (process.env.NODE_ENV !== 'production') {
       logger.debug(`Network request for `+
       `'${getFriendlyURL(request.url)}' returned a response with ` +
       `status '${fetchResponse.status}'.`);
     }
+
+    for (const plugin of plugins) {
+      if (pluginEvents.FETCH_DID_SUCCEED in plugin) {
+        fetchResponse = await plugin[pluginEvents.FETCH_DID_SUCCEED]
+            .call(plugin, {
+              request: pluginFilteredRequest,
+              response: fetchResponse,
+            });
+
+        if (process.env.NODE_ENV !== 'production') {
+          if (fetchResponse) {
+            assert.isInstance(fetchResponse, Response, {
+              moduleName: 'Plugin',
+              funcName: pluginEvents.FETCH_DID_SUCCEED,
+              isReturnValueProblem: true,
+            });
+          }
+        }
+      }
+    }
+
     return fetchResponse;
   } catch (error) {
     if (process.env.NODE_ENV !== 'production') {
@@ -115,7 +136,7 @@ const wrappedFetch = async ({
       `'${getFriendlyURL(request.url)}' threw an error.`, error);
     }
 
-    for (let plugin of failedFetchPlugins) {
+    for (const plugin of failedFetchPlugins) {
       await plugin[pluginEvents.FETCH_DID_FAIL].call(plugin, {
         error,
         event,

--- a/packages/workbox-core/models/pluginEvents.mjs
+++ b/packages/workbox-core/models/pluginEvents.mjs
@@ -13,5 +13,6 @@ export default {
   CACHE_WILL_UPDATE: 'cacheWillUpdate',
   CACHED_RESPONSE_WILL_BE_USED: 'cachedResponseWillBeUsed',
   FETCH_DID_FAIL: 'fetchDidFail',
+  FETCH_DID_SUCCEED: 'fetchDidSucceed',
   REQUEST_WILL_FETCH: 'requestWillFetch',
 };

--- a/test/workbox-core/node/_private/test-fetchWrapper.mjs
+++ b/test/workbox-core/node/_private/test-fetchWrapper.mjs
@@ -211,6 +211,7 @@ describe(`workbox-core fetchWrapper`, function() {
       for (const args of fetchDidSucceed.args) {
         expect(args[0].request).to.be.instanceOf(Request);
         expect(args[0].response).to.be.instanceOf(Response);
+        expect(args[0].event).to.be.instanceOf(FetchEvent);
       }
 
       const finalCount = finalResponse.headers.get('x-count');

--- a/test/workbox-core/node/_private/test-fetchWrapper.mjs
+++ b/test/workbox-core/node/_private/test-fetchWrapper.mjs
@@ -197,7 +197,10 @@ describe(`workbox-core fetchWrapper`, function() {
         });
       });
 
+      const event = new FetchEvent('fetch', {request: originalRequest});
+
       const finalResponse = await fetchWrapper.fetch({
+        event,
         request: originalRequest,
         plugins: [
           // Two plugins, both with the same callback.

--- a/test/workbox-core/node/_private/test-fetchWrapper.mjs
+++ b/test/workbox-core/node/_private/test-fetchWrapper.mjs
@@ -178,5 +178,43 @@ describe(`workbox-core fetchWrapper`, function() {
       const fetchRequest = global.fetch.args[0][0];
       expect(fetchRequest.url).to.equal('/test/failingRequest/1');
     });
+
+    it(`should call the fetchDidSucceed method in plugins`, async function() {
+      const originalRequest = new Request('/testing');
+
+      sandbox.stub(global, 'fetch').resolves(new Response('', {
+        headers: {
+          'x-count': 1,
+        },
+      }));
+
+      const fetchDidSucceed = sandbox.stub().callsFake(({response}) => {
+        const count = response.headers.get('x-count');
+        return new Response('', {
+          headers: {
+            'x-count': count + 1,
+          },
+        });
+      });
+
+      const finalResponse = await fetchWrapper.fetch({
+        request: originalRequest,
+        plugins: [
+          // Two plugins, both with the same callback.
+          {fetchDidSucceed},
+          {fetchDidSucceed},
+        ],
+      });
+
+      expect(fetchDidSucceed.callCount).to.eql(2);
+
+      for (const args of fetchDidSucceed.args) {
+        expect(args[0].request).to.be.instanceOf(Request);
+        expect(args[0].response).to.be.instanceOf(Response);
+      }
+
+      const finalCount = finalResponse.headers.get('x-count');
+      expect(finalCount).to.eql(3);
+    });
   });
 });


### PR DESCRIPTION
R: @philipwalton

Fixes #788, fixes #1391, fixes #1481

Adds a new `fetchDidSucceed` callback, which allows a plugin to modify a request that's been retrieved from the network.

This was requested by @weeblr back in the day.

We'll need to update https://developers.google.com/web/tools/workbox/guides/using-plugins once v4 goes live to reflect this new callback.