### PR TITLE
Update cache message wait until logic

### DIFF
--- a/packages/workbox-routing/Router.mjs
+++ b/packages/workbox-routing/Router.mjs
@@ -93,14 +93,16 @@ class Router {
           logger.debug(`Caching URLs from the window`, payload.urlsToCache);
         }
 
-        const requestPromises = payload.urlsToCache.map((entry) => {
+        const requestPromises = Promise.all(payload.urlsToCache.map((entry) => {
           if (typeof entry === 'string') {
             entry = [entry];
           }
 
           const request = new Request(...entry);
-          return this.handleRequest({request, event});
-        });
+          return this.handleRequest({request});
+        }));
+
+        event.waitUntil(requestPromises);
 
         // If a MessageChannel was used, reply to the message on success.
         if (event.ports) {

--- a/packages/workbox-strategies/CacheFirst.mjs
+++ b/packages/workbox-strategies/CacheFirst.mjs
@@ -182,7 +182,7 @@ class CacheFirst {
       } catch (error) {
         if (process.env.NODE_ENV !== 'production') {
           logger.warn(`Unable to ensure service worker stays alive when ` +
-            `updating cache for '${getFriendlyURL(event.request.url)}'.`);
+            `updating cache for '${getFriendlyURL(request.url)}'.`);
         }
       }
     }

--- a/packages/workbox-strategies/NetworkFirst.mjs
+++ b/packages/workbox-strategies/NetworkFirst.mjs
@@ -268,7 +268,7 @@ class NetworkFirst {
         } catch (err) {
           if (process.env.NODE_ENV !== 'production') {
             logger.warn(`Unable to ensure service worker stays alive when ` +
-              `updating cache for '${getFriendlyURL(event.request.url)}'.`);
+              `updating cache for '${getFriendlyURL(request.url)}'.`);
           }
         }
       }

--- a/packages/workbox-strategies/StaleWhileRevalidate.mjs
+++ b/packages/workbox-strategies/StaleWhileRevalidate.mjs
@@ -138,7 +138,7 @@ class StaleWhileRevalidate {
         } catch (error) {
           if (process.env.NODE_ENV !== 'production') {
             logger.warn(`Unable to ensure service worker stays alive when ` +
-              `updating cache for '${getFriendlyURL(event.request.url)}'.`);
+              `updating cache for '${getFriendlyURL(request.url)}'.`);
           }
         }
       }
@@ -200,7 +200,7 @@ class StaleWhileRevalidate {
       } catch (error) {
         if (process.env.NODE_ENV !== 'production') {
           logger.warn(`Unable to ensure service worker stays alive when ` +
-            `updating cache for '${getFriendlyURL(event.request.url)}'.`);
+            `updating cache for '${getFriendlyURL(request.url)}'.`);
         }
       }
     }

--- a/test/workbox-routing/node/test-Router.mjs
+++ b/test/workbox-routing/node/test-Router.mjs
@@ -200,6 +200,7 @@ describe(`[workbox-routing] Router`, function() {
         },
       });
       event.ports = [{postMessage: sinon.spy()}];
+      sinon.spy(event, 'waitUntil');
 
       sandbox.spy(router, 'handleRequest');
       self.dispatchEvent(event);
@@ -208,11 +209,10 @@ describe(`[workbox-routing] Router`, function() {
 
       expect(router.handleRequest.callCount).to.equal(3);
       expect(router.handleRequest.args[0][0].request.url).to.equal('/one');
-      expect(router.handleRequest.args[0][0].event).to.equal(event);
       expect(router.handleRequest.args[1][0].request.url).to.equal('/two');
-      expect(router.handleRequest.args[1][0].event).to.equal(event);
       expect(router.handleRequest.args[2][0].request.url).to.equal('/three');
-      expect(router.handleRequest.args[2][0].event).to.equal(event);
+      expect(event.waitUntil.callCount).to.equal(1);
+      expect(event.waitUntil.args[0][0]).to.be.instanceOf(Promise);
       expect(event.ports[0].postMessage.callCount).to.equal(1);
     });
 
@@ -243,12 +243,9 @@ describe(`[workbox-routing] Router`, function() {
 
       expect(router.handleRequest.callCount).to.equal(3);
       expect(router.handleRequest.args[0][0].request.url).to.equal('/one');
-      expect(router.handleRequest.args[0][0].event).to.equal(event);
       expect(router.handleRequest.args[1][0].request.url).to.equal('/two');
       expect(router.handleRequest.args[1][0].request.mode).to.equal('no-cors');
-      expect(router.handleRequest.args[1][0].event).to.equal(event);
       expect(router.handleRequest.args[2][0].request.url).to.equal('/three');
-      expect(router.handleRequest.args[2][0].event).to.equal(event);
     });
   });
 


### PR DESCRIPTION
R: @jeffposnick 

This PR fixes an issue with the cache listener logic (it was awaiting an array instead of a `Promise`), and it changes the code to call `event.waitUntil()` explicitly in the listener rather than passing the event to various handler functions.

This seems to be a safer approach since handler functions may incorrectly assume the event if a `FetchEvent` (as some of them already do, see the strategy changes).