### PR TITLE
Re-enable Safari integration tests

### DIFF
--- a/gulp-tasks/test-integration.js
+++ b/gulp-tasks/test-integration.js
@@ -132,12 +132,11 @@ gulp.task('test-integration', async () => {
             await runIntegrationForBrowser(localBrowser);
           }
           break;
-        // Skipped due to webdriver incompatibility.
-        // case 'safari':
-        //   if (localBrowser.getReleaseName() === 'stable') {
-        //     await runIntegrationForBrowser(localBrowser);
-        //   }
-        //   break;
+        case 'safari':
+          if (localBrowser.getReleaseName() === 'stable') {
+            await runIntegrationForBrowser(localBrowser);
+          }
+          break;
         default:
           logHelper.warn(oneLine`
             Skipping integration tests for ${localBrowser.getPrettyName()}.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16321,9 +16321,9 @@
       }
     },
     "selenium-assistant": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/selenium-assistant/-/selenium-assistant-5.3.0.tgz",
-      "integrity": "sha512-EbWg8ZtLKesVWpt66bhBOQuFQ3SgojYjN6KIp72bvzuPZlzy5xlZNyJm1mzEehlVwicidp5vONjNusXMccZ48w==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/selenium-assistant/-/selenium-assistant-5.4.0.tgz",
+      "integrity": "sha512-morRewKNTbQ7wbDtXSb3a78OJ++lHXJFv7CY18v2HDjC2mXf/96WavCNJEAkVItVGEyPul/x8hIiLhAad5nZBQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-terser": "^3.0.0",
     "rollup-stream": "^1.24.1",
-    "selenium-assistant": "^5.3.0",
+    "selenium-assistant": "^5.4.0",
     "semver": "^5.5.1",
     "serve-index": "^1.9.1",
     "service-worker-mock": "^1.9.3",


### PR DESCRIPTION
R: @jeffposnick 

This PR updates `selenium-assistant` to version `5.4.0`, which includes [this fix](https://github.com/GoogleChromeLabs/selenium-assistant/pull/113) for Safari 12. With this fix we can now resume running our local integration tests against Safari before deployments.