### PR TITLE
Fix flakiness in background sync tests

### DIFF
--- a/packages/workbox-background-sync/lib/QueueStore.mjs
+++ b/packages/workbox-background-sync/lib/QueueStore.mjs
@@ -33,7 +33,7 @@ export class QueueStore {
   constructor(queueName) {
     this._queueName = queueName;
     this._db = new DBWrapper(DB_NAME, DB_VERSION, {
-      onupgradeneeded: (evt) => this._upgradeDb(evt),
+      onupgradeneeded: this._upgradeDb,
     });
   }
 


### PR DESCRIPTION
R: @jeffposnick 

This PR incorporates some of the helpers added in the `workbox-google-analytics` tests migrations, and it updates the use of IndexedDB to avoid flakiness in Firefox and Safari being blocked when deleting databases in a service worker.