### PR TITLE
Support requestInit in CACHE_URLS message URLs

### DIFF
--- a/test/workbox-routing/node/test-Router.mjs
+++ b/test/workbox-routing/node/test-Router.mjs
@@ -213,6 +213,42 @@ describe(`[workbox-routing] Router`, function() {
       expect(router.handleRequest.args[2][0].request.url).to.equal('/three');
       expect(router.handleRequest.args[2][0].event).to.equal(event);
     });
+
+    it(`should accept URL strings or request URL+requestInit tuples`, async function() {
+      const router = new Router();
+      const route = new Route(
+          () => true,
+          () => new Response(EXPECTED_RESPONSE_BODY));
+      router.registerRoute(route);
+      router.addCacheListener();
+
+      const event = new ExtendableMessageEvent('message', {
+        data: {
+          type: 'CACHE_URLS',
+          meta: 'workbox-window',
+          payload: {
+            urlsToCache: [
+              '/one',
+              ['/two', {mode: 'no-cors'}],
+              '/three',
+            ],
+          },
+        },
+      });
+      sandbox.spy(router, 'handleRequest');
+      self.dispatchEvent(event);
+
+      await eventsDoneWaiting();
+
+      expect(router.handleRequest.callCount).to.equal(3);
+      expect(router.handleRequest.args[0][0].request.url).to.equal('/one');
+      expect(router.handleRequest.args[0][0].event).to.equal(event);
+      expect(router.handleRequest.args[1][0].request.url).to.equal('/two');
+      expect(router.handleRequest.args[1][0].request.mode).to.equal('no-cors');
+      expect(router.handleRequest.args[1][0].event).to.equal(event);
+      expect(router.handleRequest.args[2][0].request.url).to.equal('/three');
+      expect(router.handleRequest.args[2][0].event).to.equal(event);
+    });
   });
 
   describe(`unregisterRoute()`, function() {


### PR DESCRIPTION
R: @jeffposnick 

Fixes #1826

I choose to initially go with a solution that just lets developers choose what init options they want. I figure we can hold off on implementing any automagic behavior until we see what/if our `workbox-window` method for doing this automatically looks like.