### PR TITLE
CLI support for --watch

### DIFF
--- a/packages/workbox-cli/package-lock.json
+++ b/packages/workbox-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "workbox-cli",
-	"version": "4.0.0-alpha.0",
+	"version": "4.0.0-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -38,63 +38,140 @@
 				"color-convert": "^1.9.0"
 			}
 		},
+		"anymatch": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"requires": {
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
+			}
+		},
+		"arr-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+		},
+		"array-each": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+			"integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
+		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
 			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+		},
+		"array-slice": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+			"integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
+		},
+		"array-unique": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
 		},
-		"babel-extract-comments": {
+		"assign-symbols": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
-			"integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
+		"async-done": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.1.tgz",
+			"integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
 			"requires": {
-				"babylon": "^6.18.0"
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.2",
+				"process-nextick-args": "^1.0.7",
+				"stream-exhaust": "^1.0.1"
 			}
 		},
-		"babel-plugin-syntax-object-rest-spread": {
-			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+		"async-each": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
 		},
-		"babel-plugin-transform-object-rest-spread": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-runtime": "^6.26.0"
-			}
-		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.11.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-				}
-			}
-		},
-		"babylon": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"binary-extensions": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
+			"integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
 		},
 		"boxen": {
 			"version": "1.3.0",
@@ -119,10 +196,53 @@
 				"concat-map": "0.0.1"
 			}
 		},
+		"braces": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"requires": {
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			}
 		},
 		"camelcase": {
 			"version": "4.1.0",
@@ -159,10 +279,51 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 		},
+		"chokidar": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+			"requires": {
+				"anymatch": "^2.0.0",
+				"async-each": "^1.0.0",
+				"braces": "^2.3.0",
+				"fsevents": "^1.2.2",
+				"glob-parent": "^3.1.0",
+				"inherits": "^2.0.1",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"lodash.debounce": "^4.0.8",
+				"normalize-path": "^2.1.1",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.0.0",
+				"upath": "^1.0.5"
+			}
+		},
 		"ci-info": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
 			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
 		},
 		"cli-boxes": {
 			"version": "1.0.0",
@@ -192,6 +353,15 @@
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
 			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -209,6 +379,11 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
 			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -228,10 +403,15 @@
 				"xdg-basedir": "^3.0.0"
 			}
 		},
-		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"create-error-class": {
 			"version": "3.0.2",
@@ -264,6 +444,14 @@
 				"array-find-index": "^1.0.1"
 			}
 		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -285,6 +473,11 @@
 				}
 			}
 		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+		},
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -296,6 +489,43 @@
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 			"requires": {
 				"clone": "^1.0.2"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
 			}
 		},
 		"dot-prop": {
@@ -310,6 +540,14 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
 			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -338,6 +576,57 @@
 				"strip-eof": "^1.0.0"
 			}
 		},
+		"expand-brackets": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"requires": {
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
 		"external-editor": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
@@ -348,6 +637,65 @@
 				"tmp": "^0.0.33"
 			}
 		},
