### PR TITLE
Update the workbox-expiration IDB data model

### DIFF
--- a/infra/testing/comlink/sw-interface.js
+++ b/infra/testing/comlink/sw-interface.js
@@ -37,6 +37,21 @@ const api = {
     });
   },
 
+  getObjectStoreEntries: (dbName, objStoreName) => {
+    return new Promise((resolve) => {
+      const result = indexedDB.open(dbName);
+      result.onsuccess = (event) => {
+        const db = event.target.result;
+        db.transaction(objStoreName)
+            .objectStore(objStoreName)
+            .getAll()
+            .onsuccess = (event) => {
+              resolve(event.target.result);
+            };
+      };
+    });
+  },
+
   cacheURLs: async (cacheName) => {
     const cache = await caches.open(cacheName);
     const requests = await cache.keys();

--- a/package-lock.json
+++ b/package-lock.json
@@ -16619,8 +16619,8 @@
       "dev": true
     },
     "shelving-mock-indexeddb": {
-      "version": "github:philipwalton/shelving-mock-indexeddb#c7b3b002472597ee75b027011049737a06460261",
-      "from": "github:philipwalton/shelving-mock-indexeddb#c7b3b002472597ee75b027011049737a06460261",
+      "version": "github:philipwalton/shelving-mock-indexeddb#2379a818f8a45873903166d1bdb4ff3dbfbc550d",
+      "from": "github:philipwalton/shelving-mock-indexeddb#2379a818f8a45873903166d1bdb4ff3dbfbc550d",
       "dev": true,
       "requires": {
         "shelving-mock-event": "^1.0.8"

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "semver": "^5.5.1",
     "serve-index": "^1.9.1",
     "service-worker-mock": "^1.9.3",
-    "shelving-mock-indexeddb": "github:philipwalton/shelving-mock-indexeddb#c7b3b002472597ee75b027011049737a06460261",
+    "shelving-mock-indexeddb": "github:philipwalton/shelving-mock-indexeddb#2379a818f8a45873903166d1bdb4ff3dbfbc550d",
     "sinon": "^6.3.4",
     "tempy": "^0.2.1",
     "url-search-params": "^1.1.0",

--- a/packages/workbox-expiration/CacheExpiration.mjs
+++ b/packages/workbox-expiration/CacheExpiration.mjs
@@ -179,7 +179,7 @@ class CacheExpiration {
     // Make sure we don't attempt another rerun if we're called in the middle of
     // a cache expiration.
     this._rerunRequested = false;
-    await this._timestampModel.expireEntries(0, 0); // Expires all entries.
+    await this._timestampModel.expireEntries(Infinity); // Expires all.
   }
 }
 

--- a/packages/workbox-expiration/CacheExpiration.mjs
+++ b/packages/workbox-expiration/CacheExpiration.mjs
@@ -91,7 +91,7 @@ class CacheExpiration {
     this._isRunning = true;
 
     const minTimestamp = this._maxAgeSeconds ?
-        Date.now() - this._maxAgeSeconds : undefined;
+        Date.now() - (this._maxAgeSeconds * 1000) : undefined;
 
     const urlsExpired = await this._timestampModel.expireEntries(
         minTimestamp, this._maxEntries);

--- a/packages/workbox-expiration/Plugin.mjs
+++ b/packages/workbox-expiration/Plugin.mjs
@@ -10,7 +10,8 @@ import {CacheExpiration} from './CacheExpiration.mjs';
 import {WorkboxError} from 'workbox-core/_private/WorkboxError.mjs';
 import {assert} from 'workbox-core/_private/assert.mjs';
 import {cacheNames} from 'workbox-core/_private/cacheNames.mjs';
-import {registerQuotaErrorCallback} from 'workbox-core/index.mjs';
+import {registerQuotaErrorCallback}
+  from 'workbox-core/registerQuotaErrorCallback.mjs';
 
 import './_version.mjs';
 
@@ -104,7 +105,7 @@ class Plugin {
 
   /**
    * A "lifecycle" callback that will be triggered automatically by the
-   * `workbox.runtimeCaching` handlers when a `Response` is about to be returned
+   * `workbox.strategies` handlers when a `Response` is about to be returned
    * from a [Cache](https://developer.mozilla.org/en-US/docs/Web/API/Cache) to
    * the handler. It allows the `Response` to be inspected for freshness and
    * prevents it from being used if the `Response`'s `Date` header value is
@@ -119,7 +120,7 @@ class Plugin {
    *
    * @private
    */
-  cachedResponseWillBeUsed({cacheName, cachedResponse}) {
+  cachedResponseWillBeUsed({event, request, cacheName, cachedResponse}) {
     if (!cachedResponse) {
       return null;
     }
@@ -130,6 +131,13 @@ class Plugin {
     // expired, it'll only be used once.
     const cacheExpiration = this._getCacheExpiration(cacheName);
     cacheExpiration.expireEntries();
+
+    // Update the metadata for the request URL to the current timestamp,
+    // but don't `await` it as we don't want to block the response.
+    const updateTimestampDone = cacheExpiration.updateTimestamp(request.url);
+    if (event) {
+      event.waitUntil(updateTimestampDone);
+    }
 
     return isFresh ? cachedResponse : null;
   }
@@ -155,7 +163,7 @@ class Plugin {
       return true;
     }
 
-    // If we have a valid headerTime, then our response is fresh iff the
+    // If we have a valid headerTime, then our response is fresh if the
     // headerTime plus maxAgeSeconds is greater than the current time.
     const now = Date.now();
     return dateHeaderTimestamp >= now - (this._maxAgeSeconds * 1000);
@@ -190,7 +198,7 @@ class Plugin {
 
   /**
    * A "lifecycle" callback that will be triggered automatically by the
-   * `workbox.runtimeCaching` handlers when an entry is added to a cache.
+   * `workbox.strategies` handlers when an entry is added to a cache.
    *
    * @param {Object} options
    * @param {string} options.cacheName Name of the cache that was updated.
@@ -224,7 +232,7 @@ class Plugin {
    * This is a helper method that performs two operations:
    *
    * - Deletes *all* the underlying Cache instances associated with this plugin
-   * instance, by calling caches.delete() on you behalf.
+   * instance, by calling caches.delete() on your behalf.
    * - Deletes the metadata from IndexedDB used to keep track of expiration
    * details for each Cache instance.
    *

--- a/test/workbox-expiration/integration/expiration-plugin.js
+++ b/test/workbox-expiration/integration/expiration-plugin.js
@@ -143,7 +143,7 @@ describe(`expiration.Plugin`, function() {
       'expiration-plugin-deletion',
     ]);
 
-    let existence = await runInSW('doesDbExist', 'expiration-plugin-deletion');
+    let existence = await runInSW('doesDbExist', 'workbox-expiration');
     expect(existence).to.be.true;
 
     error = await global.__workbox.webdriver.executeAsyncScript((cb) => {
@@ -156,11 +156,16 @@ describe(`expiration.Plugin`, function() {
       throw new Error(error);
     }
 
-    // After cleanup, there shouldn't be any cache keys or IndexedDB dbs.
+    // After cleanup, there shouldn't be any cache keys or IndexedDB entries
+    // with the cacheName 'expiration-plugin-deletion'.
     keys = await runInSW('cachesKeys');
     expect(keys).to.deep.equal([]);
 
-    existence = await runInSW('doesDbExist', 'expiration-plugin-deletion');
-    expect(existence).to.be.false;
+    const entries = (await runInSW('getObjectStoreEntries',
+        'workbox-expiration', 'cache-entries')).filter((entry) => {
+      return entry.cacheName === 'expiration-plugin-deletion';
+    });
+
+    expect(entries).to.deep.equal([]);
   });
 });

--- a/test/workbox-expiration/node/test-CacheExpiration.mjs
+++ b/test/workbox-expiration/node/test-CacheExpiration.mjs
@@ -231,7 +231,7 @@ describe(`[workbox-expiration] CacheExpiration`, function() {
   });
 
   describe(`isURLExpired()`, function() {
-    it(`should throw when called without maxAgeSeconds`, function() {
+    devOnly.it(`should throw when called without maxAgeSeconds`, function() {
       const expirationManager = new CacheExpiration('test-cache', {maxEntries: 1});
       return expectError(() => {
         return expirationManager.isURLExpired();

--- a/test/workbox-expiration/node/test-Plugin.mjs
+++ b/test/workbox-expiration/node/test-Plugin.mjs
@@ -110,7 +110,7 @@ describe(`[workbox-expiration] Plugin`, function() {
       const expirationManager = plugin._getCacheExpiration('test-cache');
       sandbox.spy(expirationManager, 'expireEntries');
 
-      expect(plugin.cachedResponseWillBeUsed({cacheName: 'test-cache', cachedResponse})).to.eql(cachedResponse);
+      expect(plugin.cachedResponseWillBeUsed({request: new Request('/'), cacheName: 'test-cache', cachedResponse})).to.eql(cachedResponse);
       expect(expirationManager.expireEntries.callCount).to.equal(1);
     });
 
@@ -130,7 +130,7 @@ describe(`[workbox-expiration] Plugin`, function() {
       const expirationManager = plugin._getCacheExpiration('test-cache');
       sandbox.spy(expirationManager, 'expireEntries');
 
-      expect(plugin.cachedResponseWillBeUsed({cacheName: 'test-cache', cachedResponse})).to.eql(null);
+      expect(plugin.cachedResponseWillBeUsed({request: new Request('/'), cacheName: 'test-cache', cachedResponse})).to.eql(null);
       expect(expirationManager.expireEntries.callCount).to.equal(1);
     });
 
@@ -141,6 +141,22 @@ describe(`[workbox-expiration] Plugin`, function() {
       sandbox.spy(expirationManager, 'expireEntries');
 
       expect(plugin.cachedResponseWillBeUsed({cacheName: 'test-cache', cachedResponse: null})).to.eql(null);
+    });
+
+    it(`should update the timestamp for the request URL`, function() {
+      const plugin = new Plugin({maxEntries: 10});
+
+      const expirationManager = plugin._getCacheExpiration('test-cache');
+      sandbox.spy(expirationManager, 'updateTimestamp');
+
+      plugin.cachedResponseWillBeUsed({
+        request: new Request('/one'),
+        cacheName: 'test-cache',
+        cachedResponse: new Response(''),
+      });
+
+      expect(expirationManager.updateTimestamp.callCount).to.equal(1);
+      expect(expirationManager.updateTimestamp.args[0][0]).to.equal('/one');
     });
   });
 

--- a/test/workbox-expiration/static/expiration-plugin/sw-deletion.js
+++ b/test/workbox-expiration/static/expiration-plugin/sw-deletion.js
@@ -21,7 +21,7 @@ const cacheName = 'expiration-plugin-deletion';
 
 workbox.routing.registerRoute(
     /.*.txt/,
-    workbox.strategies.cacheFirst({
+    new workbox.strategies.CacheFirst({
       cacheName,
       plugins: [
         expirationPlugin,

--- a/test/workbox-expiration/static/expiration-plugin/sw-max-age-seconds.js
+++ b/test/workbox-expiration/static/expiration-plugin/sw-max-age-seconds.js
@@ -14,7 +14,7 @@ importScripts('/infra/testing/comlink/sw-interface.js');
 
 workbox.routing.registerRoute(
     /.*.txt/,
-    workbox.strategies.cacheFirst({
+    new workbox.strategies.CacheFirst({
       cacheName: 'expiration-plugin-max-age-seconds',
       plugins: [
         new workbox.expiration.Plugin({

--- a/test/workbox-expiration/static/expiration-plugin/sw-max-entries.js
+++ b/test/workbox-expiration/static/expiration-plugin/sw-max-entries.js
@@ -14,7 +14,7 @@ importScripts('/infra/testing/comlink/sw-interface.js');
 
 workbox.routing.registerRoute(
     /.*.txt/,
-    workbox.strategies.cacheFirst({
+    new workbox.strategies.CacheFirst({
       cacheName: 'expiration-plugin-max-entries',
       plugins: [
         new workbox.expiration.Plugin({


### PR DESCRIPTION
R: @jeffposnick 

Fixes #1398, Fixes #1400. 

This PR updates the IDB data model used by `workbox-expiration`, switching it to from multiple databases (named the same as the cache name), to  a single database (named `workbox-expiration`) where the entries in the database have a `cacheName` property.

I've also updated how expiration happens to make it more efficient. Previously the entire contents of the object store would be read out, the purgeable entires were determined, and then in a second transaction those entries would be removed. In this PR I've moved the logic that determines what needs to be expired into `CacheTimestampsModel`, so it can all happen inside a single transaction.

Lastly, I had to update our IDB mocks yet again due to bugs I found when running tests. I've manually confirmed that the logic in this PR does work in Chrome, FF, and Safari's IDB implementations.