### PR TITLE
Call bind() to get the right this in precaching's plugins

### DIFF
--- a/packages/workbox-precaching/PrecacheController.mjs
+++ b/packages/workbox-precaching/PrecacheController.mjs
@@ -177,7 +177,7 @@ class PrecacheController {
     let cacheWillUpdateCallback;
     for (const plugin of (plugins || [])) {
       if ('cacheWillUpdate' in plugin) {
-        cacheWillUpdateCallback = plugin.cacheWillUpdate;
+        cacheWillUpdateCallback = plugin.cacheWillUpdate.bind(plugin);
       }
     }
 

--- a/test/workbox-precaching/node/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/test-PrecacheController.mjs
@@ -442,8 +442,6 @@ describe(`[workbox-precaching] PrecacheController`, function() {
     });
 
     it(`it should use the proper 'this' when calling a cacheWillUpdate plugin`, async function() {
-      sandbox.spy(cacheWrapper, 'put');
-
       const precacheController = new PrecacheController();
       const cacheList = [
         '/index.1234.html',
@@ -452,18 +450,17 @@ describe(`[workbox-precaching] PrecacheController`, function() {
 
       class TestPlugin {
         cacheWillUpdate({response}) {
-          expect(this).to.be.an.instanceof(TestPlugin);
           return response;
         }
       }
-
-      const plugins = [new TestPlugin()];
+      const pluginInstance = new TestPlugin();
+      const cacheWillUpdateSpy = sandbox.spy(pluginInstance, 'cacheWillUpdate');
 
       await precacheController.install({
-        plugins,
+        plugins: [pluginInstance],
       });
 
-      expect(cacheWrapper.put.args[0][0].plugins).to.equal(plugins);
+      expect(cacheWillUpdateSpy.thisValues[0]).to.be.an.instanceof(TestPlugin);
     });
 
     it(`it should set credentials: 'same-origin' on the precaching requests`, async function() {

--- a/test/workbox-precaching/node/test-PrecacheController.mjs
+++ b/test/workbox-precaching/node/test-PrecacheController.mjs
@@ -441,6 +441,31 @@ describe(`[workbox-precaching] PrecacheController`, function() {
       expect(cacheWrapper.put.args[1][0].plugins).to.equal(testPlugins);
     });
 
+    it(`it should use the proper 'this' when calling a cacheWillUpdate plugin`, async function() {
+      sandbox.spy(cacheWrapper, 'put');
+
+      const precacheController = new PrecacheController();
+      const cacheList = [
+        '/index.1234.html',
+      ];
+      precacheController.addToCacheList(cacheList);
+
+      class TestPlugin {
+        cacheWillUpdate({response}) {
+          expect(this).to.be.an.instanceof(TestPlugin);
+          return response;
+        }
+      }
+
+      const plugins = [new TestPlugin()];
+
+      await precacheController.install({
+        plugins,
+      });
+
+      expect(cacheWrapper.put.args[0][0].plugins).to.equal(plugins);
+    });
+
     it(`it should set credentials: 'same-origin' on the precaching requests`, async function() {
       sandbox.spy(fetchWrapper, 'fetch');
 

--- a/test/workbox-precaching/static/precache-and-update/sw-1.js
+++ b/test/workbox-precaching/static/precache-and-update/sw-1.js
@@ -6,9 +6,16 @@
   https://opensource.org/licenses/MIT.
 */
 
-importScripts('/__WORKBOX/buildFile/workbox-core');
-importScripts('/__WORKBOX/buildFile/workbox-precaching');
+importScripts('/__WORKBOX/buildFile/workbox-sw');
 importScripts('/infra/testing/comlink/sw-interface.js');
+
+workbox.setConfig({modulePathPrefix: '/__WORKBOX/buildFile/'});
+
+workbox.precaching.addPlugins([
+  new workbox.cacheableResponse.Plugin({
+    statuses: [200],
+  }),
+]);
 
 workbox.precaching.precache([
   {


### PR DESCRIPTION
R: @philipwalton 

Fixes #1927 by properly `bind()`ing to the `Plugin` instance.

This also adds to the integration test for `workbox-precaching` to ensure that the `addPlugins()` flow has better test coverage.