### PR TITLE
Don't set fetchOptions when request.mode is 'navigate'

### DIFF
--- a/packages/workbox-core/_private/fetchWrapper.mjs
+++ b/packages/workbox-core/_private/fetchWrapper.mjs
@@ -105,10 +105,8 @@ const wrappedFetch = async ({
     let fetchResponse;
 
     // See https://github.com/GoogleChrome/workbox/issues/1796
-    if (request.mode === 'navigate' && fetchOptions &&
-         Object.keys(fetchOptions).length > 0) {
-      pluginFilteredRequest = new Request(request, {mode: 'same-origin'});
-      fetchResponse = await fetch(pluginFilteredRequest, fetchOptions);
+    if (request.mode === 'navigate') {
+      fetchResponse = await fetch(request);
     } else {
       fetchResponse = await fetch(request, fetchOptions);
     }

--- a/test/workbox-core/node/_private/test-fetchWrapper.mjs
+++ b/test/workbox-core/node/_private/test-fetchWrapper.mjs
@@ -69,7 +69,8 @@ describe(`workbox-core fetchWrapper`, function() {
       expect(fetchOptions).to.deep.equal(exampleOptions);
     });
 
-    it(`should convert 'navigate' requests to 'same-origin' when fetchOptions is used`, async function() {
+    it(`should ignore fetchOptions when request.mode === 'navigate'`, async function() {
+      // See https://github.com/GoogleChrome/workbox/issues/1796
       const fetchStub = sandbox.stub(global, 'fetch').resolves(new Response());
 
       const fetchOptions = {
@@ -90,8 +91,8 @@ describe(`workbox-core fetchWrapper`, function() {
       expect(fetchStub.calledOnce).to.be.true;
       expect(fetchStub.firstCall.args[0]).to.be.instanceOf(Request);
       expect(fetchStub.firstCall.args[0].url).to.eql(request.url);
-      expect(fetchStub.firstCall.args[0].mode).to.eql('same-origin');
-      expect(fetchStub.firstCall.args[1]).to.eql(fetchOptions);
+      expect(fetchStub.firstCall.args[0].mode).to.eql('navigate');
+      expect(fetchStub.firstCall.args[1]).not.to.exist;
     });
 
     it(`should call requestWillFetch method in plugins and use the returned request`, async function() {


### PR DESCRIPTION
R: @philipwalton 

This is related to https://github.com/GoogleChrome/workbox/issues/1796, but it doesn't fix it. The workaround that I added to fix it led to issues in Edge, and rather than continue to iterate and try to find a fix for the v4.0.0 release, I'm going to work around the issue by making sure we don't set `fetchOptions` when `request.mode === 'navigate'`.

This is strictly better than the behavior in v3, where you could end up with failed navigations in this scenario.

The ultimate fix is to find the cleanest, cross-browser-compatible way to create a new `Request` with `mode` set to `'same-origin'` and all of the other `Request` properties carried over. I'd like to punt on that until after the final v4.0.0 release, though.