### PR TITLE
GenerateSW config support for cleanupOutdatedCaches

### DIFF
--- a/infra/testing/validator/service-worker-runtime.js
+++ b/infra/testing/validator/service-worker-runtime.js
@@ -47,6 +47,7 @@ function setupSpiesAndContext() {
     },
     precaching: {
       precacheAndRoute: sinon.spy(),
+      cleanupOutdatedCaches: sinon.spy(),
     },
     routing: {
       registerNavigationRoute: sinon.spy(),
@@ -73,6 +74,7 @@ function setupSpiesAndContext() {
   const methodsToSpies = {
     importScripts,
     cacheableResponsePlugin: cacheableResponsePluginSpy,
+    cleanupOutdatedCaches: workbox.precaching.cleanupOutdatedCaches,
     cacheExpirationPlugin: cacheExpirationPluginSpy,
     CacheFirst: workbox.strategies.CacheFirst,
     clientsClaim: workbox.core.clientsClaim,

--- a/packages/workbox-build/src/entry-points/options/common-generate-schema.js
+++ b/packages/workbox-build/src/entry-points/options/common-generate-schema.js
@@ -15,6 +15,7 @@ const regExpObject = require('./reg-exp-object');
 // Add some constraints that apply to both generateSW and generateSWString.
 module.exports = baseSchema.keys({
   cacheId: joi.string(),
+  cleanupOutdatedCaches: joi.boolean().default(defaults.cleanupOutdatedCaches),
   clientsClaim: joi.boolean().default(defaults.clientsClaim),
   directoryIndex: joi.string(),
   ignoreURLParametersMatching: joi.array().items(regExpObject),

--- a/packages/workbox-build/src/entry-points/options/defaults.js
+++ b/packages/workbox-build/src/entry-points/options/defaults.js
@@ -7,6 +7,7 @@
 */
 
 module.exports = {
+  cleanupOutdatedCaches: false,
   clientsClaim: false,
   globFollow: true,
   globIgnores: ['**/node_modules/**/*'],

--- a/packages/workbox-build/src/lib/populate-sw-template.js
+++ b/packages/workbox-build/src/lib/populate-sw-template.js
@@ -15,6 +15,7 @@ const stringifyWithoutComments = require('./stringify-without-comments');
 
 module.exports = ({
   cacheId,
+  cleanupOutdatedCaches,
   clientsClaim,
   directoryIndex,
   ignoreURLParametersMatching,
@@ -63,6 +64,7 @@ module.exports = ({
   try {
     const populatedTemplate = template(swTemplate)({
       cacheId,
+      cleanupOutdatedCaches,
       clientsClaim,
       importScripts,
       manifestEntries,

--- a/packages/workbox-build/src/lib/write-sw-using-default-template.js
+++ b/packages/workbox-build/src/lib/write-sw-using-default-template.js
@@ -14,6 +14,7 @@ const populateSWTemplate = require('./populate-sw-template');
 
 module.exports = async ({
   cacheId,
+  cleanupOutdatedCaches,
   clientsClaim,
   directoryIndex,
   handleFetch,
@@ -39,6 +40,7 @@ module.exports = async ({
 
   const populatedTemplate = populateSWTemplate({
     cacheId,
+    cleanupOutdatedCaches,
     clientsClaim,
     directoryIndex,
     handleFetch,

--- a/packages/workbox-build/src/templates/sw-template.js
+++ b/packages/workbox-build/src/templates/sw-template.js
@@ -47,6 +47,7 @@ if (Array.isArray(self.__precacheManifest)) {
   workbox.precaching.precacheAndRoute(self.__precacheManifest, <%= precacheOptionsString %>);
 }
 <% } %>
+<% if (cleanupOutdatedCaches) { %>workbox.precaching.cleanupOutdatedCaches();<% } %>
 <% if (navigateFallback) { %>workbox.routing.registerNavigationRoute(<%= JSON.stringify(navigateFallback) %><% if (navigateFallbackWhitelist || navigateFallbackBlacklist) { %>, {
   <% if (navigateFallbackWhitelist) { %>whitelist: [<%= navigateFallbackWhitelist %>],<% } %>
   <% if (navigateFallbackBlacklist) { %>blacklist: [<%= navigateFallbackBlacklist %>],<% } %>

--- a/test/workbox-build/node/lib/populate-sw-template.js
+++ b/test/workbox-build/node/lib/populate-sw-template.js
@@ -48,6 +48,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
     expect(outerStub.alwaysCalledWith(swTemplate)).to.be.true;
     expect(innerStub.args[0]).to.eql([{
       cacheId: undefined,
+      cleanupOutdatedCaches: undefined,
       clientsClaim: undefined,
       importScripts: undefined,
       manifestEntries: undefined,
@@ -65,6 +66,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
 
   it(`should pass the expected options to the template`, function() {
     const cacheId = 'test-cache-id';
+    const cleanupOutdatedCaches = true;
     const clientsClaim = true;
     const directoryIndex = 'index.html';
     const handleFetch = true;
@@ -98,6 +100,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
 
     populateSWTemplate({
       cacheId,
+      cleanupOutdatedCaches,
       clientsClaim,
       directoryIndex,
       handleFetch,
@@ -117,6 +120,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
     expect(templateCreationStub.alwaysCalledWith(swTemplate)).to.be.true;
     expect(templatePopulationStub.args[0]).to.eql([{
       cacheId,
+      cleanupOutdatedCaches,
       clientsClaim,
       importScripts,
       manifestEntries,
@@ -160,6 +164,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
     expect(outerStub.alwaysCalledWith(swTemplate)).to.be.true;
     expect(innerStub.args[0]).to.eql([{
       cacheId: undefined,
+      cleanupOutdatedCaches: undefined,
       clientsClaim: undefined,
       importScripts: undefined,
       manifestEntries: undefined,

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -688,6 +688,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           // it should be enough to confirm that they're being interpreted
           // by workbox-build.generateSWString() properly.
           new GenerateSW({
+            cleanupOutdatedCaches: true,
             clientsClaim: true,
             skipWaiting: true,
             globDirectory: SRC_DIR,
@@ -716,6 +717,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
               [WORKBOX_SW_FILE_NAME],
               [FILE_MANIFEST_NAME],
             ],
+            cleanupOutdatedCaches: [[]],
             clientsClaim: [[]],
             skipWaiting: [[]],
             precacheAndRoute: [[[{


### PR DESCRIPTION
R: @philipwalton 

This adds a new option available to the various `GenerateSW` build integrations to automatically call `workbox.precaching.cleanupOutdatedCaches()` for you, when `cleanupOutdatedCaches: true` is set. (The default is not to call it.)

Calling that method will attempt to find and remove any of the older precaches that might have been used by previous versions of Workbox, as Workbox v4 moved to a new, incompatible precaching format.