### PR TITLE
Ensure workbox is available before referencing it

### DIFF
--- a/packages/workbox-build/src/templates/sw-template.js
+++ b/packages/workbox-build/src/templates/sw-template.js
@@ -6,6 +6,8 @@
   https://opensource.org/licenses/MIT.
 */
 
+// All workbox references must come after the workboxSWImport/importScripts block
+
 module.exports = `/**
  * Welcome to your Workbox-powered service worker!
  *
@@ -19,8 +21,6 @@ module.exports = `/**
  * See https://goo.gl/2aRDsh
  */
 
-<% if (navigationPreload) { %>workbox.navigationPreload.enable();<% } %>
-
 <% if (workboxSWImport) { %>
 importScripts(<%= JSON.stringify(workboxSWImport) %>);
 <% if (modulePathPrefix) { %>workbox.setConfig({modulePathPrefix: <%= JSON.stringify(modulePathPrefix) %>});<% } %>
@@ -30,6 +30,8 @@ importScripts(
   <%= importScripts.map(JSON.stringify).join(',\\n  ') %>
 );
 <% } %>
+
+<% if (navigationPreload) { %>workbox.navigationPreload.enable();<% } %>
 
 <% if (cacheId) { %>workbox.core.setCacheNameDetails({prefix: <%= JSON.stringify(cacheId) %>});<% } %>
 


### PR DESCRIPTION
R: @jeffposnick @philipwalton

Fixes #1915 / #1981 

Sorry to follow up with a PR immediately after the publish, but it turns out order in the template does matter, as otherwise `workbox` might not be defined yet (total facepalm on my part)! I feel like I probably missed implementing a test somewhere in the initial pass but I'm not sure where that should've gone, so I at least added a warning comment for now. Let me know if there's something better I could add.