### PR TITLE
Remove the scriptVersion option

### DIFF
--- a/packages/workbox-window/messageSW.mjs
+++ b/packages/workbox-window/messageSW.mjs
@@ -16,27 +16,19 @@ import './_version.mjs';
  * A response can be set in a message handler in the service worker by
  * calling `event.ports[0].postMessage(...)`, which will resolve the promise
  * returned by `messageSW()`. If no response is set, the promise will not
- * resolve unless an optional timeout value is passed, in which case the
- * promise will resolve with undefined if it hasn't been resolved after
- * that amount of time.
+ * resolve.
  *
  * @param {ServiceWorker} sw The service worker to send the message to.
  * @param {Object} data An object to send to the service worker.
- * @param {Object} [timeout] If set, the amount of time to wait before
- *     resolving the promise to `undefined`.
  * @return {Promise<Object|undefined>}
  *
  * @memberof module:workbox-window
  */
-const messageSW = (sw, data, timeout) => {
+const messageSW = (sw, data) => {
   return new Promise((resolve) => {
     let messageChannel = new MessageChannel();
     messageChannel.port1.onmessage = (evt) => resolve(evt.data);
     sw.postMessage(data, [messageChannel.port2]);
-
-    if (timeout) {
-      setTimeout(resolve, timeout);
-    }
   });
 };
 


### PR DESCRIPTION
R: @jeffposnick

Based on in-person discussion, this PR removes the `scriptVersion` option from `Workbox` and reverts the constructor function signature to how it was before beta 2.