+		"extglob": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"requires": {
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
 		"figures": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -356,12 +704,54 @@
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
+		"fill-range": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"requires": {
 				"locate-path": "^2.0.0"
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"for-own": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+			"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+			"requires": {
+				"for-in": "^1.0.1"
+			}
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"requires": {
+				"map-cache": "^0.2.2"
 			}
 		},
 		"fs-extra": {
@@ -379,15 +769,477 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
-		"get-own-enumerable-property-symbols": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
-			"integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
+		"fsevents": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"optional": true,
+			"requires": {
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "1.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"chownr": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"debug": {
+					"version": "2.6.9",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.5.1",
+					"bundled": true,
+					"optional": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.3",
+					"bundled": true,
+					"optional": true
+				},
+				"fs-minipass": {
+					"version": "1.2.5",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"iconv-lite": {
+					"version": "0.4.21",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"safer-buffer": "^2.1.0"
+					}
+				},
+				"ignore-walk": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"minimatch": "^3.0.4"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"ini": {
+					"version": "1.3.5",
+					"bundled": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"minipass": {
+					"version": "2.2.4",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "1.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"needle": {
+					"version": "2.2.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
+					}
+				},
+				"node-pre-gyp": {
+					"version": "0.10.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.0",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1",
+						"osenv": "^0.1.4"
+					}
+				},
+				"npm-bundled": {
+					"version": "1.0.3",
+					"bundled": true,
+					"optional": true
+				},
+				"npm-packlist": {
+					"version": "1.1.10",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.5",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.7",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "^0.5.1",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"glob": "^7.0.5"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"bundled": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true,
+					"optional": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"bundled": true,
+					"optional": true
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "4.4.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"chownr": "^1.0.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.2.4",
+						"minizlib": "^1.1.0",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.2"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"string-width": "^1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"yallist": {
+					"version": "3.0.2",
+					"bundled": true
+				}
+			}
 		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"glob": {
 			"version": "7.1.3",
@@ -400,6 +1252,38 @@
 				"minimatch": "^3.0.4",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"requires": {
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
+			},
+			"dependencies": {
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				}
+			}
+		},
+		"glob-watcher": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+			"integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
+			"requires": {
+				"anymatch": "^2.0.0",
+				"async-done": "^1.2.0",
+				"chokidar": "^2.0.0",
+				"is-negated-glob": "^1.0.0",
+				"just-debounce": "^1.0.0",
+				"object.defaults": "^1.1.0"
 			}
 		},
 		"global-dirs": {
@@ -438,10 +1322,34 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
-		"hoek": {
-			"version": "4.2.1",
-			"resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"hosted-git-info": {
 			"version": "2.7.1",
@@ -510,10 +1418,41 @@
 				"through": "^2.3.6"
 			}
 		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"requires": {
+				"binary-extensions": "^1.0.0"
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
@@ -531,10 +1470,63 @@
 				"ci-info": "^1.5.0"
 			}
 		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+		},
+		"is-glob": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
 		},
 		"is-installed-globally": {
 			"version": "0.1.0",
@@ -545,10 +1537,33 @@
 				"is-path-inside": "^1.0.0"
 			}
 		},
+		"is-negated-glob": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
+		},
 		"is-npm": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
 			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+		},
+		"is-number": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"is-obj": {
 			"version": "1.0.1",
@@ -568,6 +1583,14 @@
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -577,11 +1600,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
 			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
-		},
-		"is-regexp": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
 		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
@@ -593,28 +1611,25 @@
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
-		"isemail": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-			"integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-			"requires": {
-				"punycode": "2.x.x"
-			}
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
-		"joi": {
-			"version": "11.4.0",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
-			"integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
-			"requires": {
-				"hoek": "4.x.x",
-				"isemail": "3.x.x",
-				"topo": "2.x.x"
-			}
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
@@ -628,6 +1643,16 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
+		},
+		"just-debounce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+			"integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo="
+		},
+		"kind-of": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 		},
 		"latest-version": {
 			"version": "3.1.0",
@@ -662,27 +1687,10 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
 			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 		},
-		"lodash._reinterpolate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-		},
-		"lodash.template": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-			"requires": {
-				"lodash._reinterpolate": "~3.0.0",
-				"lodash.templatesettings": "^4.0.0"
-			}
-		},
-		"lodash.templatesettings": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-			"requires": {
-				"lodash._reinterpolate": "~3.0.0"
-			}
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -723,10 +1731,23 @@
 				"pify": "^3.0.0"
 			}
 		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+		},
 		"map-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
 			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"requires": {
+				"object-visit": "^1.0.0"
+			}
 		},
 		"meow": {
 			"version": "5.0.0",
@@ -742,6 +1763,26 @@
 				"redent": "^2.0.0",
 				"trim-newlines": "^2.0.0",
 				"yargs-parser": "^10.0.0"
+			}
+		},
+		"micromatch": {
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
 			}
 		},
 		"mimic-fn": {
@@ -771,10 +1812,58 @@
 				"is-plain-obj": "^1.1.0"
 			}
 		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+		},
