### PR TITLE
Explicitly check event.request in BroadcastUpdatePlugin

### DIFF
--- a/packages/workbox-broadcast-update/BroadcastCacheUpdate.mjs
+++ b/packages/workbox-broadcast-update/BroadcastCacheUpdate.mjs
@@ -98,7 +98,7 @@ class BroadcastCacheUpdate {
         // In the case of a navigation request, the requesting page will likely
         // not have loaded its JavaScript in time to recevied the update
         // notification, so we defer it until ready (or we timeout waiting).
-        if (event && event.request.mode === 'navigate') {
+        if (event && event.request && event.request.mode === 'navigate') {
           if (process.env.NODE_ENV !== 'production') {
             logger.debug(`Original request was a navigation request, ` +
                 `waiting for a ready message from the window`, event.request);


### PR DESCRIPTION
R: @philipwalton

Fixes #1931

Right now the plugin assumes that if `event` is set, then `event.request` will also be set. That isn't the case if `event` is an `InstallEvent`, which is what happens when the plugin is used along with `workbox-precaching`.