### PR TITLE
Reduce the unit test timeout

### DIFF
--- a/test/workbox-window/unit/index.html
+++ b/test/workbox-window/unit/index.html
@@ -24,7 +24,7 @@
 
   <script>
   mocha.ui('bdd');
-  mocha.timeout(60000);
+  mocha.timeout(5000);
 
   // Expose chai's expect globally.
   self.expect = chai.expect;


### PR DESCRIPTION
R: @jeffposnick 

Addresses #1864, I ran the tests several times and didn't see the flakiness, but reducing this timeout should help make the failure report more actionable.

Right now the webdriver timeout is the same as the unit test timeout, so the result we see is just that there was a timeout, but with this change it should let the unit tests finish and report their results, so at least we'll be able to know which unit test(s) is causing the issue.