### PR TITLE
Remove extra escaping in Windows CLI test

### DIFF
--- a/test/workbox-cli/node/app.js
+++ b/test/workbox-cli/node/app.js
@@ -86,9 +86,7 @@ describe(`[workbox-cli] app.js`, function() {
               loggerErrorStub.alwaysCalledWithExactly(errors['invalid-common-js-module'])
           ).to.be.true;
 
-          // Windows will log with backslashes that need escaping
-          const escapedPath = INVALID_CONFIG_FILE.split('\\').join('\\\\');
-          expect(error.message).to.have.string(escapedPath);
+          expect(error.message).to.have.string(INVALID_CONFIG_FILE);
         }
       });
     }


### PR DESCRIPTION
R: @philipwalton 

It's no longer needed now that we're not using `esm`.