### PR TITLE
Ensure navigation requests queue as some-origin

### DIFF
--- a/packages/workbox-background-sync/lib/StorableRequest.mjs
+++ b/packages/workbox-background-sync/lib/StorableRequest.mjs
@@ -94,6 +94,12 @@ class StorableRequest {
       });
     }
 
+    // If the request's mode is `navigate`, convert it to `same-origin` since
+    // navigation requests can't be constructed via script.
+    if (requestData.mode === 'navigate') {
+      requestData.mode = 'same-origin';
+    }
+
     this._requestData = requestData;
   }
 

--- a/test/workbox-background-sync/sw/lib/test-StorableRequest.mjs
+++ b/test/workbox-background-sync/sw/lib/test-StorableRequest.mjs
@@ -10,6 +10,16 @@ import {StorableRequest} from 'workbox-background-sync/lib/StorableRequest.mjs';
 
 
 describe(`StorableRequest`, function() {
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(function() {
+    sandbox.restore();
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
   describe(`static fromRequest`, function() {
     it(`should convert a Request to a StorableRequest instance`, async function() {
       const request = new Request('/foo', {
@@ -49,6 +59,18 @@ describe(`StorableRequest`, function() {
 
       const storableRequest = new StorableRequest(requestData);
       expect(storableRequest._requestData).to.deep.equal(requestData);
+    });
+
+    it(`handles navigation requests by converting them to same-origin`, async function() {
+      const requestData = {
+        url: '/api',
+        method: 'POST',
+        body: '{"json":"data"}',
+        mode: 'navigate',
+      };
+
+      const storableRequest = new StorableRequest(requestData);
+      expect(storableRequest._requestData.mode).to.equal('same-origin');
     });
 
     it(`throws if not given a requestData object`, function() {


### PR DESCRIPTION
R: @jeffposnick 

Fixes #1955

PR updates the `StorableRequest` object to ensure any instances created from navigation requests will get serialized as `same-origin` requests since navigation requests cannot be script-constructed.