### PR TITLE
Resolve getSW correctly after an update is found

### DIFF
--- a/packages/workbox-window/Workbox.mjs
+++ b/packages/workbox-window/Workbox.mjs
@@ -220,7 +220,9 @@ class Workbox extends EventTargetShim {
    * @return {Promise<ServiceWorker>}
    */
   async getSW() {
-    return this._swDeferred.promise;
+    // If `this._sw` is set, resolve with that as we want `getSW()` to
+    // return the correct (new) service worker if an update is found.
+    return this._sw || this._swDeferred.promise;
   }
 
   /**


### PR DESCRIPTION
R: @jeffposnick 

Fixes #1939

The previous workbox-window logic would created a deferred for the instances "own" service worker and, once resolved, always return that service worker in the `getSW()` (and consequently the `messageSW()` method). But in the case of a SW already controlling the page and then an update being found for the same URL, this wouldn't be the desired behavior.

This PR updates the logic to handle this case.

/cc @Avocher