+		"nan": {
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+			"optional": true
+		},
+		"nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			}
 		},
 		"normalize-package-data": {
 			"version": "2.4.0",
@@ -787,12 +1876,75 @@
 				"validate-npm-package-license": "^3.0.1"
 			}
 		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"requires": {
+				"remove-trailing-separator": "^1.0.1"
+			}
+		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
 				"path-key": "^2.0.0"
+			}
+		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"requires": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"requires": {
+				"isobject": "^3.0.0"
+			}
+		},
+		"object.defaults": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+			"integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+			"requires": {
+				"array-each": "^1.0.1",
+				"array-slice": "^1.0.0",
+				"for-own": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"requires": {
+				"isobject": "^3.0.1"
 			}
 		},
 		"once": {
@@ -875,6 +2027,16 @@
 				"json-parse-better-errors": "^1.0.1"
 			}
 		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -908,6 +2070,11 @@
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+		},
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
@@ -918,15 +2085,15 @@
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.1.0.tgz",
 			"integrity": "sha512-wa5+qGVg9Yt7PB6rYm3kXlKzgzgivYTLRandezh43jjRqgyDyP+9YxfJpJiLs9yKD1WeU8/OvtToWpW7255FtA=="
 		},
+		"process-nextick-args": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-		},
-		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"quick-lru": {
 			"version": "1.1.0",
@@ -963,6 +2130,37 @@
 				"read-pkg": "^3.0.0"
 			}
 		},
+		"readable-stream": {
+			"version": "2.3.6",
+			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+				}
+			}
+		},
+		"readdirp": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"micromatch": "^3.1.10",
+				"readable-stream": "^2.0.2"
+			}
+		},
 		"redent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -976,6 +2174,15 @@
 			"version": "0.12.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
 			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
+			}
 		},
 		"registry-auth-token": {
 			"version": "3.3.2",
@@ -994,6 +2201,26 @@
 				"rc": "^1.0.1"
 			}
 		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+		},
+		"repeat-element": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -1002,6 +2229,11 @@
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
 			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"run-async": {
 			"version": "2.3.0",
@@ -1024,6 +2256,14 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -1040,6 +2280,27 @@
 			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
 			"requires": {
 				"semver": "^5.0.3"
+			}
+		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"shebang-command": {
@@ -1059,6 +2320,125 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"requires": {
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"requires": {
+				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"requires": {
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"spdx-correct": {
 			"version": "3.0.0",
@@ -1088,6 +2468,38 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
 			"integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
 		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"stream-exhaust": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+			"integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw=="
+		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -1097,14 +2509,12 @@
 				"strip-ansi": "^4.0.0"
 			}
 		},
-		"stringify-object": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
-				"get-own-enumerable-property-symbols": "^3.0.0",
-				"is-obj": "^1.0.1",
-				"is-regexp": "^1.0.0"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -1119,15 +2529,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
 			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-		},
-		"strip-comments": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
-			"integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
-			"requires": {
-				"babel-extract-comments": "^1.0.0",
-				"babel-plugin-transform-object-rest-spread": "^6.26.0"
-			}
 		},
 		"strip-eof": {
 			"version": "1.0.0",
@@ -1178,12 +2579,42 @@
 				"os-tmpdir": "~1.0.2"
 			}
 		},
-		"topo": {
-			"version": "2.0.2",
-			"resolved": "http://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-			"integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"requires": {
-				"hoek": "4.x.x"
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"requires": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
 			}
 		},
 		"trim-newlines": {
@@ -1195,6 +2626,38 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
 			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
+					}
+				}
+			}
 		},
 		"unique-string": {
 			"version": "1.0.0",
@@ -1209,10 +2672,51 @@
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+				}
+			}
+		},
 		"unzip-response": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
 			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+		},
+		"upath": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
 		},
 		"update-notifier": {
 			"version": "2.5.0",
@@ -1231,6 +2735,11 @@
 				"xdg-basedir": "^3.0.0"
 			}
 		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+		},
 		"url-parse-lax": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -1238,6 +2747,16 @@
 			"requires": {
 				"prepend-http": "^1.0.1"
 			}
