### PR TITLE
Use ignoreSearch to fix precaching broadcast updates.

### DIFF
--- a/packages/workbox-core/_private/cacheWrapper.mjs
+++ b/packages/workbox-core/_private/cacheWrapper.mjs
@@ -19,7 +19,8 @@ import '../_version.mjs';
 /**
  * Wrapper around cache.put().
  *
- * Will call `cacheDidUpdate` on plugins if the cache was updated.
+ * Will call `cacheDidUpdate` on plugins if the cache was updated, using
+ * `matchOptions` when determining what the old entry is.
  *
  * @param {Object} options
  * @param {string} options.cacheName
@@ -27,6 +28,7 @@ import '../_version.mjs';
  * @param {Response} options.response
  * @param {Event} [options.event]
  * @param {Array<Object>} [options.plugins=[]]
+ * @param {Object} [options.matchOptions]
  *
  * @private
  * @memberof module:workbox-core
@@ -37,6 +39,7 @@ const putWrapper = async ({
   response,
   event,
   plugins = [],
+  matchOptions,
 } = {}) => {
   if (!response) {
     if (process.env.NODE_ENV !== 'production') {
@@ -75,7 +78,7 @@ const putWrapper = async ({
       plugins, pluginEvents.CACHE_DID_UPDATE);
 
   let oldResponse = updatePlugins.length > 0 ?
-    await matchWrapper({cacheName, request}) : null;
+    await matchWrapper({cacheName, request, matchOptions}) : null;
 
   if (process.env.NODE_ENV !== 'production') {
     logger.debug(`Updating the '${cacheName}' cache with a new Response for ` +

--- a/packages/workbox-precaching/PrecacheController.mjs
+++ b/packages/workbox-precaching/PrecacheController.mjs
@@ -207,6 +207,9 @@ class PrecacheController {
       request,
       response,
       cacheName: this._cacheName,
+      matchOptions: {
+        ignoreSearch: true,
+      },
     });
   }
 

--- a/test/workbox-core/node/_private/test-cacheWrapper.mjs
+++ b/test/workbox-core/node/_private/test-cacheWrapper.mjs
@@ -266,6 +266,30 @@ describe(`workbox-core cacheWrapper`, function() {
   });
 
   describe(`.match()`, function() {
+    it(`should use the matchOptions that were provided to put()`, async function() {
+      const matchOptions = {
+        ignoreSearch: true,
+      };
+      const cacheName = 'test-cache';
+
+      const testCache = await caches.open(cacheName);
+      sandbox.stub(global.caches, 'open').resolves(testCache);
+      const matchSpy = sandbox.spy(testCache, 'match');
+
+      await cacheWrapper.put({
+        cacheName,
+        matchOptions,
+        plugins: [{
+          cacheDidUpdate: () => {},
+        }],
+        request: new Request('/test/request'),
+        response: new Response('test'),
+      });
+
+      expect(matchSpy.calledOnce).to.be.true;
+      expect(matchSpy.args[0][1]).to.eql(matchOptions);
+    });
+
     it(`should call cachedResponseWillBeUsed`, async function() {
       const options = {};
       const matchCacheName = 'MATCH-CACHE-NAME';

--- a/test/workbox-precaching/node/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/test-PrecacheController.mjs
@@ -430,6 +430,9 @@ describe(`[workbox-precaching] PrecacheController`, function() {
 
       expect(fetchWrapper.fetch.args[0][0].plugins).to.equal(testPlugins);
       expect(cacheWrapper.put.args[0][0].plugins).to.equal(testPlugins);
+      expect(cacheWrapper.put.args[0][0].matchOptions).to.eql({
+        ignoreSearch: true,
+      });
 
       await precacheController.activate({
         plugins: testPlugins,


### PR DESCRIPTION
This will pass `ignoreSearch: true` through to the underlying call to `cache.match()` that attempts to find the previously precached entry with the same URL, in order to detect whether there's been an update. This is in turn used by the `broadcast-update` plugin.

This is necessary in v4 because the previously cached URL may have a `__WB_REVISION__` URL query parameter.

This should only affect cache wrapper usage from within the `PrecacheController`, as in all other uses, the `matchOptions` will remain `undefined`.

CC: @webmaxru