### PR TITLE
Preserve the temporary cache

### DIFF
--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -156,16 +156,6 @@ class PrecacheController {
       }
     }
 
-    // Empty the temporary cache.
-    // NOTE: We remove all entries instead of calling caches.delete(), as the
-    // cache may be marked for deletion but still exist.
-    // See https://github.com/GoogleChrome/workbox/issues/1368
-    const tempCache = await caches.open(this._getTempCacheName());
-    const requests = await tempCache.keys();
-    await Promise.all(requests.map((request) => {
-      return tempCache.delete(request);
-    }));
-
     const entriesToPrecache = [];
     const entriesAlreadyPrecached = [];
 
@@ -221,10 +211,6 @@ class PrecacheController {
       });
       await tempCache.delete(request);
     }
-
-    // Remove the temporary Cache object, now that all the entries are copied.
-    // See https://github.com/GoogleChrome/workbox/issues/1735
-    await caches.delete(this._getTempCacheName());
 
     return this._cleanup();
   }

--- a/test/workbox-precaching/integration/precache-and-update.js
+++ b/test/workbox-precaching/integration/precache-and-update.js
@@ -43,6 +43,7 @@ describe(`[workbox-precaching] Precache and Update`, function() {
     const keys = await runInSW('cachesKeys');
     expect(keys).to.eql([
       'workbox-precache-http://localhost:3004/test/workbox-precaching/static/precache-and-update/',
+      'workbox-precache-http://localhost:3004/test/workbox-precaching/static/precache-and-update/-temp',
     ]);
 
     // Check that the cached requests are what we expect for sw-1.js

--- a/test/workbox-precaching/integration/precache-and-update.js
+++ b/test/workbox-precaching/integration/precache-and-update.js
@@ -41,7 +41,7 @@ describe(`[workbox-precaching] Precache and Update`, function() {
 
     // Check that only the precache cache was created.
     const keys = await runInSW('cachesKeys');
-    expect(keys).sort().to.eql([
+    expect(keys.sort()).to.eql([
       'workbox-precache-http://localhost:3004/test/workbox-precaching/static/precache-and-update/',
       'workbox-precache-http://localhost:3004/test/workbox-precaching/static/precache-and-update/-temp',
     ]);

--- a/test/workbox-precaching/integration/precache-and-update.js
+++ b/test/workbox-precaching/integration/precache-and-update.js
@@ -41,7 +41,7 @@ describe(`[workbox-precaching] Precache and Update`, function() {
 
     // Check that only the precache cache was created.
     const keys = await runInSW('cachesKeys');
-    expect(keys).to.eql([
+    expect(keys).sort().to.eql([
       'workbox-precache-http://localhost:3004/test/workbox-precaching/static/precache-and-update/',
       'workbox-precache-http://localhost:3004/test/workbox-precaching/static/precache-and-update/-temp',
     ]);

--- a/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
@@ -688,12 +688,12 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       expect(hasCache).to.equal(false);
     });
 
-    it(`should delete the temporary cache after activation`, async function() {
+    it(`should not delete the temporary cache after activation`, async function() {
       const precacheController = new PrecacheController();
       await precacheController.activate();
 
       const hasCache = await caches.has(precacheController._getTempCacheName());
-      expect(hasCache).to.equal(false);
+      expect(hasCache).to.equal(true);
     });
 
     prodOnly.it(`shouldn't log anything in production`, async function() {


### PR DESCRIPTION
R: @philipwalton

Fixes #1783

Based on my manual testing, this should ensure that precaching in both Chrome and Firefox are able to recover from a crash or unexpected shutdown that prevents the `activate` handler from completing. The actual `Response` entries in the temporary cache still get cleaned up once each one is moved over to the permanent cache in a successful `activate` handler.

Unfortunately:

- I haven't been able to add in an integration test to confirm this behavior, since you can't cause activation to fail by, e.g., throwing an exception or passing a rejected promise to `event.waitUntil()`. Activation failure isn't really *supposed* to happen, and it only appears to happen in the wild due to browser bugs.

- This does not account for the Edge is supposed to behave when activation fails, which is not to re-run either the `install` or `activate` event handlers at all. I'm not sure *how* we could actually recover from that, and have an open question at https://github.com/w3c/ServiceWorker/issues/1372#issuecomment-446766388 to see whether there's any advice. But this PR should help Firefox, at least.

- Some folks wanted the `-temp` cache to disappear entirely following a successful activation, and I had previously committed something to the `next` branch that would do that. In the course of investigating this PR, I realize why we have to keep the `-temp` cache around—see https://github.com/GoogleChrome/workbox/pull/1372 for more context. Given that, this PR also reverts the previous PR (https://github.com/GoogleChrome/workbox/pull/1736) which deleted the cache.