### PR TITLE
Add a cache listener message response

### DIFF
--- a/test/workbox-routing/node/test-Router.mjs
+++ b/test/workbox-routing/node/test-Router.mjs
@@ -194,12 +194,13 @@ describe(`[workbox-routing] Router`, function() {
       const event = new ExtendableMessageEvent('message', {
         data: {
           type: 'CACHE_URLS',
-          meta: 'workbox-window',
           payload: {
             urlsToCache: ['/one', '/two', '/three'],
           },
         },
       });
+      event.ports = [{postMessage: sinon.spy()}];
+
       sandbox.spy(router, 'handleRequest');
       self.dispatchEvent(event);
 
@@ -212,6 +213,7 @@ describe(`[workbox-routing] Router`, function() {
       expect(router.handleRequest.args[1][0].event).to.equal(event);
       expect(router.handleRequest.args[2][0].request.url).to.equal('/three');
       expect(router.handleRequest.args[2][0].event).to.equal(event);
+      expect(event.ports[0].postMessage.callCount).to.equal(1);
     });
 
     it(`should accept URL strings or request URL+requestInit tuples`, async function() {
@@ -225,7 +227,6 @@ describe(`[workbox-routing] Router`, function() {
       const event = new ExtendableMessageEvent('message', {
         data: {
           type: 'CACHE_URLS',
-          meta: 'workbox-window',
           payload: {
             urlsToCache: [
               '/one',


### PR DESCRIPTION
R: @jeffposnick @philipwalton

When writing the `workbow-window` documentation, I realized that the logic in `Router#addCacheListener` includes a check for `meta === 'workbox-window'`, but we shouldn't require developers to be use `workbox-window` to cache URLs (or ask them to set that meta value themselves, which wouldn't make sense).

This PR removes that check. It also adds a response to the message event if it contains a message channel (which `workbox-window` message do by default). This allows users to await successful caching of all URLs, similar to what you get with precaching.

Note: I did not add a message response in the event of an error, but I potentially could? WDYT?