### PR TITLE
Add getCacheKeyForUrl() in GenerateSW mode

### DIFF
--- a/demos/functions/cdn-details.json
+++ b/demos/functions/cdn-details.json
@@ -1,1 +1,1 @@
-{"latestUrl":"https://storage.googleapis.com/workbox-cdn/releases/4.0.0-beta.1"}
+{"latestUrl":"https://storage.googleapis.com/workbox-cdn/releases/4.0.0-beta.2"}

--- a/infra/testing/validator/service-worker-runtime.js
+++ b/infra/testing/validator/service-worker-runtime.js
@@ -46,6 +46,8 @@ function setupSpiesAndContext() {
       initialize: sinon.spy(),
     },
     precaching: {
+      // To make testing easier, hardcode this fake URL return value.
+      getCacheKeyForUrl: sinon.stub().returns('/urlWithCacheKey'),
       precacheAndRoute: sinon.spy(),
       cleanupOutdatedCaches: sinon.spy(),
     },
@@ -78,6 +80,7 @@ function setupSpiesAndContext() {
     cacheExpirationPlugin: cacheExpirationPluginSpy,
     CacheFirst: workbox.strategies.CacheFirst,
     clientsClaim: workbox.core.clientsClaim,
+    getCacheKeyForUrl: workbox.precaching.getCacheKeyForUrl,
     googleAnalyticsInitialize: workbox.googleAnalytics.initialize,
     NetworkFirst: workbox.strategies.NetworkFirst,
     precacheAndRoute: workbox.precaching.precacheAndRoute,

--- a/packages/workbox-build/src/templates/sw-template.js
+++ b/packages/workbox-build/src/templates/sw-template.js
@@ -48,7 +48,7 @@ if (Array.isArray(self.__precacheManifest)) {
 }
 <% } %>
 <% if (cleanupOutdatedCaches) { %>workbox.precaching.cleanupOutdatedCaches();<% } %>
-<% if (navigateFallback) { %>workbox.routing.registerNavigationRoute(<%= JSON.stringify(navigateFallback) %><% if (navigateFallbackWhitelist || navigateFallbackBlacklist) { %>, {
+<% if (navigateFallback) { %>workbox.routing.registerNavigationRoute(workbox.precaching.getCacheKeyForUrl(<%= JSON.stringify(navigateFallback) %>)<% if (navigateFallbackWhitelist || navigateFallbackBlacklist) { %>, {
   <% if (navigateFallbackWhitelist) { %>whitelist: [<%= navigateFallbackWhitelist %>],<% } %>
   <% if (navigateFallbackBlacklist) { %>blacklist: [<%= navigateFallbackBlacklist %>],<% } %>
 }<% } %>);<% } %>

--- a/packages/workbox-routing/registerNavigationRoute.mjs
+++ b/packages/workbox-routing/registerNavigationRoute.mjs
@@ -19,13 +19,18 @@ import './_version.mjs';
  * request. This is useful for the
  * [application shell pattern]{@link https://developers.google.com/web/fundamentals/architecture/app-shell}.
  *
+ * When determining the URL of the precached HTML document, you will likely need
+ * to call `workbox.precaching.getCacheKeyForURL(originalUrl)`, to account for
+ * the fact that Workbox's precaching naming conventions often results in URL
+ * cache keys that contain extra revisioning info.
+ *
  * This method will generate a
  * [NavigationRoute]{@link workbox.routing.NavigationRoute}
  * and call
  * [Router.registerRoute()]{@link workbox.routing.Router#registerRoute} on a
  * singleton Router instance.
  *
- * @param {string} cachedAssetUrl
+ * @param {string} cachedAssetUrl The cache key to use for the HTML file.
  * @param {Object} [options]
  * @param {string} [options.cacheName] Cache name to store and retrieve
  * requests. Defaults to precache cache name provided by

--- a/test/workbox-build/node/entry-points/generate-sw-string.js
+++ b/test/workbox-build/node/entry-points/generate-sw-string.js
@@ -210,9 +210,10 @@ describe(`[workbox-build] entry-points/generate-sw-string.js (End to End)`, func
       const {swString, warnings} = await generateSWString(options);
       expect(warnings).to.be.empty;
       await validateServiceWorkerRuntime({swString, expectedMethodCalls: {
+        getCacheKeyForUrl: [[navigateFallback]],
         importScripts: [[...DEFAULT_IMPORT_SCRIPTS]],
         precacheAndRoute: [[[], {}]],
-        registerNavigationRoute: [[navigateFallback]],
+        registerNavigationRoute: [['/urlWithCacheKey']],
       }});
     });
 
@@ -227,9 +228,10 @@ describe(`[workbox-build] entry-points/generate-sw-string.js (End to End)`, func
       const {swString, warnings} = await generateSWString(options);
       expect(warnings).to.be.empty;
       await validateServiceWorkerRuntime({swString, expectedMethodCalls: {
+        getCacheKeyForUrl: [[navigateFallback]],
         importScripts: [[...DEFAULT_IMPORT_SCRIPTS]],
         precacheAndRoute: [[[], {}]],
-        registerNavigationRoute: [[navigateFallback, {
+        registerNavigationRoute: [['/urlWithCacheKey', {
           whitelist: navigateFallbackWhitelist,
         }]],
       }});

--- a/test/workbox-build/node/entry-points/generate-sw.js
+++ b/test/workbox-build/node/entry-points/generate-sw.js
@@ -366,6 +366,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       expect(count).to.eql(6);
       expect(size).to.eql(2604);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
+        getCacheKeyForUrl: [[navigateFallback]],
         importScripts: [[WORKBOX_SW_CDN_URL]],
         precacheAndRoute: [[[{
           url: 'index.html',
@@ -386,7 +387,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
           url: 'webpackEntry.js',
           revision: '5b652181a25e96f255d0490203d3c47e',
         }], {}]],
-        registerNavigationRoute: [[navigateFallback, {
+        registerNavigationRoute: [['/urlWithCacheKey', {
           whitelist: navigateFallbackWhitelist,
         }]],
       }});


### PR DESCRIPTION
R: @philipwalton

Fixes #1873

This updates the templated used in `GenerateSW` mode to account for the fact that `workbox.precaching.getCacheKeyForUrl()` need to be called to translate the `navigateFallback` URL into a cache key URL.

It also updates the JSDoc to reflect that requirement. This should also be called out as part of our migration docs, for folks like @prateekbh who ran into this when using `InjectManifest` mode and need to make manual updates.