### PR TITLE
Default to response.status === 200 instead of response.ok

### DIFF
--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -161,7 +161,7 @@ const matchWrapper = async ({
 
 /**
  * This method will call cacheWillUpdate on the available plugins (or use
- * response.ok) to determine if the Response is safe and valid to cache.
+ * status === 200) to determine if the Response is safe and valid to cache.
  *
  * @param {Object} options
  * @param {Request} options.request
@@ -204,7 +204,7 @@ const _isResponseSafeToCache = async ({request, response, event, plugins}) => {
 
   if (!pluginsUsed) {
     if (process.env.NODE_ENV !== 'production') {
-      if (!responseToCache.ok) {
+      if (!responseToCache.status === 200) {
         if (responseToCache.status === 0) {
           logger.warn(`The response for '${request.url}' is an opaque ` +
             `response. The caching strategy that you're using will not ` +
@@ -216,7 +216,7 @@ const _isResponseSafeToCache = async ({request, response, event, plugins}) => {
         }
       }
     }
-    responseToCache = responseToCache.ok ? responseToCache : null;
+    responseToCache = responseToCache.status === 200 ? responseToCache : null;
   }
 
   return responseToCache ? responseToCache : null;

--- a/packages/workbox-strategies/plugins/cacheOkAndOpaquePlugin.mjs
+++ b/packages/workbox-strategies/plugins/cacheOkAndOpaquePlugin.mjs
@@ -10,8 +10,8 @@ import '../_version.mjs';
 
 export default {
   /**
-   * Return return a response (i.e. allow caching) if the
-   * response is ok (i.e. 200) or is opaque.
+   * Returns a valid response (to allow caching) if the status is 200 (OK) or
+   * 0 (opaque).
    *
    * @param {Object} options
    * @param {Response} options.response
@@ -20,7 +20,7 @@ export default {
    * @private
    */
   cacheWillUpdate: ({response}) => {
-    if (response.ok || response.status === 0) {
+    if (response.status === 200 || response.status === 0) {
       return response;
     }
     return null;

--- a/test/workbox-strategies/node/test-cacheOkAndOpaquePlugin.mjs
+++ b/test/workbox-strategies/node/test-cacheOkAndOpaquePlugin.mjs
@@ -10,12 +10,14 @@ import {expect} from 'chai';
 import plugin from '../../../packages/workbox-strategies/plugins/cacheOkAndOpaquePlugin.mjs';
 
 describe(`[workbox-strategies] cacheOkAndOpaquePlugin`, function() {
-  it(`should return null if status is not ok and status is not opaque`, function() {
-    const response = new Response('Hello', {
-      status: 404,
+  for (const status of [206, 404]) {
+    it(`should return null when status is ${status}`, function() {
+      const response = new Response('Hello', {
+        status,
+      });
+      expect(plugin.cacheWillUpdate({response})).to.equal(null);
     });
-    expect(plugin.cacheWillUpdate({response})).to.equal(null);
-  });
+  }
 
   it(`should return Response if status is opaque`, function() {
     const response = new Response('Hello', {


### PR DESCRIPTION
R: @philipwalton

Fixes #1804

Currently, we'll default to attempting to cache when `response.status === 206`, which is explicitly disallowed by the Cache Storage API.

This can still be overridden by `workbox-cacheable-response` for folks who need to customize the defaults.