### PR TITLE
Standardize casing in API names

### DIFF
--- a/infra/testing/webdriver/unregisterAllSws.js
+++ b/infra/testing/webdriver/unregisterAllSws.js
@@ -13,7 +13,7 @@ const {executeAsyncAndCatch} = require('./executeAsyncAndCatch');
  * Unregisters any active SWs so the next page load can start clean.
  * Note: a new page load is needed before controlling SWs stop being active.
  */
-const unregisterAllSws = async () => {
+const unregisterAllSWs = async () => {
   await executeAsyncAndCatch(async (cb) => {
     try {
       const regs = await navigator.serviceWorker.getRegistrations();
@@ -27,4 +27,4 @@ const unregisterAllSws = async () => {
   });
 };
 
-module.exports = {unregisterAllSws};
+module.exports = {unregisterAllSWs};

--- a/packages/workbox-broadcast-cache-update/broadcastUpdate.mjs
+++ b/packages/workbox-broadcast-cache-update/broadcastUpdate.mjs
@@ -32,7 +32,7 @@ import './_version.mjs';
  *   meta: 'workbox-broadcast-cache-update',
  *   payload: {
  *     cacheName: 'the-cache-name',
- *     updatedUrl: 'https://example.com/'
+ *     updatedURL: 'https://example.com/'
  *   }
  * }
  * ```
@@ -71,7 +71,7 @@ const broadcastUpdate = async ({channel, cacheName, url}) => {
     meta: CACHE_UPDATED_MESSAGE_META,
     payload: {
       cacheName: cacheName,
-      updatedUrl: url,
+      updatedURL: url,
     },
   };
 

--- a/packages/workbox-cache-expiration/CacheExpiration.mjs
+++ b/packages/workbox-cache-expiration/CacheExpiration.mjs
@@ -100,24 +100,24 @@ class CacheExpiration {
 
     // Use a Set to remove any duplicates following the concatenation, then
     // convert back into an array.
-    const allUrls = [...new Set(oldEntries.concat(extraEntries))];
+    const allURLs = [...new Set(oldEntries.concat(extraEntries))];
 
     await Promise.all([
-      this._deleteFromCache(allUrls),
-      this._deleteFromIDB(allUrls),
+      this._deleteFromCache(allURLs),
+      this._deleteFromIDB(allURLs),
     ]);
 
     if (process.env.NODE_ENV !== 'production') {
       // TODO: break apart entries deleted due to expiration vs size restraints
-      if (allUrls.length > 0) {
+      if (allURLs.length > 0) {
         logger.groupCollapsed(
-            `Expired ${allUrls.length} ` +
-          `${allUrls.length === 1 ? 'entry' : 'entries'} and removed ` +
-          `${allUrls.length === 1 ? 'it' : 'them'} from the ` +
+            `Expired ${allURLs.length} ` +
+          `${allURLs.length === 1 ? 'entry' : 'entries'} and removed ` +
+          `${allURLs.length === 1 ? 'it' : 'them'} from the ` +
           `'${this._cacheName}' cache.`);
         logger.log(
-            `Expired the following ${allUrls.length === 1 ? 'URL' : 'URLs'}:`);
-        allUrls.forEach((url) => logger.log(`    ${url}`));
+            `Expired the following ${allURLs.length === 1 ? 'URL' : 'URLs'}:`);
+        allURLs.forEach((url) => logger.log(`    ${url}`));
         logger.groupEnd();
       } else {
         logger.debug(`Cache expiration ran and found no entries to remove.`);
@@ -155,14 +155,14 @@ class CacheExpiration {
 
     const expireOlderThan = expireFromTimestamp - (this._maxAgeSeconds * 1000);
     const timestamps = await this._timestampModel.getAllTimestamps();
-    const expiredUrls = [];
+    const expiredURLs = [];
     timestamps.forEach((timestampDetails) => {
       if (timestampDetails.timestamp < expireOlderThan) {
-        expiredUrls.push(timestampDetails.url);
+        expiredURLs.push(timestampDetails.url);
       }
     });
 
-    return expiredUrls;
+    return expiredURLs;
   }
 
   /**
@@ -171,7 +171,7 @@ class CacheExpiration {
    * @private
    */
   async _findExtraEntries() {
-    const extraUrls = [];
+    const extraURLs = [];
 
     if (!this._maxEntries) {
       return [];
@@ -180,10 +180,10 @@ class CacheExpiration {
     const timestamps = await this._timestampModel.getAllTimestamps();
     while (timestamps.length > this._maxEntries) {
       const lastUsed = timestamps.shift();
-      extraUrls.push(lastUsed.url);
+      extraURLs.push(lastUsed.url);
     }
 
-    return extraUrls;
+    return extraURLs;
   }
 
   /**
@@ -205,7 +205,7 @@ class CacheExpiration {
    */
   async _deleteFromIDB(urls) {
     for (const url of urls) {
-      await this._timestampModel.deleteUrl(url);
+      await this._timestampModel.deleteURL(url);
     }
   }
 

--- a/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
+++ b/packages/workbox-cache-expiration/models/CacheTimestampsModel.mjs
@@ -101,7 +101,7 @@ class CacheTimestampsModel {
    *
    * @private
    */
-  async deleteUrl(url) {
+  async deleteURL(url) {
     await this._db.delete(this._storeName, new URL(url, location).href);
   }
 

--- a/packages/workbox-cli/src/lib/questions/ask-sw-src.js
+++ b/packages/workbox-cli/src/lib/questions/ask-sw-src.js
@@ -9,7 +9,7 @@
 const inquirer = require('inquirer');
 const ol = require('common-tags').oneLine;
 
-const assertValidSwSrc = require('../assert-valid-sw-src');
+const assertValidSWSrc = require('../assert-valid-sw-src');
 
 // The key used for the question/answer.
 const name = 'swSrc';
@@ -31,7 +31,7 @@ module.exports = async () => {
   const answers = await askQuestion();
   const swSrc = answers[name].trim();
 
-  await assertValidSwSrc(swSrc);
+  await assertValidSWSrc(swSrc);
 
   return swSrc;
 };

--- a/packages/workbox-core/_private/assert.mjs
+++ b/packages/workbox-core/_private/assert.mjs
@@ -12,7 +12,7 @@ import '../_version.mjs';
 /*
  * This method returns true if the current context is a service worker.
  */
-const isSwEnv = (moduleName) => {
+const isSWEnv = (moduleName) => {
   if (!('ServiceWorkerGlobalScope' in self)) {
     throw new WorkboxError('not-in-sw', {moduleName});
   }
@@ -93,7 +93,7 @@ const finalAssertExports = process.env.NODE_ENV === 'production' ? null : {
   isArray,
   isInstance,
   isOneOf,
-  isSwEnv,
+  isSWEnv,
   isType,
   isArrayOfClass,
 };

--- a/packages/workbox-core/_private/checkSWFileCacheHeaders.mjs
+++ b/packages/workbox-core/_private/checkSWFileCacheHeaders.mjs
@@ -18,11 +18,11 @@ import '../_version.mjs';
  * @private
  */
 function showWarning(cacheControlHeader) {
-  const docsUrl = 'https://developers.google.com/web/tools/workbox/guides/service-worker-checklist#cache-control_of_your_service_worker_file';
+  const docsURL = 'https://developers.google.com/web/tools/workbox/guides/service-worker-checklist#cache-control_of_your_service_worker_file';
   logger.warn(`You are setting a 'cache-control' header of ` +
     `'${cacheControlHeader}' on your service worker file. This should be ` +
     `set to 'max-age=0' or 'no-cache' to ensure the latest service worker ` +
-    `is served to your users. Learn more here: ${docsUrl}`
+    `is served to your users. Learn more here: ${docsURL}`
   );
 }
 

--- a/packages/workbox-precaching/_default.mjs
+++ b/packages/workbox-precaching/_default.mjs
@@ -13,12 +13,12 @@ import {logger} from 'workbox-core/_private/logger.mjs';
 
 import PrecacheController from './controllers/PrecacheController.mjs';
 import {cleanupOutdatedCaches} from './utils/cleanupOutdatedCaches.mjs';
-import {generateUrlVariations} from './utils/generateUrlVariations.mjs';
+import {generateURLVariations} from './utils/generateURLVariations.mjs';
 
 import './_version.mjs';
 
 if (process.env.NODE_ENV !== 'production') {
-  assert.isSwEnv('workbox-precaching');
+  assert.isSWEnv('workbox-precaching');
 }
 
 let installActivateListenersAdded = false;
@@ -40,10 +40,10 @@ const precacheController = new PrecacheController(cacheName);
  *
  * @private
  */
-const _getCacheKeyForUrl = (url, options) => {
-  const urlsToCacheKeys = precacheController.getUrlsToCacheKeys();
-  for (const possibleUrl of generateUrlVariations(url, options)) {
-    const possibleCacheKey = urlsToCacheKeys.get(possibleUrl);
+const _getCacheKeyForURL = (url, options) => {
+  const urlsToCacheKeys = precacheController.getURLsToCacheKeys();
+  for (const possibleURL of generateURLVariations(url, options)) {
+    const possibleCacheKey = urlsToCacheKeys.get(possibleURL);
     if (possibleCacheKey) {
       return possibleCacheKey;
     }
@@ -113,9 +113,9 @@ moduleExports.precache = (entries) => {
  * @param {string} [options.directoryIndex=index.html] The `directoryIndex` will
  * check cache entries for a URLs ending with '/' to see if there is a hit when
  * appending the `directoryIndex` value.
- * @param {Array<RegExp>} [options.ignoreUrlParametersMatching=[/^utm_/]] An
+ * @param {Array<RegExp>} [options.ignoreURLParametersMatching=[/^utm_/]] An
  * array of regex's to remove search params when looking for a cache match.
- * @param {boolean} [options.cleanUrls=true] The `cleanUrls` option will
+ * @param {boolean} [options.cleanURLs=true] The `cleanURLs` option will
  * check the cache for the URL with a `.html` added to the end of the end.
  * @param {workbox.precaching~urlManipulation} [options.urlManipulation]
  * This is a function that should take a URL and return an array of
@@ -124,9 +124,9 @@ moduleExports.precache = (entries) => {
  * @alias workbox.precaching.addRoute
  */
 moduleExports.addRoute = ({
-  ignoreUrlParametersMatching = [/^utm_/],
+  ignoreURLParametersMatching = [/^utm_/],
   directoryIndex = 'index.html',
-  cleanUrls = true,
+  cleanURLs = true,
   urlManipulation = null,
 } = {}) => {
   if (fetchListenersAdded) {
@@ -136,13 +136,13 @@ moduleExports.addRoute = ({
   fetchListenersAdded = true;
 
   self.addEventListener('fetch', (event) => {
-    const precachedUrl = _getCacheKeyForUrl(event.request.url, {
-      cleanUrls,
+    const precachedURL = _getCacheKeyForURL(event.request.url, {
+      cleanURLs,
       directoryIndex,
-      ignoreUrlParametersMatching,
+      ignoreURLParametersMatching,
       urlManipulation,
     });
-    if (!precachedUrl) {
+    if (!precachedURL) {
       if (process.env.NODE_ENV !== 'production') {
         logger.debug(`Precaching did not find a match for ` +
           getFriendlyURL(event.request.url));
@@ -152,7 +152,7 @@ moduleExports.addRoute = ({
 
     let responsePromise = caches.open(cacheName)
         .then((cache) => {
-          return cache.match(precachedUrl);
+          return cache.match(precachedURL);
         }).then((cachedResponse) => {
           if (cachedResponse) {
             return cachedResponse;
@@ -162,11 +162,11 @@ moduleExports.addRoute = ({
           // (perhaps due to manual cache cleanup).
           if (process.env.NODE_ENV !== 'production') {
             logger.warn(`The precached response for ` +
-            `${getFriendlyURL(precachedUrl)} in ${cacheName} was not found. ` +
+            `${getFriendlyURL(precachedURL)} in ${cacheName} was not found. ` +
             `Falling back to the network instead.`);
           }
 
-          return fetch(precachedUrl);
+          return fetch(precachedURL);
         });
 
     if (process.env.NODE_ENV !== 'production') {
@@ -175,7 +175,7 @@ moduleExports.addRoute = ({
         // print the routing details to the console.
         logger.groupCollapsed(`Precaching is responding to: ` +
           getFriendlyURL(event.request.url));
-        logger.log(`Serving the precached url: ${precachedUrl}`);
+        logger.log(`Serving the precached url: ${precachedURL}`);
 
         logger.groupCollapsed(`View request details here.`);
         logger.unprefixed.log(event.request);
@@ -258,10 +258,10 @@ moduleExports.cleanupOutdatedCaches = () => {
  * @param {string} url The URL whose cache key to look up.
  * @return {string} The cache key that corresponds to that URL.
  *
- * @alias workbox.precaching.getCacheKeyForUrl
+ * @alias workbox.precaching.getCacheKeyForURL
  */
-moduleExports.getCacheKeyForUrl = (url) => {
-  return precacheController.getCacheKeyForUrl(url);
+moduleExports.getCacheKeyForURL = (url) => {
+  return precacheController.getCacheKeyForURL(url);
 };
 
 export default moduleExports;

--- a/packages/workbox-precaching/_types.mjs
+++ b/packages/workbox-precaching/_types.mjs
@@ -10,9 +10,9 @@ import './_version.mjs';
 
 /**
  * @typedef {Object} InstallResult
- * @property {Array<string>} updatedUrls List of URLs that were updated during
+ * @property {Array<string>} updatedURLs List of URLs that were updated during
  * installation.
- * @property {Array<string>} notUpdatedUrls List of URLs that were already up to
+ * @property {Array<string>} notUpdatedURLs List of URLs that were already up to
  * date.
  *
  * @memberof workbox.precaching

--- a/packages/workbox-precaching/controllers/PrecacheController.mjs
+++ b/packages/workbox-precaching/controllers/PrecacheController.mjs
@@ -94,11 +94,11 @@ class PrecacheController {
 
     const cache = await caches.open(this._cacheName);
     const alreadyCachedRequests = await cache.keys();
-    const alreadyCachedUrls = new Set(alreadyCachedRequests.map(
+    const alreadyCachedURLs = new Set(alreadyCachedRequests.map(
         (request) => request.url));
 
     for (const cacheKey of this._urlsToCacheKeys.values()) {
-      if (alreadyCachedUrls.has(cacheKey)) {
+      if (alreadyCachedURLs.has(cacheKey)) {
         urlsAlreadyPrecached.push(cacheKey);
       } else {
         urlsToPrecache.push(cacheKey);
@@ -106,7 +106,7 @@ class PrecacheController {
     }
 
     const precacheRequests = urlsToPrecache.map((url) => {
-      return this._addUrlToCache({event, plugins, url});
+      return this._addURLToCache({event, plugins, url});
     });
     await Promise.all(precacheRequests);
 
@@ -115,8 +115,8 @@ class PrecacheController {
     }
 
     return {
-      updatedUrls: urlsToPrecache,
-      notUpdatedUrls: urlsAlreadyPrecached,
+      updatedURLs: urlsToPrecache,
+      notUpdatedURLs: urlsAlreadyPrecached,
     };
   }
 
@@ -131,19 +131,19 @@ class PrecacheController {
     const currentlyCachedRequests = await cache.keys();
     const expectedCacheKeys = new Set(this._urlsToCacheKeys.values());
 
-    const deletedUrls = [];
+    const deletedURLs = [];
     for (const request of currentlyCachedRequests) {
       if (!expectedCacheKeys.has(request.url)) {
         await cache.delete(request);
-        deletedUrls.push(request.url);
+        deletedURLs.push(request.url);
       }
     }
 
     if (process.env.NODE_ENV !== 'production') {
-      printCleanupDetails(deletedUrls);
+      printCleanupDetails(deletedURLs);
     }
 
-    return {deletedUrls};
+    return {deletedURLs};
   }
 
   /**
@@ -162,7 +162,7 @@ class PrecacheController {
    * @param {Array<Object>} [options.plugins] An array of plugins to apply to
    * fetch and caching.
    */
-  async _addUrlToCache({url, event, plugins}) {
+  async _addURLToCache({url, event, plugins}) {
     const request = new Request(url, {credentials: 'same-origin'});
     let response = await fetchWrapper.fetch({
       event,
@@ -215,7 +215,7 @@ class PrecacheController {
    *
    * @return {Map<string, string>} A URL to cache key mapping.
    */
-  getUrlsToCacheKeys() {
+  getURLsToCacheKeys() {
     return this._urlsToCacheKeys;
   }
 
@@ -225,7 +225,7 @@ class PrecacheController {
    *
    * @return {Array<string>} The precached URLs.
    */
-  getCachedUrls() {
+  getCachedURLs() {
     return [...this._urlsToCacheKeys.keys()];
   }
 
@@ -238,7 +238,7 @@ class PrecacheController {
    * @return {string} The versioned URL that corresponds to a cache key
    * for the original URL, or undefined if that URL isn't precached.
    */
-  getCacheKeyForUrl(url) {
+  getCacheKeyForURL(url) {
     const urlObject = new URL(url, location);
     return this._urlsToCacheKeys.get(urlObject.href);
   }

--- a/packages/workbox-precaching/utils/createCacheKey.mjs
+++ b/packages/workbox-precaching/utils/createCacheKey.mjs
@@ -54,11 +54,11 @@ export function createCacheKey(entry) {
 
   // Otherwise, construct a properly versioned URL using the custom Workbox
   // search parameter along with the revision info.
-  const originalUrl = new URL(url, location);
-  const cacheKeyUrl = new URL(url, location);
-  cacheKeyUrl.searchParams.set(REVISION_SEARCH_PARAM, revision);
+  const originalURL = new URL(url, location);
+  const cacheKeyURL = new URL(url, location);
+  cacheKeyURL.searchParams.set(REVISION_SEARCH_PARAM, revision);
   return {
-    cacheKey: cacheKeyUrl.href,
-    url: originalUrl.href,
+    cacheKey: cacheKeyURL.href,
+    url: originalURL.href,
   };
 }

--- a/packages/workbox-precaching/utils/generateUrlVariations.mjs
+++ b/packages/workbox-precaching/utils/generateUrlVariations.mjs
@@ -20,10 +20,10 @@ import '../_version.mjs';
  * @private
  * @memberof module:workbox-precaching
  */
-export function* generateUrlVariations(url, {
-  ignoreUrlParametersMatching,
+export function* generateURLVariations(url, {
+  ignoreURLParametersMatching,
   directoryIndex,
-  cleanUrls,
+  cleanURLs,
   urlManipulation,
 } = {}) {
   const urlObject = new URL(url, location);
@@ -31,24 +31,24 @@ export function* generateUrlVariations(url, {
   yield urlObject.href;
 
   const urlWithoutIgnoredParams = removeIgnoredSearchParams(
-      urlObject, ignoreUrlParametersMatching);
+      urlObject, ignoreURLParametersMatching);
   yield urlWithoutIgnoredParams.href;
 
   if (directoryIndex && urlWithoutIgnoredParams.pathname.endsWith('/')) {
-    const directoryUrl = new URL(urlWithoutIgnoredParams);
-    directoryUrl.pathname += directoryIndex;
-    yield directoryUrl.href;
+    const directoryURL = new URL(urlWithoutIgnoredParams);
+    directoryURL.pathname += directoryIndex;
+    yield directoryURL.href;
   }
 
-  if (cleanUrls) {
-    const cleanUrl = new URL(urlWithoutIgnoredParams);
-    cleanUrl.pathname += '.html';
-    yield cleanUrl.href;
+  if (cleanURLs) {
+    const cleanURL = new URL(urlWithoutIgnoredParams);
+    cleanURL.pathname += '.html';
+    yield cleanURL.href;
   }
 
   if (urlManipulation) {
-    const additionalUrls = urlManipulation({url: urlObject});
-    for (const urlToAttempt of additionalUrls) {
+    const additionalURLs = urlManipulation({url: urlObject});
+    for (const urlToAttempt of additionalURLs) {
       yield urlToAttempt.href;
     }
   }

--- a/packages/workbox-precaching/utils/printCleanupDetails.mjs
+++ b/packages/workbox-precaching/utils/printCleanupDetails.mjs
@@ -10,10 +10,10 @@ import {logger} from 'workbox-core/_private/logger.mjs';
 
 import '../_version.mjs';
 
-const logGroup = (groupTitle, deletedUrls) => {
+const logGroup = (groupTitle, deletedURLs) => {
   logger.groupCollapsed(groupTitle);
 
-  for (const url of deletedUrls) {
+  for (const url of deletedURLs) {
     logger.log(url);
   }
 
@@ -21,18 +21,18 @@ const logGroup = (groupTitle, deletedUrls) => {
 };
 
 /**
- * @param {Array<string>} deletedUrls
+ * @param {Array<string>} deletedURLs
  *
  * @private
  * @memberof module:workbox-precaching
  */
-export function printCleanupDetails(deletedUrls) {
-  const deletionCount = deletedUrls.length;
+export function printCleanupDetails(deletedURLs) {
+  const deletionCount = deletedURLs.length;
   if (deletionCount > 0) {
     logger.groupCollapsed(`During precaching cleanup, ` +
         `${deletionCount} cached ` +
         `request${deletionCount === 1 ? ' was' : 's were'} deleted.`);
-    logGroup('Deleted Cache Requests', deletedUrls);
+    logGroup('Deleted Cache Requests', deletedURLs);
     logger.groupEnd();
   }
 }

--- a/packages/workbox-precaching/utils/removeIgnoredSearchParams.mjs
+++ b/packages/workbox-precaching/utils/removeIgnoredSearchParams.mjs
@@ -12,7 +12,7 @@ import '../_version.mjs';
  * Removes any URL search parameters that should be ignored.
  *
  * @param {URL} urlObject The original URL.
- * @param {Array<RegExp>} ignoreUrlParametersMatching RegExps to test against
+ * @param {Array<RegExp>} ignoreURLParametersMatching RegExps to test against
  * each search parameter name. Matches mean that the search parameter should be
  * ignored.
  * @return {URL} The URL with any ignored search parameters removed.
@@ -21,11 +21,11 @@ import '../_version.mjs';
  * @memberof module:workbox-precaching
  */
 export function removeIgnoredSearchParams(urlObject,
-    ignoreUrlParametersMatching) {
+    ignoreURLParametersMatching) {
   // Convert the iterable into an array at the start of the loop to make sure
   // deletion doesn't mess up iteration.
   for (const paramName of [...urlObject.searchParams.keys()]) {
-    if (ignoreUrlParametersMatching.some((regExp) => regExp.test(paramName))) {
+    if (ignoreURLParametersMatching.some((regExp) => regExp.test(paramName))) {
       urlObject.searchParams.delete(paramName);
     }
   }

--- a/packages/workbox-routing/DefaultRouter.mjs
+++ b/packages/workbox-routing/DefaultRouter.mjs
@@ -60,7 +60,7 @@ class DefaultRouter extends Router {
     let route;
 
     if (typeof capture === 'string') {
-      const captureUrl = new URL(capture, location);
+      const captureURL = new URL(capture, location);
 
       if (process.env.NODE_ENV !== 'production') {
         if (!(capture.startsWith('/') || capture.startsWith('http'))) {
@@ -75,7 +75,7 @@ class DefaultRouter extends Router {
         // We want to check if Express-style wildcards are in the pathname only.
         // TODO: Remove this log message in v4.
         const valueToCheck = capture.startsWith('http') ?
-          captureUrl.pathname :
+          captureURL.pathname :
           capture;
         // See https://github.com/pillarjs/path-to-regexp#parameters
         const wildcards = '[*:?+]';
@@ -90,8 +90,8 @@ class DefaultRouter extends Router {
 
       const matchCallback = ({url}) => {
         if (process.env.NODE_ENV !== 'production') {
-          if ((url.pathname === captureUrl.pathname) &&
-              (url.origin !== captureUrl.origin)) {
+          if ((url.pathname === captureURL.pathname) &&
+              (url.origin !== captureURL.origin)) {
             logger.debug(
                 `${capture} only partially matches the cross-origin URL ` +
               `${url}. This route will only handle cross-origin requests ` +
@@ -100,7 +100,7 @@ class DefaultRouter extends Router {
           }
         }
 
-        return url.href === captureUrl.href;
+        return url.href === captureURL.href;
       };
 
       route = new Route(matchCallback, handler, method);
@@ -134,7 +134,7 @@ class DefaultRouter extends Router {
    * [Router.registerRoute()]{@link workbox.routing.Router#registerRoute}
    * .
    *
-   * @param {string} cachedAssetUrl
+   * @param {string} cachedAssetURL
    * @param {Object} [options]
    * @param {string} [options.cacheName] Cache name to store and retrieve
    * requests. Defaults to precache cache name provided by
@@ -150,18 +150,18 @@ class DefaultRouter extends Router {
    *
    * @alias workbox.routing.registerNavigationRoute
    */
-  registerNavigationRoute(cachedAssetUrl, options = {}) {
+  registerNavigationRoute(cachedAssetURL, options = {}) {
     if (process.env.NODE_ENV !== 'production') {
-      assert.isType(cachedAssetUrl, 'string', {
+      assert.isType(cachedAssetURL, 'string', {
         moduleName: 'workbox-routing',
         className: '[default export]',
         funcName: 'registerNavigationRoute',
-        paramName: 'cachedAssetUrl',
+        paramName: 'cachedAssetURL',
       });
     }
 
     const cacheName = cacheNames.getPrecacheName(options.cacheName);
-    const handler = () => caches.match(cachedAssetUrl, {cacheName})
+    const handler = () => caches.match(cachedAssetURL, {cacheName})
         .then((response) => {
           if (response) {
             return response;
@@ -169,7 +169,7 @@ class DefaultRouter extends Router {
           // This shouldn't normally happen, but there are edge cases:
           // https://github.com/GoogleChrome/workbox/issues/1441
           throw new Error(`The cache ${cacheName} did not have an entry for ` +
-          `${cachedAssetUrl}.`);
+          `${cachedAssetURL}.`);
         }).catch((error) => {
         // If there's either a cache miss, or the caches.match() call threw
         // an exception, then attempt to fulfill the navigation request with
@@ -181,7 +181,7 @@ class DefaultRouter extends Router {
           }
 
           // This might still fail if the browser is offline...
-          return fetch(cachedAssetUrl);
+          return fetch(cachedAssetURL);
         });
 
     const route = new NavigationRoute(handler, {

--- a/packages/workbox-routing/_default.mjs
+++ b/packages/workbox-routing/_default.mjs
@@ -12,7 +12,7 @@ import './_version.mjs';
 
 
 if (process.env.NODE_ENV !== 'production') {
-  assert.isSwEnv('workbox-routing');
+  assert.isSWEnv('workbox-routing');
 }
 
 export default new DefaultRouter();

--- a/test/workbox-background-sync/integration/test-bg-sync.js
+++ b/test/workbox-background-sync/integration/test-bg-sync.js
@@ -13,8 +13,8 @@ const waitUntil = require('../../../infra/testing/wait-until');
 
 describe(`[workbox-background-sync] Load and use Background Sync`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
-  const testingUrl = `${testServerAddress}/test/workbox-background-sync/static/basic-example/`;
-  const swUrl = `${testingUrl}sw.js`;
+  const testingURL = `${testServerAddress}/test/workbox-background-sync/static/basic-example/`;
+  const swURL = `${testingURL}sw.js`;
 
   let requestCounter;
   beforeEach(function() {
@@ -26,8 +26,8 @@ describe(`[workbox-background-sync] Load and use Background Sync`, function() {
 
   it(`should load a page with service worker`, async function() {
     // Load the page and wait for the first service worker to register and activate.
-    await global.__workbox.webdriver.get(testingUrl);
-    await activateAndControlSW(swUrl);
+    await global.__workbox.webdriver.get(testingURL);
+    await activateAndControlSW(swURL);
 
     const url = `/test/workbox-background-sync/static/basic-example/example.txt`;
     const err = await global.__workbox.webdriver.executeAsyncScript((url, cb) => {
@@ -37,7 +37,7 @@ describe(`[workbox-background-sync] Load and use Background Sync`, function() {
     expect(err).to.not.exist;
 
     await waitUntil(() => {
-      const count = requestCounter.getUrlCount(url);
+      const count = requestCounter.getURLCount(url);
       return count > 0;
     }, 20, 500);
   });

--- a/test/workbox-background-sync/node/test-Queue.mjs
+++ b/test/workbox-background-sync/node/test-Queue.mjs
@@ -123,14 +123,14 @@ describe(`[workbox-background-sync] Queue`, function() {
       sandbox.spy(QueueStore.prototype, 'pushEntry');
 
       const queue = new Queue('a');
-      const requestUrl = 'https://example.com';
+      const requestURL = 'https://example.com';
       const requestInit = {
         method: 'POST',
         body: 'testing...',
         headers: {'x-foo': 'bar'},
         mode: 'cors',
       };
-      const request = new Request(requestUrl, requestInit);
+      const request = new Request(requestURL, requestInit);
       const timestamp = 1234;
       const metadata = {meta: 'data'};
 
@@ -139,7 +139,7 @@ describe(`[workbox-background-sync] Queue`, function() {
       expect(QueueStore.prototype.pushEntry.callCount).to.equal(1);
 
       const args = QueueStore.prototype.pushEntry.firstCall.args;
-      expect(args[0].requestData.url).to.equal(requestUrl);
+      expect(args[0].requestData.url).to.equal(requestURL);
       expect(args[0].requestData.method).to.equal(requestInit.method);
       expect(args[0].requestData.headers).to.deep.equal(requestInit.headers);
       expect(args[0].requestData.mode).to.deep.equal(requestInit.mode);
@@ -201,14 +201,14 @@ describe(`[workbox-background-sync] Queue`, function() {
       sandbox.spy(QueueStore.prototype, 'unshiftEntry');
 
       const queue = new Queue('a');
-      const requestUrl = 'https://example.com';
+      const requestURL = 'https://example.com';
       const requestInit = {
         method: 'POST',
         body: 'testing...',
         headers: {'x-foo': 'bar'},
         mode: 'cors',
       };
-      const request = new Request(requestUrl, requestInit);
+      const request = new Request(requestURL, requestInit);
       const timestamp = 1234;
       const metadata = {meta: 'data'};
 
@@ -217,7 +217,7 @@ describe(`[workbox-background-sync] Queue`, function() {
       expect(QueueStore.prototype.unshiftEntry.callCount).to.equal(1);
 
       const args = QueueStore.prototype.unshiftEntry.firstCall.args;
-      expect(args[0].requestData.url).to.equal(requestUrl);
+      expect(args[0].requestData.url).to.equal(requestURL);
       expect(args[0].requestData.method).to.equal(requestInit.method);
       expect(args[0].requestData.headers).to.deep.equal(requestInit.headers);
       expect(args[0].requestData.mode).to.deep.equal(requestInit.mode);
@@ -277,7 +277,7 @@ describe(`[workbox-background-sync] Queue`, function() {
       sandbox.spy(QueueStore.prototype, 'shiftEntry');
 
       const queue = new Queue('a');
-      const requestUrl = 'https://example.com';
+      const requestURL = 'https://example.com';
       const requestInit = {
         method: 'POST',
         body: 'testing...',
@@ -285,14 +285,14 @@ describe(`[workbox-background-sync] Queue`, function() {
         mode: 'cors',
       };
 
-      await queue.pushRequest({request: new Request(requestUrl, requestInit)});
+      await queue.pushRequest({request: new Request(requestURL, requestInit)});
       // Add a second request to ensure the first one is returned.
       await queue.pushRequest({request: new Request('/two')});
 
       const {request} = await queue.shiftRequest();
 
       expect(QueueStore.prototype.shiftEntry.callCount).to.equal(1);
-      expect(request.url).to.equal(requestUrl);
+      expect(request.url).to.equal(requestURL);
       expect(request.method).to.equal(requestInit.method);
       expect(request.mode).to.deep.equal(requestInit.mode);
       expect(await request.text()).to.equal(requestInit.body);
@@ -337,7 +337,7 @@ describe(`[workbox-background-sync] Queue`, function() {
       sandbox.spy(QueueStore.prototype, 'popEntry');
 
       const queue = new Queue('a');
-      const requestUrl = 'https://example.com';
+      const requestURL = 'https://example.com';
       const requestInit = {
         method: 'POST',
         body: 'testing...',
@@ -347,12 +347,12 @@ describe(`[workbox-background-sync] Queue`, function() {
 
       // Add a second request to ensure the last one is returned.
       await queue.pushRequest({request: new Request('/two')});
-      await queue.pushRequest({request: new Request(requestUrl, requestInit)});
+      await queue.pushRequest({request: new Request(requestURL, requestInit)});
 
       const {request} = await queue.popRequest();
 
       expect(QueueStore.prototype.popEntry.callCount).to.equal(1);
-      expect(request.url).to.equal(requestUrl);
+      expect(request.url).to.equal(requestURL);
       expect(request.method).to.equal(requestInit.method);
       expect(request.mode).to.deep.equal(requestInit.mode);
       expect(await request.text()).to.equal(requestInit.body);

--- a/test/workbox-broadcast-cache-update/integration/broadcast-cache-update-plugin.js
+++ b/test/workbox-broadcast-cache-update/integration/broadcast-cache-update-plugin.js
@@ -12,13 +12,13 @@ const activateAndControlSW = require('../../../infra/testing/activate-and-contro
 
 describe(`broadcastCacheUpdate.Plugin`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
-  const testingUrl = `${testServerAddress}/test/workbox-broadcast-cache-update/static/`;
-  const swUrl = `${testingUrl}sw.js`;
-  const apiUrl = `${testServerAddress}/__WORKBOX/uniqueETag`;
+  const testingURL = `${testServerAddress}/test/workbox-broadcast-cache-update/static/`;
+  const swURL = `${testingURL}sw.js`;
+  const apiURL = `${testServerAddress}/__WORKBOX/uniqueETag`;
 
   it(`should broadcast a message on the expected channel when there's a cache update`, async function() {
-    await global.__workbox.webdriver.get(testingUrl);
-    await activateAndControlSW(swUrl);
+    await global.__workbox.webdriver.get(testingURL);
+    await activateAndControlSW(swURL);
 
     const supported = await global.__workbox.webdriver.executeScript(() => {
       return 'BroadcastChannel' in window;
@@ -29,13 +29,13 @@ describe(`broadcastCacheUpdate.Plugin`, function() {
       return;
     }
 
-    const err = await global.__workbox.webdriver.executeAsyncScript((apiUrl, cb) => {
-      // There's already a cached entry for apiUrl created by the
+    const err = await global.__workbox.webdriver.executeAsyncScript((apiURL, cb) => {
+      // There's already a cached entry for apiURL created by the
       // service worker's install handler.
-      fetch(apiUrl)
+      fetch(apiURL)
           .then(() => cb())
           .catch((err) => cb(err.message));
-    }, apiUrl);
+    }, apiURL);
 
     expect(err).to.not.exist;
 
@@ -53,7 +53,7 @@ describe(`broadcastCacheUpdate.Plugin`, function() {
       meta: 'workbox-broadcast-cache-update',
       payload: {
         cacheName: 'bcu-integration-test',
-        updatedUrl: apiUrl,
+        updatedURL: apiURL,
       },
       type: 'CACHE_UPDATED',
     });

--- a/test/workbox-broadcast-cache-update/node/test-BroadcastCacheUpdate.mjs
+++ b/test/workbox-broadcast-cache-update/node/test-BroadcastCacheUpdate.mjs
@@ -122,7 +122,7 @@ describe(`[workbox-broadcast-cache-udpate] BroadcastCacheUpdate`, function() {
         type: CACHE_UPDATED_MESSAGE_TYPE,
         meta: CACHE_UPDATED_MESSAGE_META,
         payload: {
-          updatedUrl: '/',
+          updatedURL: '/',
           cacheName: 'cache-name',
         },
       });
@@ -174,7 +174,7 @@ describe(`[workbox-broadcast-cache-udpate] BroadcastCacheUpdate`, function() {
         type: CACHE_UPDATED_MESSAGE_TYPE,
         meta: CACHE_UPDATED_MESSAGE_META,
         payload: {
-          updatedUrl: '/',
+          updatedURL: '/',
           cacheName: 'cache-name',
         },
       };

--- a/test/workbox-broadcast-cache-update/node/test-broadcastUpdate.mjs
+++ b/test/workbox-broadcast-cache-update/node/test-broadcastUpdate.mjs
@@ -30,7 +30,7 @@ describe(`[workbox-broadcast-cache-update] broadcastUpdate`, function() {
       meta: CACHE_UPDATED_MESSAGE_META,
       payload: {
         cacheName,
-        updatedUrl: url,
+        updatedURL: url,
       },
     });
   });

--- a/test/workbox-cache-expiration/integration/expiration-plugin.js
+++ b/test/workbox-cache-expiration/integration/expiration-plugin.js
@@ -14,18 +14,18 @@ const runInSW = require('../../../infra/testing/comlink/node-interface');
 const waitUntil = require('../../../infra/testing/wait-until');
 
 describe(`expiration.Plugin`, function() {
-  const baseUrl = `${global.__workbox.server.getAddress()}/test/workbox-cache-expiration/static/expiration-plugin/`;
+  const baseURL = `${global.__workbox.server.getAddress()}/test/workbox-cache-expiration/static/expiration-plugin/`;
 
   beforeEach(async function() {
     // Navigate to our test page and clear all caches before this test runs.
-    await cleanSWEnv(global.__workbox.webdriver, `${baseUrl}integration.html`);
+    await cleanSWEnv(global.__workbox.webdriver, `${baseURL}integration.html`);
   });
 
   it(`should load a page with entries managed by maxEntries`, async function() {
-    const swUrl = `${baseUrl}sw-max-entries.js`;
+    const swURL = `${baseURL}sw-max-entries.js`;
 
     // Wait for the service worker to register and activate.
-    await activateAndControlSW(swUrl);
+    await activateAndControlSW(swURL);
 
     let error = await global.__workbox.webdriver.executeAsyncScript((cb) => {
       fetch(`example-1.txt`).then(() => cb()).catch((err) => cb(err.message));
@@ -46,9 +46,9 @@ describe(`expiration.Plugin`, function() {
       'expiration-plugin-max-entries',
     ]);
 
-    let cachedRequests = await runInSW('cacheUrls', keys[0]);
+    let cachedRequests = await runInSW('cacheURLs', keys[0]);
     expect(cachedRequests).to.eql([
-      `${baseUrl}example-1.txt`,
+      `${baseURL}example-1.txt`,
     ]);
 
     error = await global.__workbox.webdriver.executeAsyncScript((cb) => {
@@ -61,17 +61,17 @@ describe(`expiration.Plugin`, function() {
     // Caching is done async from returning a response, so we may need
     // to wait before the cache has be cleaned up.
     await waitUntil(async () => {
-      cachedRequests = await runInSW('cacheUrls', keys[0]);
+      cachedRequests = await runInSW('cacheURLs', keys[0]);
       return (cachedRequests.length === 1 &&
-              cachedRequests[0] === `${baseUrl}example-2.txt`);
+              cachedRequests[0] === `${baseURL}example-2.txt`);
     });
   });
 
   it(`should load a page with entries managed by maxAgeSeconds`, async function() {
-    const swUrl = `${baseUrl}sw-max-age-seconds.js`;
+    const swURL = `${baseURL}sw-max-age-seconds.js`;
 
     // Wait for the service worker to register and activate.
-    await activateAndControlSW(swUrl);
+    await activateAndControlSW(swURL);
 
     let error = await global.__workbox.webdriver.executeAsyncScript((cb) => {
       fetch(`example-1.txt`).then(() => cb()).catch((err) => cb(err.message));
@@ -92,9 +92,9 @@ describe(`expiration.Plugin`, function() {
       'expiration-plugin-max-age-seconds',
     ]);
 
-    let cachedRequests = await runInSW('cacheUrls', keys[0]);
+    let cachedRequests = await runInSW('cacheURLs', keys[0]);
     expect(cachedRequests).to.eql([
-      `${baseUrl}example-1.txt`,
+      `${baseURL}example-1.txt`,
     ]);
 
     // Wait 2 seconds to expire entry.
@@ -112,17 +112,17 @@ describe(`expiration.Plugin`, function() {
     // Caching is done async from returning a response, so we may need
     // to wait before the cache has be cleaned up.
     await waitUntil(async () => {
-      cachedRequests = await runInSW('cacheUrls', keys[0]);
+      cachedRequests = await runInSW('cacheURLs', keys[0]);
       return (cachedRequests.length === 1 &&
-              cachedRequests[0] === `${baseUrl}example-2.txt`);
+              cachedRequests[0] === `${baseURL}example-2.txt`);
     });
   });
 
   it(`should clean up when deleteCacheAndMetadata() is called`, async function() {
-    const swUrl = `${baseUrl}sw-deletion.js`;
+    const swURL = `${baseURL}sw-deletion.js`;
 
     // Wait for the service worker to register and activate.
-    await activateAndControlSW(swUrl);
+    await activateAndControlSW(swURL);
 
     let error = await global.__workbox.webdriver.executeAsyncScript((cb) => {
       fetch(`example-1.txt`).then(() => cb()).catch((err) => cb(err.message));

--- a/test/workbox-cache-expiration/node/test-CacheExpiration.mjs
+++ b/test/workbox-cache-expiration/node/test-CacheExpiration.mjs
@@ -71,12 +71,12 @@ describe(`[workbox-cache-expiration] CacheExpiration`, function() {
 
       const expirationManager = new CacheExpiration(cacheName, {maxAgeSeconds});
 
-      let expiredUrls = await expirationManager._findOldEntries(currentTimestamp);
-      expect(expiredUrls).to.deep.equal([]);
+      let expiredURLs = await expirationManager._findOldEntries(currentTimestamp);
+      expect(expiredURLs).to.deep.equal([]);
 
       // The plus one is to ensure it expires
-      expiredUrls = await expirationManager._findOldEntries(currentTimestamp + maxAgeSeconds * 1000 + 1);
-      expect(expiredUrls).to.deep.equal(['https://example.com/']);
+      expiredURLs = await expirationManager._findOldEntries(currentTimestamp + maxAgeSeconds * 1000 + 1);
+      expect(expiredURLs).to.deep.equal(['https://example.com/']);
     });
   });
 
@@ -98,26 +98,26 @@ describe(`[workbox-cache-expiration] CacheExpiration`, function() {
       const expirationManager = new CacheExpiration(cacheName, {maxEntries});
 
       // No entries added, should be empty
-      let extraUrls = await expirationManager._findExtraEntries();
-      expect(extraUrls).to.deep.equal([]);
+      let extraURLs = await expirationManager._findExtraEntries();
+      expect(extraURLs).to.deep.equal([]);
 
       await timestampModel.setTimestamp('/second-earliest', secondEarlistTimestamp);
 
       // Added one entry, max is one, return empty array
-      extraUrls = await expirationManager._findExtraEntries();
-      expect(extraUrls).to.deep.equal([]);
+      extraURLs = await expirationManager._findExtraEntries();
+      expect(extraURLs).to.deep.equal([]);
 
       await timestampModel.setTimestamp('/latest', latestTimestamp);
 
       // Added two entries, max is one, return one entry
-      extraUrls = await expirationManager._findExtraEntries();
-      expect(extraUrls).to.deep.equal(['https://example.com/second-earliest']);
+      extraURLs = await expirationManager._findExtraEntries();
+      expect(extraURLs).to.deep.equal(['https://example.com/second-earliest']);
 
       await timestampModel.setTimestamp('/earliest', earliestTimestamp);
 
       // Added three entries, max is one, return two entries
-      extraUrls = await expirationManager._findExtraEntries();
-      expect(extraUrls).to.deep.equal(['https://example.com/earliest', 'https://example.com/second-earliest']);
+      extraURLs = await expirationManager._findExtraEntries();
+      expect(extraURLs).to.deep.equal(['https://example.com/earliest', 'https://example.com/second-earliest']);
     });
   });
 

--- a/test/workbox-cacheable-response/integration/test-cacheable-response-plugin.js
+++ b/test/workbox-cacheable-response/integration/test-cacheable-response-plugin.js
@@ -14,18 +14,18 @@ const runInSW = require('../../../infra/testing/comlink/node-interface');
 const waitUntil = require('../../../infra/testing/wait-until');
 
 describe(`cacheableResponse.Plugin`, function() {
-  const baseUrl = `${global.__workbox.server.getAddress()}/test/workbox-cacheable-response/static/cacheable-response-plugin/`;
+  const baseURL = `${global.__workbox.server.getAddress()}/test/workbox-cacheable-response/static/cacheable-response-plugin/`;
 
   beforeEach(async function() {
     // Navigate to our test page and clear all caches before this test runs.
-    await cleanSWEnv(global.__workbox.webdriver, `${baseUrl}integration.html`);
+    await cleanSWEnv(global.__workbox.webdriver, `${baseURL}integration.html`);
   });
 
   it(`should load a page and cache entries`, async function() {
-    const swUrl = `${baseUrl}sw.js`;
+    const swURL = `${baseURL}sw.js`;
 
     // Wait for the service worker to register and activate.
-    await activateAndControlSW(swUrl);
+    await activateAndControlSW(swURL);
 
     let error = await global.__workbox.webdriver.executeAsyncScript((cb) => {
       fetch(`example-1.txt`).then(() => cb()).catch((err) => cb(err.message));
@@ -46,9 +46,9 @@ describe(`cacheableResponse.Plugin`, function() {
       'cacheable-response-cache',
     ]);
 
-    let cachedRequests = await runInSW('cacheUrls', keys[0]);
+    let cachedRequests = await runInSW('cacheURLs', keys[0]);
     expect(cachedRequests).to.eql([
-      `${baseUrl}example-1.txt`,
+      `${baseURL}example-1.txt`,
     ]);
   });
 });

--- a/test/workbox-core/integration/test-core.js
+++ b/test/workbox-core/integration/test-core.js
@@ -10,12 +10,12 @@ const activateAndControlSW = require('../../../infra/testing/activate-and-contro
 
 describe(`[workbox-core] Load core in the browser`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
-  const testingUrl = `${testServerAddress}/test/workbox-core/static/core-in-browser/`;
-  const swUrl = `${testingUrl}sw.js`;
+  const testingURL = `${testServerAddress}/test/workbox-core/static/core-in-browser/`;
+  const swURL = `${testingURL}sw.js`;
 
   it(`should load workbox-core in a service worker.`, async function() {
-    await global.__workbox.webdriver.get(testingUrl);
-    await activateAndControlSW(swUrl);
+    await global.__workbox.webdriver.get(testingURL);
+    await activateAndControlSW(swURL);
 
     // If the service worker activated, it meant the assertions in sw.js were
     // met and workbox-core exposes the expected API and defaults that were

--- a/test/workbox-core/node/_private/test-assert.mjs
+++ b/test/workbox-core/node/_private/test-assert.mjs
@@ -19,7 +19,7 @@ describe(`workbox-core  assert`, function() {
     });
   });
 
-  describe(`isSwEnv`, function() {
+  describe(`isSWEnv`, function() {
     let sandbox;
     before(function() {
       sandbox = sinon.createSandbox();
@@ -33,7 +33,7 @@ describe(`workbox-core  assert`, function() {
       const originalServiceWorkerGlobalScope = global.ServiceWorkerGlobalScope;
       delete global.ServiceWorkerGlobalScope;
 
-      await expectError(() => assert.isSwEnv('example-module'), 'not-in-sw');
+      await expectError(() => assert.isSWEnv('example-module'), 'not-in-sw');
 
       global.ServiceWorkerGlobalScope = originalServiceWorkerGlobalScope;
     });
@@ -41,12 +41,12 @@ describe(`workbox-core  assert`, function() {
     devOnly.it(`should return false if self is not an instance of ServiceWorkerGlobalScope`, function() {
       sandbox.stub(global, 'self').value({});
 
-      return expectError(() => assert.isSwEnv('example-module'), 'not-in-sw');
+      return expectError(() => assert.isSWEnv('example-module'), 'not-in-sw');
     });
 
     devOnly.it(`should not throw is self is an instance of ServiceWorkerGlobalScope`, function() {
       sandbox.stub(global, 'self').value(new ServiceWorkerGlobalScope());
-      assert.isSwEnv('example-module');
+      assert.isSWEnv('example-module');
     });
   });
 

--- a/test/workbox-core/node/_private/test-getFriendlyURL.mjs
+++ b/test/workbox-core/node/_private/test-getFriendlyURL.mjs
@@ -16,8 +16,8 @@ describe(`[workbox-core] getFriendlyURL()`, function() {
   });
 
   it(`should return short URL for local origin '<local origin>/hi'`, function() {
-    const fullUrl = new URL('/hi', self.location).toString();
-    const url = getFriendlyURL(fullUrl);
+    const fullURL = new URL('/hi', self.location).toString();
+    const url = getFriendlyURL(fullURL);
     expect(url).to.equal('/hi');
   });
 

--- a/test/workbox-google-analytics/integration/basic-example.js
+++ b/test/workbox-google-analytics/integration/basic-example.js
@@ -14,8 +14,8 @@ const activateAndControlSW = require('../../../infra/testing/activate-and-contro
 describe(`[workbox-google-analytics] Load and use Google Analytics`, function() {
   const driver = global.__workbox.webdriver;
   const testServerAddress = global.__workbox.server.getAddress();
-  const testingUrl = `${testServerAddress}/test/workbox-google-analytics/static/basic-example/`;
-  const swUrl = `${testingUrl}sw.js`;
+  const testingURL = `${testServerAddress}/test/workbox-google-analytics/static/basic-example/`;
+  const swURL = `${testingURL}sw.js`;
 
   /**
    * Sends a mesage to the service worker via postMessage and invokes the
@@ -26,7 +26,7 @@ describe(`[workbox-google-analytics] Load and use Google Analytics`, function() 
    * @param {Function} done The callback automatically passed via webdriver's
    *     `executeAsyncScript()` method.
    */
-  const messageSw = (data, done) => {
+  const messageSW = (data, done) => {
     let messageChannel = new MessageChannel();
     messageChannel.port1.onmessage = (evt) => done(evt.data);
     navigator.serviceWorker.controller.postMessage(
@@ -35,14 +35,14 @@ describe(`[workbox-google-analytics] Load and use Google Analytics`, function() 
 
   before(async function() {
     // Load the page and wait for the first service worker to activate.
-    await driver.get(testingUrl);
+    await driver.get(testingURL);
 
-    await activateAndControlSW(swUrl);
+    await activateAndControlSW(swURL);
   });
 
   beforeEach(async function() {
     // Reset the spied requests array.
-    await driver.executeAsyncScript(messageSw, {
+    await driver.executeAsyncScript(messageSW, {
       action: 'clear-spied-requests',
     });
   });
@@ -75,13 +75,13 @@ describe(`[workbox-google-analytics] Load and use Google Analytics`, function() 
       });
     });
 
-    let requests = await driver.executeAsyncScript(messageSw, {
+    let requests = await driver.executeAsyncScript(messageSW, {
       action: 'get-spied-requests',
     });
     expect(requests).to.have.lengthOf(1);
 
     // Reset the spied requests array.
-    await driver.executeAsyncScript(messageSw, {
+    await driver.executeAsyncScript(messageSW, {
       action: 'clear-spied-requests',
     });
 
@@ -107,19 +107,19 @@ describe(`[workbox-google-analytics] Load and use Google Analytics`, function() 
 
     // Get all spied requests and ensure there haven't been any (since we're
     // offline).
-    requests = await driver.executeAsyncScript(messageSw, {
+    requests = await driver.executeAsyncScript(messageSW, {
       action: 'get-spied-requests',
     });
     expect(requests).to.have.lengthOf(0);
 
     // Uncheck the "simulate offline" checkbox and then trigger a sync.
     await simulateOfflineEl.click();
-    await driver.executeAsyncScript(messageSw, {
+    await driver.executeAsyncScript(messageSW, {
       action: 'dispatch-sync-event',
     });
 
     // Ensure only 2 requests have replayed, since only 2 of them were to GA.
-    requests = await driver.executeAsyncScript(messageSw, {
+    requests = await driver.executeAsyncScript(messageSW, {
       action: 'get-spied-requests',
     });
     expect(requests).to.have.lengthOf(2);

--- a/test/workbox-google-analytics/static/basic-example/index.html
+++ b/test/workbox-google-analytics/static/basic-example/index.html
@@ -26,7 +26,7 @@
       gtag('js', new Date());
       gtag('config', 'UA-12345-1', {send_page_view: false});
 
-      const messageSw = (data) => {
+      const messageSW = (data) => {
         return new Promise((resolve) => {
           var messageChannel = new MessageChannel();
           messageChannel.port1.onmessage = (evt) => resolve(evt.data);
@@ -52,22 +52,22 @@
       };
 
       document.getElementById('dispatch-sync-event').onclick = () => {
-        messageSw({action: 'dispatch-sync-event'});
+        messageSW({action: 'dispatch-sync-event'});
       }
 
       document.getElementById('simulate-offline').onclick = (evt) => {
-        messageSw({
+        messageSW({
           action: 'simulate-offline',
           value: evt.target.checked,
         });
       }
 
       document.getElementById('clear-spied-requests').onclick = (evt) => {
-        messageSw({action: 'clear-spied-requests'});
+        messageSW({action: 'clear-spied-requests'});
       }
 
       document.getElementById('log-spied-requests').onclick = async (evt) => {
-        const requests = await messageSw({action: 'get-spied-requests'});
+        const requests = await messageSW({action: 'get-spied-requests'});
         console.log(requests);
       };
     </script>

--- a/test/workbox-navigation-preload/integration/disable.js
+++ b/test/workbox-navigation-preload/integration/disable.js
@@ -14,14 +14,14 @@ const runInSW = require('../../../infra/testing/comlink/node-interface');
 
 describe(`navigationPreload.disable`, function() {
   const staticPath = `/test/workbox-navigation-preload/static/`;
-  const baseUrl = global.__workbox.server.getAddress() + staticPath;
-  const integrationUrl = `${baseUrl}integration.html`;
-  const integrationUrlPath = `${staticPath}integration.html`;
+  const baseURL = global.__workbox.server.getAddress() + staticPath;
+  const integrationURL = `${baseURL}integration.html`;
+  const integrationURLPath = `${staticPath}integration.html`;
 
   let requestCounter;
   beforeEach(async function() {
     // Navigate to our test page and clear all caches before this test runs.
-    await cleanSWEnv(global.__workbox.webdriver, integrationUrl);
+    await cleanSWEnv(global.__workbox.webdriver, integrationURL);
     requestCounter = global.__workbox.server.startCountingRequests('Service-Worker-Navigation-Preload');
   });
   afterEach(function() {
@@ -29,7 +29,7 @@ describe(`navigationPreload.disable`, function() {
   });
 
   it(`should support disabling previously enabled navigation preload`, async function() {
-    await activateAndControlSW(`${baseUrl}sw-default-header.js`);
+    await activateAndControlSW(`${baseURL}sw-default-header.js`);
 
     const isEnabled = await runInSW('isNavigationPreloadSupported');
 
@@ -39,20 +39,20 @@ describe(`navigationPreload.disable`, function() {
       return this.skip();
     }
 
-    expect(requestCounter.getUrlCount(integrationUrlPath)).to.eql(0);
+    expect(requestCounter.getURLCount(integrationURLPath)).to.eql(0);
 
-    await global.__workbox.webdriver.get(integrationUrl);
+    await global.__workbox.webdriver.get(integrationURL);
 
-    expect(requestCounter.getUrlCount(integrationUrlPath)).to.eql(1);
+    expect(requestCounter.getURLCount(integrationURLPath)).to.eql(1);
 
     // Active the new service worker that has navigation preload disabled.
-    await activateAndControlSW(`${baseUrl}sw-disable.js`);
+    await activateAndControlSW(`${baseURL}sw-disable.js`);
 
-    await global.__workbox.webdriver.get(integrationUrl);
+    await global.__workbox.webdriver.get(integrationURL);
 
     // With navigation preload now disabled, the synthetic response from the
     // service worker should fulfill the navigation request, and the server
     // won't get another HTTP request.
-    expect(requestCounter.getUrlCount(integrationUrlPath)).to.eql(1);
+    expect(requestCounter.getURLCount(integrationURLPath)).to.eql(1);
   });
 });

--- a/test/workbox-navigation-preload/integration/enable.js
+++ b/test/workbox-navigation-preload/integration/enable.js
@@ -14,14 +14,14 @@ const runInSW = require('../../../infra/testing/comlink/node-interface');
 
 describe(`navigationPreload.enable`, function() {
   const staticPath = `/test/workbox-navigation-preload/static/`;
-  const baseUrl = global.__workbox.server.getAddress() + staticPath;
-  const integrationUrl = `${baseUrl}integration.html`;
-  const integrationUrlPath = `${staticPath}integration.html`;
+  const baseURL = global.__workbox.server.getAddress() + staticPath;
+  const integrationURL = `${baseURL}integration.html`;
+  const integrationURLPath = `${staticPath}integration.html`;
 
   let requestCounter;
   beforeEach(async function() {
     // Navigate to our test page and clear all caches before this test runs.
-    await cleanSWEnv(global.__workbox.webdriver, integrationUrl);
+    await cleanSWEnv(global.__workbox.webdriver, integrationURL);
     requestCounter = global.__workbox.server.startCountingRequests('Service-Worker-Navigation-Preload');
   });
   afterEach(function() {
@@ -29,17 +29,17 @@ describe(`navigationPreload.enable`, function() {
   });
 
   it(`should make a network request if navigation preload is supported`, async function() {
-    await activateAndControlSW(`${baseUrl}sw-default-header.js`);
+    await activateAndControlSW(`${baseURL}sw-default-header.js`);
 
     const isEnabled = await runInSW('isNavigationPreloadSupported');
 
-    expect(requestCounter.getUrlCount(integrationUrlPath)).to.eql(0);
+    expect(requestCounter.getURLCount(integrationURLPath)).to.eql(0);
 
-    await global.__workbox.webdriver.get(integrationUrl);
+    await global.__workbox.webdriver.get(integrationURL);
 
     // If navigation preload is enabled, there should be 1 request. Otherwise,
     // no requests.
-    expect(requestCounter.getUrlCount(integrationUrlPath)).to.eql(isEnabled ? 1 : 0);
+    expect(requestCounter.getURLCount(integrationURLPath)).to.eql(isEnabled ? 1 : 0);
 
     // Check to make sure that the correct header value was sent if navigation
     // preload is enabled.
@@ -47,17 +47,17 @@ describe(`navigationPreload.enable`, function() {
   });
 
   it(`should make a network request if navigation preload is supported, with a custom header value`, async function() {
-    await activateAndControlSW(`${baseUrl}sw-custom-header.js`);
+    await activateAndControlSW(`${baseURL}sw-custom-header.js`);
 
     const isEnabled = await runInSW('isNavigationPreloadSupported');
 
-    expect(requestCounter.getUrlCount(integrationUrlPath)).to.eql(0);
+    expect(requestCounter.getURLCount(integrationURLPath)).to.eql(0);
 
-    await global.__workbox.webdriver.get(integrationUrl);
+    await global.__workbox.webdriver.get(integrationURL);
 
     // If navigation preload is enabled, there should be 1 request. Otherwise,
     // no requests.
-    expect(requestCounter.getUrlCount(integrationUrlPath)).to.eql(isEnabled ? 1 : 0);
+    expect(requestCounter.getURLCount(integrationURLPath)).to.eql(isEnabled ? 1 : 0);
 
     // Check to make sure that the correct header value was sent if navigation
     // preload is enabled.

--- a/test/workbox-precaching/integration/cleanup-outdated-caches.js
+++ b/test/workbox-precaching/integration/cleanup-outdated-caches.js
@@ -13,11 +13,11 @@ const cleanSWEnv = require('../../../infra/testing/clean-sw');
 const runInSW = require('../../../infra/testing/comlink/node-interface');
 
 describe(`[workbox-precaching] cleanupOutdatedCaches()`, function() {
-  const baseUrl = `${global.__workbox.server.getAddress()}/test/workbox-precaching/static/cleanup-outdated-caches/`;
+  const baseURL = `${global.__workbox.server.getAddress()}/test/workbox-precaching/static/cleanup-outdated-caches/`;
 
   beforeEach(async function() {
     // Navigate to our test page and clear all caches before this test runs.
-    await cleanSWEnv(global.__workbox.webdriver, `${baseUrl}integration.html`);
+    await cleanSWEnv(global.__workbox.webdriver, `${baseURL}integration.html`);
   });
 
   it(`should clean up outdated precached after activation`, async function() {
@@ -35,7 +35,7 @@ describe(`[workbox-precaching] cleanupOutdatedCaches()`, function() {
 
 
     // Register the first service worker.
-    await activateAndControlSW(`${baseUrl}sw.js`);
+    await activateAndControlSW(`${baseURL}sw.js`);
 
     const postActivateKeys = await runInSW('cachesKeys');
     expect(postActivateKeys).to.not.include('workbox-precache-http://localhost:3004/test/workbox-precaching/static/cleanup-outdated-caches/');

--- a/test/workbox-precaching/integration/precache-and-update.js
+++ b/test/workbox-precaching/integration/precache-and-update.js
@@ -13,16 +13,16 @@ const cleanSWEnv = require('../../../infra/testing/clean-sw');
 const runInSW = require('../../../infra/testing/comlink/node-interface');
 
 describe(`[workbox-precaching] Precache and Update`, function() {
-  const baseUrl = `${global.__workbox.server.getAddress()}/test/workbox-precaching/static/precache-and-update/`;
+  const baseURL = `${global.__workbox.server.getAddress()}/test/workbox-precaching/static/precache-and-update/`;
 
   beforeEach(async function() {
     // Navigate to our test page and clear all caches before this test runs.
-    await cleanSWEnv(global.__workbox.webdriver, `${baseUrl}index.html`);
+    await cleanSWEnv(global.__workbox.webdriver, `${baseURL}index.html`);
   });
 
   it(`should load a page with service worker `, async function() {
-    const SW_1_URL = `${baseUrl}sw-1.js`;
-    const SW_2_URL = `${baseUrl}sw-2.js`;
+    const SW_1_URL = `${baseURL}sw-1.js`;
+    const SW_2_URL = `${baseURL}sw-2.js`;
 
     const cacheName = 'workbox-precache-v2-http://localhost:3004/test/workbox-precaching/static/precache-and-update/';
 
@@ -38,25 +38,25 @@ describe(`[workbox-precaching] Precache and Update`, function() {
     ]);
 
     // Check that the cached requests are what we expect for sw-1.js
-    let cachedRequests = await runInSW('cacheUrls', cacheName);
+    let cachedRequests = await runInSW('cacheURLs', cacheName);
     expect(cachedRequests).to.have.members([
       'http://localhost:3004/test/workbox-precaching/static/precache-and-update/index.html?__WB_REVISION__=1',
       'http://localhost:3004/test/workbox-precaching/static/precache-and-update/styles/index.css?__WB_REVISION__=1',
     ]);
 
-    expect(requestCounter.getUrlCount('/test/workbox-precaching/static/precache-and-update/styles/index.css?__WB_REVISION__=1')).to.equal(1);
-    expect(requestCounter.getUrlCount('/test/workbox-precaching/static/precache-and-update/index.html?__WB_REVISION__=1')).to.equal(1);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/styles/index.css?__WB_REVISION__=1')).to.equal(1);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html?__WB_REVISION__=1')).to.equal(1);
 
     // Unregister the old counter, and start a new count.
     global.__workbox.server.stopCountingRequests(requestCounter);
     requestCounter = global.__workbox.server.startCountingRequests();
 
     // Request the page and check that the precached assets weren't requested from the network.
-    await global.__workbox.webdriver.get(`${baseUrl}index.html`);
+    await global.__workbox.webdriver.get(`${baseURL}index.html`);
 
-    expect(requestCounter.getUrlCount('/test/workbox-precaching/static/precache-and-update/')).to.eql(0);
-    expect(requestCounter.getUrlCount('/test/workbox-precaching/static/precache-and-update/index.html')).to.eql(0);
-    expect(requestCounter.getUrlCount('/test/workbox-precaching/static/precache-and-update/styles/index.css')).to.eql(0);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/')).to.eql(0);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html')).to.eql(0);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/styles/index.css')).to.eql(0);
 
     // Unregister the old counter, and start a new count.
     global.__workbox.server.stopCountingRequests(requestCounter);
@@ -67,12 +67,12 @@ describe(`[workbox-precaching] Precache and Update`, function() {
     // Add a slight delay for the caching operation to complete.
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
-    expect(requestCounter.getUrlCount('/test/workbox-precaching/static/precache-and-update/index.html?__WB_REVISION__=2')).to.equal(1);
-    expect(requestCounter.getUrlCount('/test/workbox-precaching/static/precache-and-update/hashed-file.abcd1234.txt')).to.equal(1);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html?__WB_REVISION__=2')).to.equal(1);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/hashed-file.abcd1234.txt')).to.equal(1);
 
     // Check that the cached entries were deleted / added as expected when
     // updating from sw-1.js to sw-2.js
-    cachedRequests = await runInSW('cacheUrls', cacheName);
+    cachedRequests = await runInSW('cacheURLs', cacheName);
     expect(cachedRequests).to.have.members([
       'http://localhost:3004/test/workbox-precaching/static/precache-and-update/index.html?__WB_REVISION__=2',
       'http://localhost:3004/test/workbox-precaching/static/precache-and-update/hashed-file.abcd1234.txt',
@@ -82,12 +82,12 @@ describe(`[workbox-precaching] Precache and Update`, function() {
     global.__workbox.server.stopCountingRequests(requestCounter);
     requestCounter = global.__workbox.server.startCountingRequests();
 
-    await global.__workbox.webdriver.get(baseUrl);
+    await global.__workbox.webdriver.get(baseURL);
 
     // Ensure the HTML page is returned from cache and not network.
-    expect(requestCounter.getUrlCount('/test/workbox-precaching/static/precache-and-update/')).to.eql(0);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/')).to.eql(0);
     // Ensure the now deleted index.css file is returned from network and not cache.
-    expect(requestCounter.getUrlCount('/test/workbox-precaching/static/precache-and-update/styles/index.css')).to.equal(1);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/styles/index.css')).to.equal(1);
 
     global.__workbox.server.stopCountingRequests(requestCounter);
   });

--- a/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/controllers/test-PrecacheController.mjs
@@ -131,12 +131,12 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       it(`should remove duplicate ${groupName}`, async function() {
         const precacheController = new PrecacheController();
 
-        const inputUrls = [
+        const inputURLs = [
           ...inputGroup,
           ...inputGroup,
         ];
 
-        precacheController.addToCacheList(inputUrls);
+        precacheController.addToCacheList(inputURLs);
 
         expect([...precacheController._urlsToCacheKeys.values()]).to.eql([
           'https://example.com/',
@@ -220,8 +220,8 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       logger.log.resetHistory();
 
       const updateInfo = await precacheController.install();
-      expect(updateInfo.updatedUrls.length).to.equal(cacheList.length);
-      expect(updateInfo.notUpdatedUrls.length).to.equal(0);
+      expect(updateInfo.updatedURLs.length).to.equal(cacheList.length);
+      expect(updateInfo.notUpdatedURLs.length).to.equal(0);
 
       const cache = await caches.open(cacheNames.getPrecacheName());
       const keys = await cache.keys();
@@ -324,8 +324,8 @@ describe(`[workbox-precaching] PrecacheController`, function() {
         'https://example.com/scripts/stress.js?test=search&foo=bar&__WB_REVISION__=1234',
       ];
 
-      expect(initialInstallInfo.updatedUrls).to.have.members(initialExpectedCacheKeys);
-      expect(initialInstallInfo.notUpdatedUrls).to.be.empty;
+      expect(initialInstallInfo.updatedURLs).to.have.members(initialExpectedCacheKeys);
+      expect(initialInstallInfo.notUpdatedURLs).to.be.empty;
 
       if (process.env.NODE_ENV != 'production') {
         // Make sure we print some debug info.
@@ -338,7 +338,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       expect(initialCacheKeys.map((r) => r.url)).to.have.members(initialExpectedCacheKeys);
 
       const initialActivateInfo = await initialPrecacheController.activate();
-      expect(initialActivateInfo.deletedUrls).to.be.empty;
+      expect(initialActivateInfo.deletedURLs).to.be.empty;
 
       // Make sure the files are cached after activation.
       for (const key of initialExpectedCacheKeys) {
@@ -361,11 +361,11 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       logger.log.resetHistory();
 
       const updateInstallInfo = await updatePrecacheController.install();
-      expect(updateInstallInfo.updatedUrls).to.have.members([
+      expect(updateInstallInfo.updatedURLs).to.have.members([
         'https://example.com/index.4321.html',
         'https://example.com/scripts/stress.js?test=search&foo=bar&__WB_REVISION__=4321',
       ]);
-      expect(updateInstallInfo.notUpdatedUrls).to.have.members([
+      expect(updateInstallInfo.notUpdatedURLs).to.have.members([
         'https://example.com/example.1234.css',
         'https://example.com/scripts/index.js?__WB_REVISION__=1234',
       ]);
@@ -389,7 +389,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       }
 
       const updateActivateInfo = await updatePrecacheController.activate();
-      expect(updateActivateInfo.deletedUrls).to.have.members([
+      expect(updateActivateInfo.deletedURLs).to.have.members([
         'https://example.com/index.1234.html',
         'https://example.com/scripts/stress.js?test=search&foo=bar&__WB_REVISION__=1234',
       ]);
@@ -531,7 +531,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       await precacheControllerOne.install();
 
       const cleanupDetailsOne = await precacheControllerOne.activate();
-      expect(cleanupDetailsOne.deletedUrls.length).to.equal(0);
+      expect(cleanupDetailsOne.deletedURLs.length).to.equal(0);
 
       const precacheControllerTwo = new PrecacheController();
       const cacheListTwo = [];
@@ -539,8 +539,8 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       await precacheControllerTwo.install();
 
       const cleanupDetailsTwo = await precacheControllerTwo.activate();
-      expect(cleanupDetailsTwo.deletedUrls.length).to.equal(1);
-      expect(cleanupDetailsTwo.deletedUrls[0]).to.eql('https://example.com/scripts/index.js?__WB_REVISION__=1234');
+      expect(cleanupDetailsTwo.deletedURLs.length).to.equal(1);
+      expect(cleanupDetailsTwo.deletedURLs[0]).to.eql('https://example.com/scripts/index.js?__WB_REVISION__=1234');
 
       const keysTwo = await cache.keys();
       expect(keysTwo.length).to.equal(cacheListTwo.length);
@@ -564,7 +564,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       logger.log.resetHistory();
 
       const cleanupDetailsOne = await precacheControllerOne.activate();
-      expect(cleanupDetailsOne.deletedUrls.length).to.equal(0);
+      expect(cleanupDetailsOne.deletedURLs.length).to.equal(0);
 
       // Then, precache the same URLs, but two with different revisions.
       const precacheControllerTwo = new PrecacheController();
@@ -581,7 +581,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       logger.log.resetHistory();
 
       const cleanupDetailsTwo = await precacheControllerTwo.activate();
-      expect(cleanupDetailsTwo.deletedUrls).to.deep.equal([
+      expect(cleanupDetailsTwo.deletedURLs).to.deep.equal([
         'https://example.com/index.1234.html',
         'https://example.com/scripts/stress.js?test=search&foo=bar&__WB_REVISION__=1234',
       ]);
@@ -640,7 +640,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
     });
   });
 
-  describe(`getCachedUrls()`, function() {
+  describe(`getCachedURLs()`, function() {
     it(`should return the cached URLs`, function() {
       const precacheController = new PrecacheController();
       const cacheList = [
@@ -651,7 +651,7 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       ];
       precacheController.addToCacheList(cacheList);
 
-      const urls = precacheController.getCachedUrls();
+      const urls = precacheController.getCachedURLs();
       expect(urls).to.deep.equal([
         new URL('/index.1234.html', location).toString(),
         new URL('/example.1234.css', location).toString(),

--- a/test/workbox-precaching/node/controllers/test-default.mjs
+++ b/test/workbox-precaching/node/controllers/test-default.mjs
@@ -153,7 +153,7 @@ describe(`[workbox-precaching] default export`, function() {
       cache.put(new URL(`/?${SEARCH_1}&${SEARCH_2}`, location).href, cachedResponse);
 
       precaching.addRoute({
-        ignoreUrlParametersMatching: [/ignoreMe/],
+        ignoreURLParametersMatching: [/ignoreMe/],
       });
       precaching.precache([`/?${SEARCH_1}&${SEARCH_2}`]);
 
@@ -189,7 +189,7 @@ describe(`[workbox-precaching] default export`, function() {
       cache.put(new URL(`/?${SEARCH_1}&${SEARCH_2}`, location).href, cachedResponse);
 
       precaching.addRoute({
-        ignoreUrlParametersMatching: [/ignoreMe/],
+        ignoreURLParametersMatching: [/ignoreMe/],
       });
       precaching.precache([`/?${SEARCH_1}&${SEARCH_2}`]);
 
@@ -271,7 +271,7 @@ describe(`[workbox-precaching] default export`, function() {
       expect(response).to.equal(cachedResponse);
     });
 
-    it(`should use the cleanUrls of 'about.html'`, async function() {
+    it(`should use the cleanURLs of 'about.html'`, async function() {
       let fetchCb;
       sandbox.stub(self, 'addEventListener').callsFake((eventName, cb) => {
         if (eventName === 'fetch') {
@@ -302,7 +302,7 @@ describe(`[workbox-precaching] default export`, function() {
       expect(response).to.equal(cachedResponse);
     });
 
-    it(`should *not* use the cleanUrls of 'about.html' if set to false`, async function() {
+    it(`should *not* use the cleanURLs of 'about.html' if set to false`, async function() {
       let fetchCb;
       sandbox.stub(self, 'addEventListener').callsFake((eventName, cb) => {
         if (eventName === 'fetch') {
@@ -317,7 +317,7 @@ describe(`[workbox-precaching] default export`, function() {
       cache.put(new URL(`/${PRECACHED_FILE}`, location).href, cachedResponse);
 
       precaching.addRoute({
-        cleanUrls: false,
+        cleanURLs: false,
       });
       precaching.precache([`/${PRECACHED_FILE}`]);
 
@@ -351,10 +351,10 @@ describe(`[workbox-precaching] default export`, function() {
       precaching.addRoute({
         urlManipulation: ({url}) => {
           expect(url.pathname).to.equal('/');
-          const customUrl = new URL(url);
-          customUrl.pathname = PRECACHED_FILE;
+          const customURL = new URL(url);
+          customURL.pathname = PRECACHED_FILE;
           return [
-            customUrl,
+            customURL,
           ];
         },
       });
@@ -455,7 +455,7 @@ describe(`[workbox-precaching] default export`, function() {
 
       const precacheArgs = ['/'];
       const routeOptions = {
-        ignoreUrlParametersMatching: [/utm_/],
+        ignoreURLParametersMatching: [/utm_/],
         directoryIndex: 'example.html',
       };
       precaching.precacheAndRoute(precacheArgs, routeOptions);
@@ -529,18 +529,18 @@ describe(`[workbox-precaching] default export`, function() {
     });
   });
 
-  describe(`getCacheKeyForUrl()`, function() {
+  describe(`getCacheKeyForURL()`, function() {
     it(`should return the expected cache keys for various URLs`, async function() {
       precaching.precache([
         '/one',
         {url: '/two', revision: '1234'},
       ]);
 
-      expect(precaching.getCacheKeyForUrl('/one'))
+      expect(precaching.getCacheKeyForURL('/one'))
           .to.eql('https://example.com/one');
-      expect(precaching.getCacheKeyForUrl('https://example.com/two'))
+      expect(precaching.getCacheKeyForURL('https://example.com/two'))
           .to.eql('https://example.com/two?__WB_REVISION__=1234');
-      expect(precaching.getCacheKeyForUrl('/not-precached'))
+      expect(precaching.getCacheKeyForURL('/not-precached'))
           .to.not.exist;
     });
   });

--- a/test/workbox-precaching/node/test-environment.mjs
+++ b/test/workbox-precaching/node/test-environment.mjs
@@ -43,7 +43,7 @@ describe(`[workbox-precaching] WorkboxPrecaching`, function() {
     });
 
     devOnly.it(`should not throw when in SW in dev`, async function() {
-      sandbox.stub(assert, 'isSwEnv').callsFake(() => true);
+      sandbox.stub(assert, 'isSWEnv').callsFake(() => true);
 
       await import('../../../packages/workbox-precaching/index.mjs');
     });

--- a/test/workbox-precaching/node/test-precaching-module.mjs
+++ b/test/workbox-precaching/node/test-precaching-module.mjs
@@ -22,7 +22,7 @@ describe(`[workbox-precaching] Module`, function() {
     // Won't be needed after https://github.com/pinterest/service-workers/pull/44
     // is fixed
     if (process.env.NODE_ENV !== 'production') {
-      sandbox.stub(assert, 'isSwEnv').callsFake(() => true);
+      sandbox.stub(assert, 'isSWEnv').callsFake(() => true);
     }
 
     // tmp here is to avoid @std/esm weirdness
@@ -41,7 +41,7 @@ describe(`[workbox-precaching] Module`, function() {
         'addPlugins',
         'addRoute',
         'cleanupOutdatedCaches',
-        'getCacheKeyForUrl',
+        'getCacheKeyForURL',
         'precache',
         'precacheAndRoute',
       ]);

--- a/test/workbox-precaching/static/addToCacheList.html
+++ b/test/workbox-precaching/static/addToCacheList.html
@@ -9,7 +9,7 @@
 <script src="../../../../packages/workbox-core/build/browser/workbox-core.dev.js"></script>
 <script>
   // Make precaching think it's in the SW.
-  workbox.core.default.assert.isSwEnv = () => {}
+  workbox.core.default.assert.isSWEnv = () => {}
 </script>
 <script src="../../../../packages/workbox-precaching/build/browser/workbox-precaching.dev.js"></script>
 <script>

--- a/test/workbox-precaching/static/precache.html
+++ b/test/workbox-precaching/static/precache.html
@@ -16,7 +16,7 @@
 <script src="../../../../packages/workbox-core/build/browser/workbox-core.dev.js"></script>
 <script>
   // Make precaching think it's in the SW.
-  workbox.core.default.assert.isSwEnv = () => {}
+  workbox.core.default.assert.isSWEnv = () => {}
 </script>
 <script src="../../../../packages/workbox-precaching/build/browser/workbox-precaching.dev.js"></script>
 

--- a/test/workbox-range-requests/integration/range-requests-plugin.js
+++ b/test/workbox-range-requests/integration/range-requests-plugin.js
@@ -13,36 +13,36 @@ const cleanSWEnv = require('../../../infra/testing/clean-sw');
 
 describe(`rangeRequests.Plugin`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
-  const testingUrl = `${testServerAddress}/test/workbox-range-requests/static/`;
+  const testingURL = `${testServerAddress}/test/workbox-range-requests/static/`;
 
   beforeEach(async function() {
     // Navigate to our test page and clear all caches before this test runs.
-    await cleanSWEnv(global.__workbox.webdriver, testingUrl);
+    await cleanSWEnv(global.__workbox.webdriver, testingURL);
   });
 
   it(`should return a partial response that satisfies the request's Range: header, and an error response when it can't be satisfied`, async function() {
-    const swUrl = `${testingUrl}sw.js`;
-    await activateAndControlSW(swUrl);
+    const swURL = `${testingURL}sw.js`;
+    await activateAndControlSW(swURL);
 
-    const dummyUrl = `this-file-doesnt-exist.txt`;
+    const dummyURL = `this-file-doesnt-exist.txt`;
 
-    const partialResponseBody = await global.__workbox.webdriver.executeAsyncScript((dummyUrl, cb) => {
+    const partialResponseBody = await global.__workbox.webdriver.executeAsyncScript((dummyURL, cb) => {
       // Prime the cache, and then make the Range: request.
-      fetch(new Request(dummyUrl, {headers: {Range: `bytes=5-6`}}))
+      fetch(new Request(dummyURL, {headers: {Range: `bytes=5-6`}}))
           .then((response) => response.text())
           .then((text) => cb(text))
           .catch((error) => cb(error.message));
-    }, dummyUrl);
+    }, dummyURL);
 
     // The values used for the byte range are inclusive, so we'll end up with
     // 11 characters returned in the partial response.
     expect(partialResponseBody).to.eql('56');
 
-    const errorResponseStatus = await global.__workbox.webdriver.executeAsyncScript((dummyUrl, cb) => {
+    const errorResponseStatus = await global.__workbox.webdriver.executeAsyncScript((dummyURL, cb) => {
       // These are arbitrary large values that extend past the end of the file.
-      fetch(new Request(dummyUrl, {headers: {Range: `bytes=100-101`}}))
+      fetch(new Request(dummyURL, {headers: {Range: `bytes=100-101`}}))
           .then((response) => cb(response.status));
-    }, dummyUrl);
+    }, dummyURL);
 
     // The expected error status is 416 (Range Not Satisfiable)
     expect(errorResponseStatus).to.eql(416);

--- a/test/workbox-routing/integration/navigation-route.js
+++ b/test/workbox-routing/integration/navigation-route.js
@@ -12,22 +12,22 @@ const activateAndControlSW = require('../../../infra/testing/activate-and-contro
 
 describe(`[workbox-routing] Route via NavigationRoute`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
-  const testingUrl = `${testServerAddress}/test/workbox-routing/static/routing-navigation/`;
-  const swUrl = `${testingUrl}sw.js`;
+  const testingURL = `${testServerAddress}/test/workbox-routing/static/routing-navigation/`;
+  const swURL = `${testingURL}sw.js`;
 
   it(`should load a page and route requests`, async function() {
     // Load the page and wait for the first service worker to register and activate.
-    await global.__workbox.webdriver.get(testingUrl);
-    await activateAndControlSW(swUrl);
+    await global.__workbox.webdriver.get(testingURL);
+    await activateAndControlSW(swURL);
 
-    const nestedUrl = `${testingUrl}TestNavigationURL`;
+    const nestedURL = `${testingURL}TestNavigationURL`;
 
-    await global.__workbox.webdriver.get(nestedUrl);
+    await global.__workbox.webdriver.get(nestedURL);
 
     const bodyText = await global.__workbox.webdriver.executeScript(() => {
       return document.body.textContent;
     });
 
-    expect(bodyText).to.equal(`NavigationRoute.${nestedUrl}`);
+    expect(bodyText).to.equal(`NavigationRoute.${nestedURL}`);
   });
 });

--- a/test/workbox-routing/integration/routing-basic.js
+++ b/test/workbox-routing/integration/routing-basic.js
@@ -12,57 +12,57 @@ const activateAndControlSW = require('../../../infra/testing/activate-and-contro
 
 describe(`[workbox-routing] Basic Route`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
-  const testingUrl = `${testServerAddress}/test/workbox-routing/static/routing-basic/`;
-  const swUrl = `${testingUrl}sw.js`;
+  const testingURL = `${testServerAddress}/test/workbox-routing/static/routing-basic/`;
+  const swURL = `${testingURL}sw.js`;
 
   before(async function() {
-    await global.__workbox.webdriver.get(testingUrl);
-    await activateAndControlSW(swUrl);
+    await global.__workbox.webdriver.get(testingURL);
+    await activateAndControlSW(swURL);
   });
 
   it(`should honor a route created by a Route object`, async function() {
-    const testUrl = `${testServerAddress}/routeObject`;
-    const responseBody = await global.__workbox.webdriver.executeAsyncScript((testUrl, cb) => {
-      fetch(testUrl)
+    const testURL = `${testServerAddress}/routeObject`;
+    const responseBody = await global.__workbox.webdriver.executeAsyncScript((testURL, cb) => {
+      fetch(testURL)
           .then((response) => response.text())
           .then((responseBody) => cb(responseBody))
           .catch((err) => cb(err.message));
-    }, testUrl);
+    }, testURL);
 
-    expect(responseBody).to.eql(testUrl);
+    expect(responseBody).to.eql(testURL);
   });
 
   it(`should honor a same-origin route created by a string`, async function() {
-    const testUrl = `${testServerAddress}/sameOrigin`;
-    const responseBody = await global.__workbox.webdriver.executeAsyncScript((testUrl, cb) => {
-      fetch(testUrl)
+    const testURL = `${testServerAddress}/sameOrigin`;
+    const responseBody = await global.__workbox.webdriver.executeAsyncScript((testURL, cb) => {
+      fetch(testURL)
           .then((response) => response.text())
           .then((responseBody) => cb(responseBody))
           .catch((err) => cb(err.message));
-    }, testUrl);
+    }, testURL);
 
-    expect(responseBody).to.eql(testUrl);
+    expect(responseBody).to.eql(testURL);
   });
 
   it(`should honor a cross-origin route created by a string`, async function() {
-    const testUrl = 'https://example.com/crossOrigin';
-    const responseBody = await global.__workbox.webdriver.executeAsyncScript((testUrl, cb) => {
-      fetch(testUrl)
+    const testURL = 'https://example.com/crossOrigin';
+    const responseBody = await global.__workbox.webdriver.executeAsyncScript((testURL, cb) => {
+      fetch(testURL)
           .then((response) => response.text())
           .then((responseBody) => cb(responseBody))
           .catch((err) => cb(err.message));
-    }, testUrl);
+    }, testURL);
 
-    expect(responseBody).to.eql(testUrl);
+    expect(responseBody).to.eql(testURL);
   });
 
   it(`should return a 404 when passed a URL that isn't routed and doesn't exist`, async function() {
-    const testUrl = `${testServerAddress}/doesNotMatch`;
-    const responseStatus = await global.__workbox.webdriver.executeAsyncScript((testUrl, cb) => {
-      fetch(testUrl)
+    const testURL = `${testServerAddress}/doesNotMatch`;
+    const responseStatus = await global.__workbox.webdriver.executeAsyncScript((testURL, cb) => {
+      fetch(testURL)
           .then((response) => cb(response.status))
           .catch((err) => cb(err.message));
-    }, testUrl);
+    }, testURL);
 
     expect(responseStatus).to.eql(404);
   });

--- a/test/workbox-routing/integration/routing-regex.js
+++ b/test/workbox-routing/integration/routing-regex.js
@@ -12,13 +12,13 @@ const activateAndControlSW = require('../../../infra/testing/activate-and-contro
 
 describe(`[workbox-routing] Route via RegExp`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
-  const testingUrl = `${testServerAddress}/test/workbox-routing/static/routing-regex/`;
-  const swUrl = `${testingUrl}sw.js`;
+  const testingURL = `${testServerAddress}/test/workbox-routing/static/routing-regex/`;
+  const swURL = `${testingURL}sw.js`;
 
   it(`should load a page and route requests`, async function() {
     // Load the page and wait for the first service worker to register and activate.
-    await global.__workbox.webdriver.get(testingUrl);
-    await activateAndControlSW(swUrl);
+    await global.__workbox.webdriver.get(testingURL);
+    await activateAndControlSW(swURL);
 
     let testCounter = 0;
 

--- a/test/workbox-routing/node/test-DefaultRouter.mjs
+++ b/test/workbox-routing/node/test-DefaultRouter.mjs
@@ -92,8 +92,8 @@ describe(`[workbox-routing] Default Router`, function() {
       const route = defaultRouter.registerRoute(pathname, handlerSpy);
       expect(route).to.be.an.instanceof(Route);
 
-      const sameOriginUrl = new URL(pathname, location);
-      const sameOriginRequest = new Request(sameOriginUrl);
+      const sameOriginURL = new URL(pathname, location);
+      const sameOriginRequest = new Request(sameOriginURL);
       const sameOriginEvent =
           new FetchEvent('fetch', {request: sameOriginRequest});
 
@@ -102,9 +102,9 @@ describe(`[workbox-routing] Default Router`, function() {
         event: sameOriginEvent,
       });
 
-      const sameOriginUrlNotMatching = new URL('/does/not/match', location);
+      const sameOriginURLNotMatching = new URL('/does/not/match', location);
       const sameOriginRequestNotMatching =
-          new Request(sameOriginUrlNotMatching);
+          new Request(sameOriginURLNotMatching);
       const sameOriginEventNotMatching =
           new FetchEvent('fetch', {request: sameOriginRequestNotMatching});
 
@@ -113,8 +113,8 @@ describe(`[workbox-routing] Default Router`, function() {
         event: sameOriginEventNotMatching,
       });
 
-      const crossOriginUrl = new URL(pathname, crossOrigin);
-      const crossOriginRequest = new Request(crossOriginUrl);
+      const crossOriginURL = new URL(pathname, crossOrigin);
+      const crossOriginRequest = new Request(crossOriginURL);
       const crossOriginEvent =
           new FetchEvent('fetch', {request: crossOriginRequest});
 
@@ -124,7 +124,7 @@ describe(`[workbox-routing] Default Router`, function() {
       });
 
       expect(handlerSpy.callCount).to.equal(1);
-      expect(handlerSpy.firstCall.args[0].url).to.deep.equal(sameOriginUrl);
+      expect(handlerSpy.firstCall.args[0].url).to.deep.equal(sameOriginURL);
       expect(handlerSpy.firstCall.args[0].request).to.equal(sameOriginRequest);
       expect(handlerSpy.firstCall.args[0].event).to.equal(sameOriginEvent);
 
@@ -147,8 +147,8 @@ describe(`[workbox-routing] Default Router`, function() {
       const route = defaultRouter.registerRoute(`${crossOrigin}${pathname}`, handlerSpy);
       expect(route).to.be.an.instanceof(Route);
 
-      const sameOriginUrl = new URL(pathname, location);
-      const sameOriginRequest = new Request(sameOriginUrl);
+      const sameOriginURL = new URL(pathname, location);
+      const sameOriginRequest = new Request(sameOriginURL);
       const sameOriginEvent =
           new FetchEvent('fetch', {request: sameOriginRequest});
 
@@ -157,8 +157,8 @@ describe(`[workbox-routing] Default Router`, function() {
         event: sameOriginEvent,
       });
 
-      const crossOriginUrl = new URL(pathname, crossOrigin);
-      const crossOriginRequest = new Request(crossOriginUrl);
+      const crossOriginURL = new URL(pathname, crossOrigin);
+      const crossOriginRequest = new Request(crossOriginURL);
       const crossOriginEvent =
           new FetchEvent('fetch', {request: crossOriginRequest});
 
@@ -168,7 +168,7 @@ describe(`[workbox-routing] Default Router`, function() {
       });
 
       expect(handlerSpy.callCount).to.equal(1);
-      expect(handlerSpy.args[0][0].url).to.deep.equal(crossOriginUrl);
+      expect(handlerSpy.args[0][0].url).to.deep.equal(crossOriginURL);
       expect(handlerSpy.args[0][0].request).to.equal(crossOriginRequest);
       expect(handlerSpy.args[0][0].event).to.equal(crossOriginEvent);
       sandbox.resetHistory();
@@ -374,9 +374,9 @@ describe(`[workbox-routing] Default Router`, function() {
       const fetchStub = sandbox.stub(self, 'fetch').returns(fakeResponse);
 
       const cacheName = 'does-not-exist';
-      const shellUrl = '/does-not-exist.html';
+      const shellURL = '/does-not-exist.html';
 
-      const route = defaultRouter.registerNavigationRoute(shellUrl, {
+      const route = defaultRouter.registerNavigationRoute(shellURL, {
         cacheName,
       });
       const response = await route.handler.handle(new FetchEvent('fetch', {
@@ -386,7 +386,7 @@ describe(`[workbox-routing] Default Router`, function() {
       }));
 
       expect(fetchStub.calledOnce).to.be.true;
-      expect(fetchStub.firstCall.args[0]).to.eql(shellUrl);
+      expect(fetchStub.firstCall.args[0]).to.eql(shellURL);
       expect(response).to.eql(fakeResponse);
     });
   });

--- a/test/workbox-routing/node/test-RegExpRoute.mjs
+++ b/test/workbox-routing/node/test-RegExpRoute.mjs
@@ -48,36 +48,36 @@ describe(`[workbox-routing] RegExpRoute`, function() {
   });
 
   it(`should properly match URLs`, function() {
-    const matchingUrl = new URL(PATH, SAME_ORIGIN_URL);
-    const nonMatchingUrl = new URL('/does/not/match', SAME_ORIGIN_URL);
-    const crossOriginUrl = new URL(PATH, CROSS_ORIGIN_URL);
+    const matchingURL = new URL(PATH, SAME_ORIGIN_URL);
+    const nonMatchingURL = new URL('/does/not/match', SAME_ORIGIN_URL);
+    const crossOriginURL = new URL(PATH, CROSS_ORIGIN_URL);
     const regExp = new RegExp(PATH);
 
     const route = new RegExpRoute(regExp, HANDLER);
-    expect(route.match({url: matchingUrl})).to.be.ok;
-    expect(route.match({url: nonMatchingUrl})).not.to.be.ok;
+    expect(route.match({url: matchingURL})).to.be.ok;
+    expect(route.match({url: nonMatchingURL})).not.to.be.ok;
     // This route will not match because while the RegExp matches, the match
     // doesn't occur at the start of the cross-origin URL.
-    expect(route.match({url: crossOriginUrl})).not.to.be.ok;
+    expect(route.match({url: crossOriginURL})).not.to.be.ok;
   });
 
   it(`should properly match cross-origin URLs with wildcards`, function() {
-    const matchingUrl = new URL('https://fonts.googleapis.com/icon?family=Material+Icons');
-    const matchingUrl2 = new URL('https://code.getmdl.io/1.2.1/material.indigo-pink.min.css');
+    const matchingURL = new URL('https://fonts.googleapis.com/icon?family=Material+Icons');
+    const matchingURL2 = new URL('https://code.getmdl.io/1.2.1/material.indigo-pink.min.css');
 
     const route = new RegExpRoute(/.*\.(?:googleapis|getmdl)\.(?:com|io)\/.*/, HANDLER);
-    expect(route.match({url: matchingUrl})).to.be.ok;
-    expect(route.match({url: matchingUrl2})).to.be.ok;
+    expect(route.match({url: matchingURL})).to.be.ok;
+    expect(route.match({url: matchingURL2})).to.be.ok;
   });
 
   it(`should properly match cross-origin URLs without wildcards`, function() {
-    const matchingUrl = new URL(PATH, CROSS_ORIGIN_URL);
-    const nonMatchingUrl = new URL('/does/not/match', CROSS_ORIGIN_URL);
-    const crossOriginRegExp = new RegExp(matchingUrl.href);
+    const matchingURL = new URL(PATH, CROSS_ORIGIN_URL);
+    const nonMatchingURL = new URL('/does/not/match', CROSS_ORIGIN_URL);
+    const crossOriginRegExp = new RegExp(matchingURL.href);
 
     const route = new RegExpRoute(crossOriginRegExp, HANDLER);
-    expect(route.match({url: matchingUrl})).to.be.ok;
-    expect(route.match({url: nonMatchingUrl})).not.to.be.ok;
+    expect(route.match({url: matchingURL})).to.be.ok;
+    expect(route.match({url: nonMatchingURL})).not.to.be.ok;
   });
 
   it(`should properly match URLs with capture groups`, function() {
@@ -85,16 +85,16 @@ describe(`[workbox-routing] RegExpRoute`, function() {
     const value2 = 'value2';
 
     const captureGroupRegExp = new RegExp('/(\\w+)/dummy/(\\w+)');
-    const captureGroupMatchingUrl = new URL(`/${value1}/dummy/${value2}`, SAME_ORIGIN_URL);
-    const captureGroupNonMatchingUrl = new URL(`/${value1}/${value2}`, SAME_ORIGIN_URL);
+    const captureGroupMatchingURL = new URL(`/${value1}/dummy/${value2}`, SAME_ORIGIN_URL);
+    const captureGroupNonMatchingURL = new URL(`/${value1}/${value2}`, SAME_ORIGIN_URL);
 
     const route = new RegExpRoute(captureGroupRegExp, HANDLER);
 
-    const match = route.match({url: captureGroupMatchingUrl});
+    const match = route.match({url: captureGroupMatchingURL});
     expect(match.length).to.equal(2);
     expect(match[0]).to.equal(value1);
     expect(match[1]).to.equal(value2);
 
-    expect(route.match({url: captureGroupNonMatchingUrl})).not.to.be.ok;
+    expect(route.match({url: captureGroupNonMatchingURL})).not.to.be.ok;
   });
 });

--- a/test/workbox-routing/node/test-environment.mjs
+++ b/test/workbox-routing/node/test-environment.mjs
@@ -40,7 +40,7 @@ describe(`[workbox-routing] SW environment`, function() {
   });
 
   devOnly.it(`should not throw when in SW in dev`, async function() {
-    sandbox.stub(assert, 'isSwEnv').callsFake(() => true);
+    sandbox.stub(assert, 'isSWEnv').callsFake(() => true);
 
     await import(MODULE_PATH);
   });

--- a/test/workbox-routing/node/test-interface.mjs
+++ b/test/workbox-routing/node/test-interface.mjs
@@ -22,7 +22,7 @@ describe(`[workbox-routing] Module Interface`, function() {
     // Won't be needed after https://github.com/pinterest/service-workers/pull/44
     // is fixed
     if (process.env.NODE_ENV !== 'production') {
-      sandbox.stub(assert, 'isSwEnv').callsFake(() => true);
+      sandbox.stub(assert, 'isSWEnv').callsFake(() => true);
     }
 
     // tmp here is to avoid @std/esm weirdness

--- a/test/workbox-routing/static/sw.js
+++ b/test/workbox-routing/static/sw.js
@@ -12,9 +12,9 @@ importScripts('../../../../packages/workbox-routing/build/browser/workbox-routin
 const routing = self.workbox.routing;
 const Route = self.workbox.routing.Route;
 
-const specialImgUrl = new URL('/test/workbox-routing/static/demo-img.png', location).toString();
+const specialImgURL = new URL('/test/workbox-routing/static/demo-img.png', location).toString();
 const specialImgRoute = new Route(({event}) => {
-  return (event.request.url === specialImgUrl);
+  return (event.request.url === specialImgURL);
 }, ()=> {
   return fetch('http://via.placeholder.com/300x300/ffffff/F57C00?text=Hello+from+Workbox', {mode: 'no-cors'});
 });

--- a/test/workbox-strategies/integration/test-cacheFirst.js
+++ b/test/workbox-strategies/integration/test-cacheFirst.js
@@ -12,12 +12,12 @@ const activateAndControlSW = require('../../../infra/testing/activate-and-contro
 const cleanSWEnv = require('../../../infra/testing/clean-sw');
 
 describe(`[workbox-strategies] CacheFirst Requests`, function() {
-  const baseUrl = `${global.__workbox.server.getAddress()}/test/workbox-strategies/static/cache-first/`;
+  const baseURL = `${global.__workbox.server.getAddress()}/test/workbox-strategies/static/cache-first/`;
 
   let requestCounter;
   beforeEach(async function() {
     // Navigate to our test page and clear all caches before this test runs.
-    await cleanSWEnv(global.__workbox.webdriver, `${baseUrl}integration.html`);
+    await cleanSWEnv(global.__workbox.webdriver, `${baseURL}integration.html`);
     requestCounter = global.__workbox.server.startCountingRequests();
   });
   afterEach(function() {
@@ -25,10 +25,10 @@ describe(`[workbox-strategies] CacheFirst Requests`, function() {
   });
 
   it(`should respond with a cached response`, async function() {
-    const swUrl = `${baseUrl}sw.js`;
+    const swURL = `${baseURL}sw.js`;
 
     // Wait for the service worker to register and activate.
-    await activateAndControlSW(swUrl);
+    await activateAndControlSW(swURL);
 
     let response = await global.__workbox.webdriver.executeAsyncScript((cb) => {
       fetch(new URL(`/test/workbox-strategies/static/cache-first/example.txt`, location).href)
@@ -38,7 +38,7 @@ describe(`[workbox-strategies] CacheFirst Requests`, function() {
     });
     expect(response.trim()).to.equal('hello');
 
-    expect(requestCounter.getUrlCount('/test/workbox-strategies/static/cache-first/example.txt')).to.eql(1);
+    expect(requestCounter.getURLCount('/test/workbox-strategies/static/cache-first/example.txt')).to.eql(1);
 
     // This request should come from cache and not the server
     response = await global.__workbox.webdriver.executeAsyncScript((cb) => {
@@ -49,6 +49,6 @@ describe(`[workbox-strategies] CacheFirst Requests`, function() {
     });
     expect(response.trim()).to.equal('hello');
 
-    expect(requestCounter.getUrlCount('/test/workbox-strategies/static/cache-first/example.txt')).to.eql(1);
+    expect(requestCounter.getURLCount('/test/workbox-strategies/static/cache-first/example.txt')).to.eql(1);
   });
 });

--- a/test/workbox-strategies/integration/test-cacheOnly.js
+++ b/test/workbox-strategies/integration/test-cacheOnly.js
@@ -12,18 +12,18 @@ const activateAndControlSW = require('../../../infra/testing/activate-and-contro
 const cleanSWEnv = require('../../../infra/testing/clean-sw');
 
 describe(`[workbox-strategies] CacheOnly`, function() {
-  const baseUrl = `${global.__workbox.server.getAddress()}/test/workbox-strategies/static/cache-only/`;
+  const baseURL = `${global.__workbox.server.getAddress()}/test/workbox-strategies/static/cache-only/`;
 
   beforeEach(async function() {
     // Navigate to our test page and clear all caches before this test runs.
-    await cleanSWEnv(global.__workbox.webdriver, `${baseUrl}integration.html`);
+    await cleanSWEnv(global.__workbox.webdriver, `${baseURL}integration.html`);
   });
 
   it(`should respond with a cached response`, async function() {
-    const swUrl = `${baseUrl}sw.js`;
+    const swURL = `${baseURL}sw.js`;
 
     // Wait for the service worker to register and activate.
-    await activateAndControlSW(swUrl);
+    await activateAndControlSW(swURL);
 
     let response = await global.__workbox.webdriver.executeAsyncScript((cb) => {
       fetch(`/CacheOnly/InCache/`)

--- a/test/workbox-strategies/integration/test-networkFirst.js
+++ b/test/workbox-strategies/integration/test-networkFirst.js
@@ -14,18 +14,18 @@ const runInSW = require('../../../infra/testing/comlink/node-interface');
 const waitUntil = require('../../../infra/testing/wait-until');
 
 describe(`[workbox-strategies] NetworkFirst Requests`, function() {
-  const baseUrl = `${global.__workbox.server.getAddress()}/test/workbox-strategies/static/network-first/`;
+  const baseURL = `${global.__workbox.server.getAddress()}/test/workbox-strategies/static/network-first/`;
 
   beforeEach(async function() {
     // Navigate to our test page and clear all caches before this test runs.
-    await cleanSWEnv(global.__workbox.webdriver, `${baseUrl}integration.html`);
+    await cleanSWEnv(global.__workbox.webdriver, `${baseURL}integration.html`);
   });
 
   it(`should respond with a non-cached entry but stash request in a cache`, async function() {
-    const swUrl = `${baseUrl}sw.js`;
+    const swURL = `${baseURL}sw.js`;
 
     // Wait for the service worker to register and activate.
-    await activateAndControlSW(swUrl);
+    await activateAndControlSW(swURL);
 
     const cacheName = 'network-first';
 

--- a/test/workbox-strategies/integration/test-networkOnly.js
+++ b/test/workbox-strategies/integration/test-networkOnly.js
@@ -13,18 +13,18 @@ const cleanSWEnv = require('../../../infra/testing/clean-sw');
 const runInSW = require('../../../infra/testing/comlink/node-interface');
 
 describe(`[workbox-strategies] NetworkOnly Requests`, function() {
-  const baseUrl = `${global.__workbox.server.getAddress()}/test/workbox-strategies/static/network-only/`;
+  const baseURL = `${global.__workbox.server.getAddress()}/test/workbox-strategies/static/network-only/`;
 
   beforeEach(async function() {
     // Navigate to our test page and clear all caches before this test runs.
-    await cleanSWEnv(global.__workbox.webdriver, `${baseUrl}integration.html`);
+    await cleanSWEnv(global.__workbox.webdriver, `${baseURL}integration.html`);
   });
 
   it(`should respond with a non-cached entry`, async function() {
-    const swUrl = `${baseUrl}sw.js`;
+    const swURL = `${baseURL}sw.js`;
 
     // Wait for the service worker to register and activate.
-    await activateAndControlSW(swUrl);
+    await activateAndControlSW(swURL);
 
     let response = await global.__workbox.webdriver.executeAsyncScript((cb) => {
       fetch(`/__WORKBOX/uniqueValue`)

--- a/test/workbox-strategies/integration/test-staleWhileRevalidate.js
+++ b/test/workbox-strategies/integration/test-staleWhileRevalidate.js
@@ -14,18 +14,18 @@ const runInSW = require('../../../infra/testing/comlink/node-interface');
 const waitUntil = require('../../../infra/testing/wait-until');
 
 describe(`[workbox-strategies] StaleWhileRevalidate Requests`, function() {
-  const baseUrl = `${global.__workbox.server.getAddress()}/test/workbox-strategies/static/stale-while-revalidate/`;
+  const baseURL = `${global.__workbox.server.getAddress()}/test/workbox-strategies/static/stale-while-revalidate/`;
 
   beforeEach(async function() {
     // Navigate to our test page and clear all caches before this test runs.
-    await cleanSWEnv(global.__workbox.webdriver, `${baseUrl}integration.html`);
+    await cleanSWEnv(global.__workbox.webdriver, `${baseURL}integration.html`);
   });
 
   it(`should respond with cached entry and update it`, async function() {
-    const swUrl = `${baseUrl}sw.js`;
+    const swURL = `${baseURL}sw.js`;
 
     // Wait for the service worker to register and activate.
-    await activateAndControlSW(swUrl);
+    await activateAndControlSW(swURL);
 
     const cacheName = 'stale-while-revalidate';
 

--- a/test/workbox-streams/integration/test.js
+++ b/test/workbox-streams/integration/test.js
@@ -12,12 +12,12 @@ const activateAndControlSW = require('../../../infra/testing/activate-and-contro
 
 describe(`[workbox-streams] Integration Tests`, function() {
   const testServerAddress = global.__workbox.server.getAddress();
-  const testingUrl = `${testServerAddress}/test/workbox-streams/static/`;
-  const swUrl = `${testingUrl}sw.js`;
+  const testingURL = `${testServerAddress}/test/workbox-streams/static/`;
+  const swURL = `${testingURL}sw.js`;
 
   before(async function() {
-    await global.__workbox.webdriver.get(testingUrl);
-    await activateAndControlSW(swUrl);
+    await global.__workbox.webdriver.get(testingURL);
+    await activateAndControlSW(swURL);
   });
 
   for (const testCase of ['concatenate', 'concatenateToResponse', 'strategy']) {

--- a/test/workbox-sw/integration/workbox-sw.js
+++ b/test/workbox-sw/integration/workbox-sw.js
@@ -19,10 +19,10 @@ describe(`WorkboxSW interface`, function() {
   };
 
   const testServerAddress = global.__workbox.server.getAddress();
-  const testPageUrl = `${testServerAddress}/test/workbox-sw/static/integration/`;
+  const testPageURL = `${testServerAddress}/test/workbox-sw/static/integration/`;
 
   before(async function() {
-    await global.__workbox.webdriver.get(testPageUrl);
+    await global.__workbox.webdriver.get(testPageURL);
   });
 
   it(`should fail to activate an invalid SW which loads non-existent modules`, async function() {

--- a/test/workbox-window/integration/test.js
+++ b/test/workbox-window/integration/test.js
@@ -13,7 +13,7 @@ const waitUntil = require('../../../infra/testing/wait-until');
 const {executeAsyncAndCatch} = require('../../../infra/testing/webdriver/executeAsyncAndCatch');
 const {getLastWindowHandle} = require('../../../infra/testing/webdriver/getLastWindowHandle');
 const {openNewTab} = require('../../../infra/testing/webdriver/openNewTab');
-const {unregisterAllSws} = require('../../../infra/testing/webdriver/unregisterAllSws');
+const {unregisterAllSWs} = require('../../../infra/testing/webdriver/unregisterAllSWs');
 const {windowLoaded} = require('../../../infra/testing/webdriver/windowLoaded');
 
 // Store local references of these globals.
@@ -69,7 +69,7 @@ describe(`[workbox-window] Workbox`, function() {
   });
 
   afterEach(async function() {
-    await unregisterAllSws();
+    await unregisterAllSWs();
   });
 
   describe('register', () => {
@@ -82,13 +82,13 @@ describe(`[workbox-window] Workbox`, function() {
           const reg = await navigator.serviceWorker.getRegistration();
           const sw = reg.installing || reg.waiting || reg.active;
 
-          cb({scriptUrl: sw.scriptURL});
+          cb({scriptURL: sw.scriptURL});
         } catch (error) {
           cb({error: error.stack});
         }
       });
 
-      expect(result.scriptUrl).to.equal(`${testPath}sw-clients-claim.tmp.js`);
+      expect(result.scriptURL).to.equal(`${testPath}sw-clients-claim.tmp.js`);
     });
 
     it(`reports all events for a new SW registration`, async function() {
@@ -151,8 +151,8 @@ describe(`[workbox-window] Workbox`, function() {
           wb.addEventListener('waiting', self.__spies.waitingSpy);
           wb.addEventListener('activated', self.__spies.activatedSpy);
           wb.addEventListener('controlling', self.__spies.controllingSpy);
-          wb.addEventListener('externalInstalled', self.__spies.externalInstalledSpy);
-          wb.addEventListener('externalActivated', self.__spies.externalActivatedSpy);
+          wb.addEventListener('externalinstalled', self.__spies.externalInstalledSpy);
+          wb.addEventListener('externalactivated', self.__spies.externalActivatedSpy);
 
           // Resolve this execution block once the SW is controlling.
           wb.addEventListener('controlling', () => cb());


### PR DESCRIPTION
Workbox has been somewhat inconsistent with respect to the casing in its API names. Specifically with regards to `SW` vs. `Sw`, and `URL` vs. `Url`.

This PR standardizes on `SW` and `URL` per the [W3C TAG's design principles doc](https://w3ctag.github.io/design-principles/#casing-rules), in an attempt to be as consistent as possible to the underlying web API names. It also updates any mixed-case event names to all lowercase.

Here is a list of changes to the public API:

**`workbox-broadcast-cache-update`**

- The broadcast update message data: `data.payload.updatedURL`

**`workbox-precaching`**

- `workbox.precaching.addRoute(options)`: `options.cleanURLs`
- `workbox.precaching.precacheAndRoute(entries, options)`: `options.cleanURLs`
- `workbox.precaching.PrecacheController`:`getCachedURLs()`

Note, I haven't changed any of the node tools yet (`workbox-build`, `workbox-cli`, or `workbox-webpack-plugin`) as we may try to accept both variants in v4, and log a deprecation warning.