### PR TITLE
Add a null check for cache listener message data

### DIFF
--- a/infra/testing/sw-env-mocks/ExtendableMessageEvent.js
+++ b/infra/testing/sw-env-mocks/ExtendableMessageEvent.js
@@ -12,7 +12,7 @@ const ExtendableEvent = require('./ExtendableEvent');
 // ExtendableMessageEvent
 // https://w3c.github.io/ServiceWorker/#extendablemessageevent-interface
 class ExtendableMessageEvent extends ExtendableEvent {
-  constructor(type, eventInitDict) {
+  constructor(type, eventInitDict = {}) {
     super(type, eventInitDict);
 
     this.data = eventInitDict.data || null;

--- a/packages/workbox-routing/Router.mjs
+++ b/packages/workbox-routing/Router.mjs
@@ -86,9 +86,9 @@ class Router {
    */
   addCacheListener() {
     self.addEventListener('message', async (event) => {
-      const {type, payload} = event.data;
+      if (event.data && event.data.type === 'CACHE_URLS') {
+        const {payload} = event.data;
 
-      if (type === 'CACHE_URLS') {
         if (process.env.NODE_ENV !== 'production') {
           logger.debug(`Caching URLs from the window`, payload.urlsToCache);
         }

--- a/test/workbox-routing/node/test-Router.mjs
+++ b/test/workbox-routing/node/test-Router.mjs
@@ -247,6 +247,23 @@ describe(`[workbox-routing] Router`, function() {
       expect(router.handleRequest.args[1][0].request.mode).to.equal('no-cors');
       expect(router.handleRequest.args[2][0].request.url).to.equal('/three');
     });
+
+    it(`should do nothing for non CACHE_URLS message types`, async function() {
+      const router = new Router();
+      const route = new Route(
+          () => true,
+          () => new Response(EXPECTED_RESPONSE_BODY));
+      router.registerRoute(route);
+      router.addCacheListener();
+
+      const event = new ExtendableMessageEvent('message');
+      sandbox.spy(router, 'handleRequest');
+
+      self.dispatchEvent(event);
+      await eventsDoneWaiting();
+
+      expect(router.handleRequest.callCount).to.equal(0);
+    });
   });
 
   describe(`unregisterRoute()`, function() {


### PR DESCRIPTION
R: @jeffposnick 

While testing out the latest Workbox RC I noticed that if you run `Router#addCacheListener()` and then `postMessage()` to the SW anything that's not an object, it'll fail.

This PR adds an extra check and test that should ensure non-`CACHE_URLS` messages don't cause errors.