### PR TITLE
Update log messages on redundant SW

### DIFF
--- a/packages/workbox-window/Workbox.mjs
+++ b/packages/workbox-window/Workbox.mjs
@@ -447,7 +447,9 @@ class Workbox extends EventTargetShim {
           }
           break;
         case 'redundant':
-          if (!isExternal) {
+          if (sw === this._compatibleControllingSW) {
+            logger.log('Previously controlling service worker now redundant!');
+          } else if (!isExternal) {
             logger.log('Registered service worker now redundant!');
           }
           break;


### PR DESCRIPTION
R: @jeffposnick 

While implementing `workbox-window` myself, I noticed that when upgrading a service worker, the message that was logged for the old service worker becoming redundant was a bit misleading. This change better handles both a registered and an originally-controlling service worker becoming redundant.