### PR TITLE
Bumps a sleep value in workbox-precaching's integration test

### DIFF
--- a/test/workbox-precaching/integration/precache-and-update.js
+++ b/test/workbox-precaching/integration/precache-and-update.js
@@ -92,7 +92,7 @@ describe(`[workbox-precaching] Precache and Update`, function() {
     // Activate the second service worker
     await activateAndControlSW(SW_2_URL);
     // Add a slight delay for the caching operation to complete.
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // Ensure that the new assets were requested and cache busted.
     if (needsCacheBustSearchParam) {


### PR DESCRIPTION
R: @philipwalton

Fixes #1804

This, as all magic sleep values, is gross... but we already were sleeping for `100ms`, and it looks like that isn't enough in the current Chrome Beta. Bumping it up to `1000ms` made the tests pass locally...