### PR TITLE
Prevent onSync infinite loops

### DIFF
--- a/packages/workbox-google-analytics/initialize.mjs
+++ b/packages/workbox-google-analytics/initialize.mjs
@@ -94,7 +94,7 @@ const createOnSyncCallback = (config) => {
           logger.log(`Request for '${getFriendlyURL(url.href)}'` +
              `failed to replay, putting it back in the queue.`);
         }
-        return;
+        throw err;
       }
     }
     if (process.env.NODE_ENV !== 'production') {

--- a/test/workbox-google-analytics/integration/basic-example.js
+++ b/test/workbox-google-analytics/integration/basic-example.js
@@ -115,9 +115,11 @@ describe(`[workbox-google-analytics] Load and use Google Analytics`, function() 
     });
     expect(requests).to.have.lengthOf(0);
 
-    // Uncheck the "simulate offline" checkbox, which should let queued
-    // requests start to replay successfully.
+    // Uncheck the "simulate offline" checkbox and then trigger a sync.
     await simulateOfflineEl.click();
+    await driver.executeAsyncScript(messageSW, {
+      action: 'dispatch-sync-event',
+    });
 
     // Wait until all expected requests have replayed.
     await waitUntil(async () => {

--- a/test/workbox-google-analytics/static/basic-example/sw.js
+++ b/test/workbox-google-analytics/static/basic-example/sw.js
@@ -52,6 +52,20 @@ self.addEventListener('message', (evt) => {
     case 'get-spied-requests':
       evt.ports[0].postMessage(spiedRequests);
       break;
+    case 'dispatch-sync-event':
+    {
+      // Override `.waitUntil` so we can signal when the sync is done.
+      const originalSyncEventWaitUntil = SyncEvent.prototype.waitUntil;
+      SyncEvent.prototype.waitUntil = (promise) => {
+        return promise.then(() => evt.ports[0].postMessage(null));
+      };
+
+      self.dispatchEvent(new SyncEvent('sync', {
+        tag: 'workbox-background-sync:workbox-google-analytics',
+      }));
+      SyncEvent.prototype.waitUntil = originalSyncEventWaitUntil;
+      break;
+    }
   }
 });
 


### PR DESCRIPTION
R: @jeffposnick

Fixes #1937 

This PR updates the background sync replay logic in the following ways to help prevent infinite loops when adding new requests to the queue during a sync event replay:

- Adding a request to the queue only registers a sync tag if a `sync` event is not currently in progress.
- At the end of a successful sync event replay (i.e. the `waitUntil` promise did not reject) a sync tag is registered if new requests have been added to the queue.
- At the end of a failed sync event replay (i.e. the waitUntil promise rejected) no sync event is registered because the browser will automatically retry later (unless the `event.lastChance` property is true, in which case a new sync tag is registered

The PR also updates some of the `workbox-google-analytics` behavior to handle these new changes.
