### PR TITLE
concat, rather than overwrite, self.__precacheManifest

### DIFF
--- a/packages/workbox-webpack-plugin/src/lib/stringify-manifest.js
+++ b/packages/workbox-webpack-plugin/src/lib/stringify-manifest.js
@@ -32,5 +32,6 @@ module.exports = (manifestEntries) => {
   // There's a hash created of the serialized JSON data, and we want the hash to
   // be the same if the data is the same, without any sort-order variation.
   const entriesJson = stringify(sortedEntries, {space: 2});
-  return `self.${PRECACHE_MANIFEST_VAR} = ${entriesJson};`;
+  return `self.${PRECACHE_MANIFEST_VAR} = (self.${PRECACHE_MANIFEST_VAR} || ` +
+      `[]).concat(${entriesJson});`;
 };

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -147,7 +147,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Ensure only one precache-manifest is present on re-compile`, function() {
     it(`should only have one reference to precache-manifest file in 'importScripts'`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.afaa1016313821cd74bbe81a9cf68406.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.ea23e32058279c8eaa936321febd3c34.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -219,7 +219,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] multiple chunks`, function() {
     it(`should work when called without any parameters`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.afaa1016313821cd74bbe81a9cf68406.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.ea23e32058279c8eaa936321febd3c34.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -278,7 +278,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should support setting importWorkboxFrom to a chunk's name`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.4b8f8eed0501cb79a5e4c7a1d3ffab4e.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.87c9951460ef50e83fd20b5ac561ab50.js';
       const workboxEntryName = 'workboxEntry-278b92112247f26eee29.js';
       const outputDir = tempy.directory();
       const config = {
@@ -339,7 +339,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should support setting importWorkboxFrom to 'local'`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.afaa1016313821cd74bbe81a9cf68406.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.ea23e32058279c8eaa936321febd3c34.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -415,7 +415,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should support setting importWorkboxFrom to 'local', respecting output.publicPath`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.e3e0421906d624c0b0b442717e2f9c9d.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.d2ea7192d3a7a9aebc840de75be50d67.js';
       const outputDir = tempy.directory();
       const publicPath = '/testing/';
       const config = {
@@ -494,7 +494,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should honor the 'chunks' whitelist config`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.4b8f8eed0501cb79a5e4c7a1d3ffab4e.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.87c9951460ef50e83fd20b5ac561ab50.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -556,7 +556,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should honor the 'excludeChunks' blacklist config`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.4b8f8eed0501cb79a5e4c7a1d3ffab4e.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.87c9951460ef50e83fd20b5ac561ab50.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -618,7 +618,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should honor setting both the 'chunks' and 'excludeChunks', with the blacklist taking precedence`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.3ab1df6ebdb6a621237f642455ee53a8.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.5c1807bea92497c4ce2edfd648c76fda.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -679,7 +679,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should pass through the config to workbox-build.generateSWString()`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.afaa1016313821cd74bbe81a9cf68406.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.ea23e32058279c8eaa936321febd3c34.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -756,7 +756,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] html-webpack-plugin and a single chunk`, function() {
     it(`should work when called without any parameters`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.d69e64fa976e4523cff05b9fc652c66c.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.961b2e55574237e7ea932b7963bc3d1d.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -821,7 +821,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] copy-webpack-plugin and a single chunk`, function() {
     it(`should work when called without any parameters`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.1e9aeed006e3e09b241faf4afb8d2cfa.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.2b3d18c77655489eaa6adb2851e7e476.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -903,7 +903,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Filtering via test/include/exclude`, function() {
     it(`should exclude .map and manifest.js files by default`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.82d9f27b442b5218244a0c9491e287c0.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.49af80607fd27ad2046d94148ac9cb2d.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -968,7 +968,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should allow developers to override the default exclude filter`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.d91063e939edda5be4d6e1093eeac5ec.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.1431038c0e75c1cf68c4206fb9230140.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1029,7 +1029,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should allow developers to whitelist via include`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.1242f9e007897f035a52e56690ff17a6.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.92ba19475051a5dc73f5693dc05fd39d.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1097,7 +1097,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should allow developers to combine the test and exclude filters`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.83df65831eb442f8ad5fbeb8edecc558.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.a586dc93ba1a7f63f945e7d6f1e08676.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1165,7 +1165,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] swDest variations`, function() {
     it(`should work when swDest is an absolute path`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.aec0313ed4dacd1c4b8981f195bf9f33.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.29f0f9b0fb8d84f04161b18c20c18fee.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1225,7 +1225,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Reporting webpack warnings`, function() {
     it(`should add warnings from the workbox-build methods to compilation.warnings`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.0588874b96c8001cce24ccd935d947f0.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.7e1d0d5a77c9c05655b6033e320028e3.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1296,7 +1296,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should add a warning when various glob-related options are set`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.0588874b96c8001cce24ccd935d947f0.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.7e1d0d5a77c9c05655b6033e320028e3.js';
       const outputDir = tempy.directory();
       const globOptionsToWarnAbout = [
         'globDirectory',
@@ -1378,7 +1378,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should add a warning when certain options are used, but globPatterns isn't set`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.0588874b96c8001cce24ccd935d947f0.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.7e1d0d5a77c9c05655b6033e320028e3.js';
       const outputDir = tempy.directory();
       const optionsToWarnAboutWhenGlobPatternsIsNotSet = [
         'dontCacheBustUrlsMatching',
@@ -1451,7 +1451,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Customizing output paths and names`, function() {
     it(`should allow overriding precacheManifestFilename`, function(done) {
-      const FILE_MANIFEST_NAME = 'custom-name.0588874b96c8001cce24ccd935d947f0.js';
+      const FILE_MANIFEST_NAME = 'custom-name.7e1d0d5a77c9c05655b6033e320028e3.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1511,7 +1511,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should allow setting importsDirectory`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.0588874b96c8001cce24ccd935d947f0.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.7e1d0d5a77c9c05655b6033e320028e3.js';
       const outputDir = tempy.directory();
       const importsDirectory = path.join('one', 'two');
       const config = {
@@ -1573,7 +1573,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
     });
 
     it(`should allow setting importsDirectory, publicPath, and importWorkboxFrom: 'local'`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.ef6ef924c8c87cec1daeb65a41ca7b54.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.0a5a96f075807fd5ebca92528f0a5156.js';
       const outputDir = tempy.directory();
       const importsDirectory = path.join('one', 'two');
       const publicPath = '/testing/';

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -152,7 +152,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Ensure only one precache-manifest is present on re-compile`, function() {
     it(`should only have one reference to precache-manifest file in 'importScripts'`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.afaa1016313821cd74bbe81a9cf68406.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.ea23e32058279c8eaa936321febd3c34.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -226,7 +226,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] multiple chunks`, function() {
     it(`should work when called with just swSrc`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.afaa1016313821cd74bbe81a9cf68406.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.ea23e32058279c8eaa936321febd3c34.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -287,7 +287,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should support setting importWorkboxFrom to a chunk's name`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.4b8f8eed0501cb79a5e4c7a1d3ffab4e.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.87c9951460ef50e83fd20b5ac561ab50.js';
       const workboxEntryName = 'workboxEntry-278b92112247f26eee29.js';
       const outputDir = tempy.directory();
       const config = {
@@ -351,7 +351,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should support setting importWorkboxFrom to 'local'`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.afaa1016313821cd74bbe81a9cf68406.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.ea23e32058279c8eaa936321febd3c34.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -430,7 +430,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should support setting importWorkboxFrom to 'local', and respect output.publicPath`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.b2ca7948c6274f6b544b6a0da937eba4.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.dc5b6abaf9a513e11137a4aff3f47050.js';
       const outputDir = tempy.directory();
       const publicPath = 'https://testing.path/';
       const config = {
@@ -511,7 +511,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should respect output.publicPath if importWorkboxFrom is set to a Webpack chunk name`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.bbadb5d9c5bcdc1c0edb55897633dd31.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.ded2225bd7265f8d8b1b4f84e8a8dd48.js';
       const publicPath = 'https://testing.path/';
       const workboxChunkName = 'workbox-sw-chunk-name';
 
@@ -579,7 +579,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should honor the 'chunks' whitelist config`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.4b8f8eed0501cb79a5e4c7a1d3ffab4e.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.87c9951460ef50e83fd20b5ac561ab50.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -642,7 +642,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should honor the 'excludeChunks' blacklist config`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.4b8f8eed0501cb79a5e4c7a1d3ffab4e.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.87c9951460ef50e83fd20b5ac561ab50.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -705,7 +705,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should honor setting both the 'chunks' and 'excludeChunks', with the blacklist taking precedence`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.3ab1df6ebdb6a621237f642455ee53a8.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.5c1807bea92497c4ce2edfd648c76fda.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -769,7 +769,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] html-webpack-plugin and a single chunk`, function() {
     it(`should work when called with just swSrc`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.d69e64fa976e4523cff05b9fc652c66c.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.961b2e55574237e7ea932b7963bc3d1d.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -834,7 +834,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should honor a custom swDest and publicPath`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.2d9e61add181ea83e1472128f9f83dd3.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.da79ba969df6446c897126b408d9a81b.js';
       const SW_DEST = 'custom-sw-dest.js';
       const publicPath = '/testing/';
 
@@ -904,7 +904,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should support passing options through to workbox-build.getManifest() to precache additional files`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.31755838840b51c1b4eba88c3bbe54bb.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.2c342c632321f089da494c0700873e9b.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -979,7 +979,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] copy-webpack-plugin and a single chunk`, function() {
     it(`should work when called with just swSrc`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.1e9aeed006e3e09b241faf4afb8d2cfa.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.2b3d18c77655489eaa6adb2851e7e476.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1063,7 +1063,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Filtering via test/include/exclude`, function() {
     it(`should exclude .map and manifest.js files by default`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.82d9f27b442b5218244a0c9491e287c0.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.49af80607fd27ad2046d94148ac9cb2d.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1130,7 +1130,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should allow developers to override the default exclude filter`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.d91063e939edda5be4d6e1093eeac5ec.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.1431038c0e75c1cf68c4206fb9230140.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1192,7 +1192,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should allow developers to whitelist via include`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.1242f9e007897f035a52e56690ff17a6.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.92ba19475051a5dc73f5693dc05fd39d.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1261,7 +1261,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should allow developers to combine the test and exclude filters`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.83df65831eb442f8ad5fbeb8edecc558.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.a586dc93ba1a7f63f945e7d6f1e08676.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1330,7 +1330,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] swDest variations`, function() {
     it(`should work when swDest is an absolute path`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.aec0313ed4dacd1c4b8981f195bf9f33.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.29f0f9b0fb8d84f04161b18c20c18fee.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1391,7 +1391,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Reporting webpack warnings`, function() {
     it(`should add warnings from the workbox-build methods to compilation.warnings`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.a4dd3e7398938bcb6409dcaea4ae8ec1.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.9a3d0d52f056554b3e5ae55e6aa95869.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1463,7 +1463,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should add a warning when various glob-related options are set`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.753ba80b7b356860e9c3f460962cdc00.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.75e9cd918a5c9e42c04de9def4ad4193.js';
       const outputDir = tempy.directory();
       const globOptionsToWarnAbout = [
         'globDirectory',
@@ -1546,7 +1546,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should add a warning when certain options are used, but globPatterns isn't set`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.0588874b96c8001cce24ccd935d947f0.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.7e1d0d5a77c9c05655b6033e320028e3.js';
       const outputDir = tempy.directory();
       const optionsToWarnAboutWhenGlobPatternsIsNotSet = [
         'dontCacheBustUrlsMatching',
@@ -1620,7 +1620,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Customizing output paths and names`, function() {
     it(`should allow overriding precacheManifestFilename`, function(done) {
-      const FILE_MANIFEST_NAME = 'custom-name.0588874b96c8001cce24ccd935d947f0.js';
+      const FILE_MANIFEST_NAME = 'custom-name.7e1d0d5a77c9c05655b6033e320028e3.js';
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
@@ -1681,7 +1681,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should allow setting importsDirectory`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.0588874b96c8001cce24ccd935d947f0.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.7e1d0d5a77c9c05655b6033e320028e3.js';
       const outputDir = tempy.directory();
       const importsDirectory = path.join('one', 'two');
       const config = {
@@ -1744,7 +1744,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
     });
 
     it(`should allow setting importsDirectory, publicPath, and importWorkboxFrom: 'local'`, function(done) {
-      const FILE_MANIFEST_NAME = 'precache-manifest.ef6ef924c8c87cec1daeb65a41ca7b54.js';
+      const FILE_MANIFEST_NAME = 'precache-manifest.0a5a96f075807fd5ebca92528f0a5156.js';
       const outputDir = tempy.directory();
       const importsDirectory = path.join('one', 'two');
       const publicPath = '/testing/';


### PR DESCRIPTION
R: @philipwalton
CC: @AidanDai to confirm this addresses their issue.

Fixes #1762

Instead of assigning to `self.__precacheManifest`, the webpack plugin will concatenate to the end (or just to the end of `[]`).