+		},
+		"use": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -1271,153 +2790,6 @@
 			"requires": {
 				"string-width": "^2.1.1"
 			}
-		},
-		"workbox-background-sync": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-xmQmWS1k0k8I429oQZK64/0zhfh5Hm+T/BCjU0HXldT4yfqE8+RkVGuxibcrJN2V4gK5SZ2PA1SWncU1Nosbmg==",
-			"requires": {
-				"workbox-core": "^4.0.0-alpha.0"
-			}
-		},
-		"workbox-broadcast-cache-update": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-DqPfRUCfHrSg0eLv8bHwXWxooY4S5Fe4xr3yWWg85zQ3Na7GF4LjVzJflWBzLrFZuZ2QnP8BxQz9ojpdm8MBcA==",
-			"requires": {
-				"workbox-core": "^4.0.0-alpha.0"
-			}
-		},
-		"workbox-build": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-1zrMQMEan8txRvPo4D+QVBsa/ZNT2O9SDDVMUeWOVAtpbnfFZcK2ph4Xv58J0j5k7dJ/b5ChHFgtnWj8qiLzlQ==",
-			"requires": {
-				"@babel/runtime": "^7.0.0",
-				"common-tags": "^1.4.0",
-				"fs-extra": "^4.0.2",
-				"glob": "^7.1.2",
-				"joi": "^11.1.1",
-				"lodash.template": "^4.4.0",
-				"pretty-bytes": "^4.0.2",
-				"stringify-object": "^3.2.2",
-				"strip-comments": "^1.0.2",
-				"workbox-background-sync": "^4.0.0-alpha.0",
-				"workbox-broadcast-cache-update": "^4.0.0-alpha.0",
-				"workbox-cache-expiration": "^4.0.0-alpha.0",
-				"workbox-cacheable-response": "^4.0.0-alpha.0",
-				"workbox-core": "^4.0.0-alpha.0",
-				"workbox-google-analytics": "^4.0.0-alpha.0",
-				"workbox-navigation-preload": "^4.0.0-alpha.0",
-				"workbox-precaching": "^4.0.0-alpha.0",
-				"workbox-range-requests": "^4.0.0-alpha.0",
-				"workbox-routing": "^4.0.0-alpha.0",
-				"workbox-strategies": "^4.0.0-alpha.0",
-				"workbox-streams": "^4.0.0-alpha.0",
-				"workbox-sw": "^4.0.0-alpha.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"pretty-bytes": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
-					"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
-				}
-			}
-		},
-		"workbox-cache-expiration": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-gMAk2OL+yF+rCwctJ5mGfUQAnH1KQfSh+8NqkkmLo+Qui9PPdrFpQEg0hG9ErdvpptgVxVwyqMnfmO4dxvxc+w==",
-			"requires": {
-				"workbox-core": "^4.0.0-alpha.0"
-			}
-		},
-		"workbox-cacheable-response": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-SmvlF0a+uvoil6RH+4r6DOBTffa6zvy4WX9YPM869gzLDXQWMonui4+Wn9kcjuWKjkNz6G1LPtwlxHHV6vDDkA==",
-			"requires": {
-				"workbox-core": "^4.0.0-alpha.0"
-			}
-		},
-		"workbox-core": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-CH1p9vSwdW9DoAnoEvBLJppFGjh2tBJVCproINKMNEc6NhfVK5XvkCBssOQ6zUf8MXUKbpMSzUlZX8h35jX1XA=="
-		},
-		"workbox-google-analytics": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-qNQsPMEyB5fy3bwprsx69DbpG7qmaTvETD6AxBb4/jvlhdHyGjpKdTxFATpv2IEgFmsei8BqlW3NBTvklHdB+A==",
-			"requires": {
-				"workbox-background-sync": "^4.0.0-alpha.0",
-				"workbox-core": "^4.0.0-alpha.0",
-				"workbox-routing": "^4.0.0-alpha.0",
-				"workbox-strategies": "^4.0.0-alpha.0"
-			}
-		},
-		"workbox-navigation-preload": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-kYKmr7Qne6JOrDt33pU91ZDTxhtg1wOkppMGDE1nZ+B5Hc43AfZLWVKQlVM2BZETodPWqEsoB1zWMT0M/AQwlg==",
-			"requires": {
-				"workbox-core": "^4.0.0-alpha.0"
-			}
-		},
-		"workbox-precaching": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-QXlSxe5RGq83QXjIauP6ZJYtqcqCERa/z2lIzZden4zy7qwDaMDHoj2BR63fJk2nidAgYogAtrVC3E/EcOkShA==",
-			"requires": {
-				"workbox-core": "^4.0.0-alpha.0"
-			}
-		},
-		"workbox-range-requests": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-yk7jfPdh8HLFhNGRav6SFpOzlmdfI58PAz2CY4UTJIL+eIn3203Mld1nWzLvrJJzZs2SNLZBb4x/FgkzuoHrlg==",
-			"requires": {
-				"workbox-core": "^4.0.0-alpha.0"
-			}
-		},
-		"workbox-routing": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-WCgeoPZJmnQmBpBA2IjRYhvjpVm8oxRKKdCeTwmvaJmT9K3FJcYiilPtJFHoXTuU9AgGn2RR7l3K8w/rUUWEig==",
-			"requires": {
-				"workbox-core": "^4.0.0-alpha.0"
-			}
-		},
-		"workbox-strategies": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-NwEGpyYmOzmA36vr8qoKYIqI0/SigSkDjzHtYRooz83pu9Iq8NK73krrckTd+6/zJg73L5bwz7ikkfyJznd9Bw==",
-			"requires": {
-				"workbox-core": "^4.0.0-alpha.0"
-			}
-		},
-		"workbox-streams": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-MRECOPgpx2tWiXijHToPCYyQ9Oir7ZYcvo2u4+Ox8gIwsN3D8sG9b3+/GW0FSUskeTNlFMzEDdruPYFIBkJcNQ==",
-			"requires": {
-				"workbox-core": "^4.0.0-alpha.0"
-			}
-		},
-		"workbox-sw": {
-			"version": "4.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-4.0.0-alpha.0.tgz",
-			"integrity": "sha512-hve+36Sg7iFR8T/cgsaQXCrVQUhhT2LsqDhkZv4OuNfmN8q6JLrkWnPBTQTA2HKEjjJCP+i8kUiIwwtR2rFJ/Q=="
 		},
 		"wrappy": {
 			"version": "1.0.2",

--- a/packages/workbox-cli/package.json
+++ b/packages/workbox-cli/package.json
@@ -34,6 +34,7 @@
     "common-tags": "^1.8.0",
     "fs-extra": "^7.0.0",
     "glob": "^7.1.3",
+    "glob-watcher": "^5.0.3",
     "inquirer": "^6.2.0",
     "meow": "^5.0.0",
     "ora": "^3.0.0",

--- a/packages/workbox-cli/src/app.js
+++ b/packages/workbox-cli/src/app.js
@@ -10,6 +10,7 @@ const assert = require('assert');
 const ol = require('common-tags').oneLine;
 const path = require('path');
 const prettyBytes = require('pretty-bytes');
+const watch = require('glob-watcher');
 const workboxBuild = require('workbox-build');
 
 const constants = require('./lib/constants');
@@ -17,6 +18,36 @@ const errors = require('./lib/errors');
 const logger = require('./lib/logger');
 const readConfig = require('./lib/read-config');
 const runWizard = require('./lib/run-wizard');
+
+/**
+ * Runs the specified build command with the provided configuration.
+ *
+ * @param {Object} options
+ */
+async function runBuildCommand({command, config, watch}) {
+  try {
+    const {size, count, warnings} = await workboxBuild[command](config);
+
+    for (const warning of warnings) {
+      logger.warn(warning);
+    }
+
+    logger.log(`The service worker was written to ${config.swDest}\n` +
+      `${count} files will be precached, totalling ${prettyBytes(size)}.`);
+
+    if (watch) {
+      logger.log(`\nWatching for changes...`);
+    }
+  } catch (error) {
+    // See https://github.com/hapijs/joi/blob/v11.3.4/API.md#errors
+    if (typeof error.annotate === 'function') {
+      throw new Error(
+          `${errors['config-validation-failed']}\n${error.annotate()}`);
+    }
+    logger.error(errors['workbox-build-runtime-error']);
+    throw error;
+  }
+}
 
 module.exports = async (params = {}) => {
   // This should not be a user-visible error, unless meow() messes something up.
@@ -47,9 +78,9 @@ module.exports = async (params = {}) => {
 
     case 'generateSW':
     case 'injectManifest': {
-    // TODO: Confirm that this works with Windows paths.
       const configPath = path.resolve(process.cwd(),
           option || constants.defaultConfigFile);
+
       let config;
       try {
         config = readConfig(configPath);
@@ -59,23 +90,21 @@ module.exports = async (params = {}) => {
       }
 
       logger.log(`Using configuration from ${configPath}.`);
-      try {
-        const {size, count, warnings} = await workboxBuild[command](config);
 
-        for (const warning of warnings) {
-          logger.warn(warning);
+      // Determine whether we're in --watch mode, or one-off mode.
+      if (params.flags && params.flags.watch) {
+        const options = {ignoreInitial: false};
+        if (config.globIgnores) {
+          options.ignored = config.globIgnores;
+        }
+        if (config.globDirectory) {
+          options.cwd = config.globDirectory;
         }
 
-        logger.log(`The service worker was written to ${config.swDest}\n` +
-          `${count} files will be precached, totalling ${prettyBytes(size)}.`);
-      } catch (error) {
-      // See https://github.com/hapijs/joi/blob/v11.3.4/API.md#errors
-        if (typeof error.annotate === 'function') {
-          throw new Error(
-              `${errors['config-validation-failed']}\n${error.annotate()}`);
-        }
-        logger.error(errors['workbox-build-runtime-error']);
-        throw error;
+        watch(config.globPatterns, options,
+            () => runBuildCommand({command, config, watch: true}));
+      } else {
+        await runBuildCommand({command, config, watch: false});
       }
       break;
     }

--- a/packages/workbox-cli/src/lib/help-text.js
+++ b/packages/workbox-cli/src/lib/help-text.js
@@ -18,16 +18,22 @@ Commands:
     If --injectManifest is provided, the wizard will ask
     questions needed for the injectManifest use case.
 
-  generateSW [<path/to/config.js>]
+  generateSW [<path/to/config.js>] [--watch]
     Creates a new service worker file based on the options
     in the config file (defaults to workbox-config.js).
+    If --watch is provided, the CLI will stay running, and will
+    rebuild the service worker each time a file in the precache
+    manifest changes.
     See https://goo.gl/gVo87N
 
-  injectManifest [<path/to/config.js>]
+  injectManifest [<path/to/config.js>] [--watch]
     Takes an existing service worker file and creates a
-    copy of it with a precaching manifest "injected" into
-    it. The precaching manifest is generated based on the
+    copy of it with a precache manifest "injected" into
+    it. The precache manifest is generated based on the
     options in the config file (defaults to workbox-config.js).
+    If --watch is provided, the CLI will stay running, and will
+    rebuild the service worker each time a file in the precache
+    manifest changes.
     See https://goo.gl/8bs14N
 
   copyLibraries <path/to/parent/dir>
@@ -46,7 +52,7 @@ Config file:
 Examples:
   $ workbox wizard
   $ workbox wizard --injectManifest
-  $ workbox generateSW
+  $ workbox generateSW --watch
   $ workbox injectManifest configs/workbox-dev-config.js
   $ workbox copyLibraries build/
 `;


### PR DESCRIPTION
**Prior to filing a PR, please:**
- [open an issue](https://github.com/GoogleChrome/workbox/issues/new) to discuss your proposed change.
- ensure that `gulp lint test` passes locally.

R: @philipwalton

Fixes #1490

Adds support for a `--watch` flag that can be passed to the CLI's `injectManifest` and `generateSW` modes. If provided, the CLI will stay running and will rebuild the SW whenever one of the `globPatterns` matches changes.
