### PR TITLE
Create a new, non-navigate request when using fetchOptions

### DIFF
--- a/infra/testing/sw-env-mocks/Request.js
+++ b/infra/testing/sw-env-mocks/Request.js
@@ -9,18 +9,24 @@
 const Blob = require('./Blob');
 const Headers = require('./Headers');
 
-
 // Stub missing/broken Request API methods in `service-worker-mock`.
 // https://fetch.spec.whatwg.org/#request-class
 class Request {
-  constructor(url, options = {}) {
-    if (url instanceof Request) {
-      options = url;
-      url = options.url;
+  constructor(urlOrRequest, options = {}) {
+    let url = urlOrRequest;
+    if (urlOrRequest instanceof Request) {
+      url = urlOrRequest.url;
+      options = Object.assign({}, {
+        body: urlOrRequest.body,
+        credentials: urlOrRequest.credentials,
+        headers: urlOrRequest.headers,
+        method: urlOrRequest.method,
+        mode: urlOrRequest.mode,
+      }, options);
     }
 
     if (!url) {
-      throw new TypeError(`Invalid url: ${url}`);
+      throw new TypeError(`Invalid url: ${urlOrRequest}`);
     }
 
     this.url = url;
@@ -57,7 +63,7 @@ class Request {
       throw new TypeError('Already read');
     } else {
       this.bodyUsed = true;
-      // Limitionation: this assumes the stored Blob is text-based.
+      // Limitation: this assumes the stored Blob is text-based.
       return this._body._text;
     }
   }

--- a/test/workbox-core/node/_private/test-fetchWrapper.mjs
+++ b/test/workbox-core/node/_private/test-fetchWrapper.mjs
@@ -69,6 +69,31 @@ describe(`workbox-core fetchWrapper`, function() {
       expect(fetchOptions).to.deep.equal(exampleOptions);
     });
 
+    it(`should convert 'navigate' requests to 'same-origin' when fetchOptions is used`, async function() {
+      const fetchStub = sandbox.stub(global, 'fetch').resolves(new Response());
+
+      const fetchOptions = {
+        headers: {
+          'X-Test': 'Header',
+        },
+      };
+
+      const request = new Request('/test/navigateFetchOptions', {
+        mode: 'navigate',
+      });
+
+      await fetchWrapper.fetch({
+        fetchOptions,
+        request,
+      });
+
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.firstCall.args[0]).to.be.instanceOf(Request);
+      expect(fetchStub.firstCall.args[0].url).to.eql(request.url);
+      expect(fetchStub.firstCall.args[0].mode).to.eql('same-origin');
+      expect(fetchStub.firstCall.args[1]).to.eql(fetchOptions);
+    });
+
     it(`should call requestWillFetch method in plugins and use the returned request`, async function() {
       const fetchStub = sandbox.stub(global, 'fetch').callsFake(() => new Response());
 


### PR DESCRIPTION
R: @philipwalton

Fixes #1796

As per that issue, attempting `fetch(request, fetchOptions)` when `request.mode === 'navigate'` and `fetchOptions` is non-empty  will lead to a runtime error. We can accommodate folks who need to set `fetchOptions` for navigation requests by converting things to a request with `mode` set to `same-origin` instead. 