### PR TITLE
Fix for copyLibraries

### DIFF
--- a/packages/workbox-build/src/entry-points/generate-sw.js
+++ b/packages/workbox-build/src/entry-points/generate-sw.js
@@ -59,7 +59,7 @@ async function generateSW(config) {
     // The Workbox library files should not be precached, since they're cached
     // automatically by virtue of being used with importScripts().
     options.globIgnores = [
-      `**/${workboxDirectoryName}/*.js*`,
+      `**/${workboxDirectoryName}/*.+(js|mjs)*`,
     ].concat(options.globIgnores || []);
 
     const workboxSWPkg = require(`workbox-sw/package.json`);

--- a/packages/workbox-build/src/lib/copy-workbox-libraries.js
+++ b/packages/workbox-build/src/lib/copy-workbox-libraries.js
@@ -48,8 +48,12 @@ module.exports = async (destDirectory) => {
   const librariesToCopy = Object.keys(thisPkg.dependencies).filter(
       (dependency) => dependency.startsWith(WORKBOX_PREFIX));
   for (const library of librariesToCopy) {
-    copyPromises.push(fse.copy(
-        path.join('packages', library, 'build'), workboxDirectoryPath));
+    const mainFilePath = require.resolve(library);
+    const srcPath = path.dirname(mainFilePath);
+
+    // fse.copy() copies all the files in a directory, not the directory itself.
+    // See https://github.com/jprichardson/node-fs-extra/blob/master/docs/copy.md#copysrc-dest-options-callback
+    copyPromises.push(fse.copy(srcPath, workboxDirectoryPath));
   }
 
   try {


### PR DESCRIPTION
R: @philipwalton 

Fixes #1901 by ensuring that we pick up the paths to copy via `require.resolve()`.