### PR TITLE
Adds cacheNames.prefix/suffix

### DIFF
--- a/packages/workbox-core/_private/cacheNames.mjs
+++ b/packages/workbox-core/_private/cacheNames.mjs
@@ -37,7 +37,13 @@ export const cacheNames = {
   getPrecacheName: (userCacheName) => {
     return userCacheName || _createCacheName(_cacheNameDetails.precache);
   },
+  getPrefix: () => {
+    return _cacheNameDetails.prefix;
+  },
   getRuntimeName: (userCacheName) => {
     return userCacheName || _createCacheName(_cacheNameDetails.runtime);
+  },
+  getSuffix: () => {
+    return _cacheNameDetails.suffix;
   },
 };

--- a/packages/workbox-core/cacheNames.mjs
+++ b/packages/workbox-core/cacheNames.mjs
@@ -11,14 +11,17 @@ import './_version.mjs';
 
 
 /**
- * Get the current cache names used by Workbox.
+ * Get the current cache names and prefix/suffix used by Workbox.
  *
  * `cacheNames.precache` is used for precached assets,
  * `cacheNames.googleAnalytics` is used by `workbox-google-analytics` to
  * store `analytics.js`, and `cacheNames.runtime` is used for everything else.
  *
- * @return {Object} An object with `precache`, `runtime`, and
- *     `googleAnalytics` cache names.
+ * `cacheNames.prefix` can be used to retrieve just the current prefix value.
+ * `cacheNames.suffix` can be used to retrieve just the current suffix value.
+ *
+ * @return {Object} An object with `precache`, `runtime`, `prefix`, and
+ *     `googleAnalytics` properties.
  *
  * @alias workbox.core.cacheNames
  */
@@ -29,7 +32,13 @@ export const cacheNames = {
   get precache() {
     return _cacheNames.getPrecacheName();
   },
+  get prefix() {
+    return _cacheNames.getPrefix();
+  },
   get runtime() {
     return _cacheNames.getRuntimeName();
+  },
+  get suffix() {
+    return _cacheNames.getSuffix();
   },
 };

--- a/test/workbox-core/static/core-in-browser/sw.js
+++ b/test/workbox-core/static/core-in-browser/sw.js
@@ -19,6 +19,12 @@ if (!workbox.core.cacheNames.precache) {
 if (!workbox.core.cacheNames.runtime) {
   throw new Error(`cacheNames.runtime is not defined`);
 }
+if (!workbox.core.cacheNames.prefix) {
+  throw new Error(`cacheNames.prefix is not defined`);
+}
+if (!workbox.core.cacheNames.suffix) {
+  throw new Error(`cacheNames.suffix is not defined`);
+}
 
 if (!workbox.core.setCacheNameDetails) {
   throw new Error('setCacheNameDetails() is not defined.');

--- a/test/workbox-core/sw/test-cacheNames.mjs
+++ b/test/workbox-core/sw/test-cacheNames.mjs
@@ -28,6 +28,8 @@ describe(`cacheNames`, function() {
     // Scope be default is '/' from 'service-worker-mock'
     expect(cacheNames.precache).to.equal(`workbox-precache-v2-${self.registration.scope}`);
     expect(cacheNames.runtime).to.equal(`workbox-runtime-${self.registration.scope}`);
+    expect(cacheNames.prefix).to.equal('workbox');
+    expect(cacheNames.suffix).to.equal(self.registration.scope);
   });
 
   it('should allow customising the prefix', function() {
@@ -36,6 +38,7 @@ describe(`cacheNames`, function() {
     // Scope by default is '/' from 'service-worker-mock'
     expect(cacheNames.precache).to.equal(`test-prefix-precache-${self.registration.scope}`);
     expect(cacheNames.runtime).to.equal(`test-prefix-runtime-${self.registration.scope}`);
+    expect(cacheNames.prefix).to.equal('test-prefix');
   });
 
   it('should allow customising the suffix', function() {
@@ -44,6 +47,7 @@ describe(`cacheNames`, function() {
     // Scope be default is '/' from 'service-worker-mock'
     expect(cacheNames.precache).to.equal(`workbox-precache-test-suffix`);
     expect(cacheNames.runtime).to.equal(`workbox-runtime-test-suffix`);
+    expect(cacheNames.suffix).to.equal('test-suffix');
   });
 
 


### PR DESCRIPTION
R: @philipwalton
CC: @westonruter

Fixes #1998

The original request was just for the prefix, but I've added the suffix getter as well, since it presumably might be useful for the same reasons.