### PR TITLE
use stringify-object instead of JSON.stringify

### DIFF
--- a/packages/workbox-build/src/lib/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/runtime-caching-converter.js
@@ -94,7 +94,7 @@ function getOptionsString(options = {}) {
       // expiration and cacheableResponse
       default: {
         pluginCode = `new ${pluginString}(${stringifyWithoutComments(
-          pluginConfig
+            pluginConfig
         )})`;
       }
     }

--- a/packages/workbox-build/src/lib/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/runtime-caching-converter.js
@@ -16,7 +16,7 @@ const stringifyWithoutComments = require('./stringify-without-comments');
  * into a string that would configure equivalent `workbox-sw` behavior.
  *
  * @param {Object} options See
- *        https://googlechrome.github.io/sw-toolbox/api.html#options
+ *        https://googlechromelabs.github.io/sw-toolbox/api.html#options
  * @return {string} A JSON string representing the equivalent options.
  *
  * @private
@@ -32,8 +32,12 @@ function getOptionsString(options = {}) {
   // Pull handler-specific config from the options object, since they are
   // not directly used to construct a Plugin instance. If set, need to be
   // passed as options to the handler constructor instead.
-  const handlerOptionKeys =
-      ['cacheName', 'networkTimeoutSeconds', 'fetchOptions', 'matchOptions'];
+  const handlerOptionKeys = [
+    'cacheName',
+    'networkTimeoutSeconds',
+    'fetchOptions',
+    'matchOptions',
+  ];
   const handlerOptions = {};
   for (const key of handlerOptionKeys) {
     if (key in options) {
@@ -68,7 +72,7 @@ function getOptionsString(options = {}) {
         const name = pluginConfig.name;
         pluginCode = `new ${pluginString}(${JSON.stringify(name)}`;
         if ('options' in pluginConfig) {
-          pluginCode += `, ${JSON.stringify(pluginConfig.options)}`;
+          pluginCode += `, ${stringifyWithoutComments(pluginConfig.options)}`;
         }
         pluginCode += `)`;
 
@@ -79,7 +83,7 @@ function getOptionsString(options = {}) {
         const channelName = pluginConfig.channelName;
         pluginCode = `new ${pluginString}(${JSON.stringify(channelName)}`;
         if ('options' in pluginConfig) {
-          pluginCode += `, ${JSON.stringify(pluginConfig.options)}`;
+          pluginCode += `, ${stringifyWithoutComments(pluginConfig.options)}`;
         }
         pluginCode += `)`;
 
@@ -89,7 +93,9 @@ function getOptionsString(options = {}) {
       // For plugins that just pass in an Object to the constructor, like
       // expiration and cacheableResponse
       default: {
-        pluginCode = `new ${pluginString}(${JSON.stringify(pluginConfig)})`;
+        pluginCode = `new ${pluginString}(${stringifyWithoutComments(
+          pluginConfig
+        )})`;
       }
     }
 

--- a/packages/workbox-build/src/lib/stringify-without-comments.js
+++ b/packages/workbox-build/src/lib/stringify-without-comments.js
@@ -11,6 +11,7 @@ const stripComments = require('strip-comments');
 
 module.exports = (obj) => {
   return objectStringify(obj, {
-    transform: (_obj, _prop, str) => stripComments(str),
+    transform: (_obj, _prop, str) =>
+      typeof _obj[_prop] === 'function' ? stripComments(str) : str,
   });
 };


### PR DESCRIPTION
**Prior to filing a PR, please:**
- [open an issue](https://github.com/GoogleChrome/workbox/issues/new) to discuss your proposed change.
- ensure that `gulp lint test` passes locally.

R: @jeffposnick @philipwalton

Fixes #1761

- use `stringify-object` instead of `JSON.stringify`
