### PR TITLE
Fixes opts passed to the BCU Plugin.

### DIFF
--- a/packages/workbox-build/src/lib/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/runtime-caching-converter.js
@@ -81,11 +81,8 @@ function getOptionsString(options = {}) {
 
       case 'broadcastUpdate': {
         const channelName = pluginConfig.channelName;
-        pluginCode = `new ${pluginString}(${JSON.stringify(channelName)}`;
-        if ('options' in pluginConfig) {
-          pluginCode += `, ${stringifyWithoutComments(pluginConfig.options)}`;
-        }
-        pluginCode += `)`;
+        const opts = Object.assign({channelName}, pluginConfig.options);
+        pluginCode = `new ${pluginString}(${stringifyWithoutComments(opts)})`;
 
         break;
       }

--- a/test/workbox-build/node/lib/runtime-caching-converter.js
+++ b/test/workbox-build/node/lib/runtime-caching-converter.js
@@ -115,15 +115,14 @@ function validate(runtimeCachingOptions, convertedOptions) {
 
       if (options.broadcastUpdate) {
         if ('options' in options.broadcastUpdate) {
-          expect(
-              globalScope.workbox.broadcastUpdate.Plugin.calledWith(
-                  options.broadcastUpdate.channelName, options.broadcastUpdate.options)
-          ).to.be.true;
+          const expectedOptions = Object.assign(
+              {channelName: options.broadcastUpdate.channelName},
+              options.broadcastUpdate.options);
+          expect(globalScope.workbox.broadcastUpdate.Plugin.calledWith(expectedOptions))
+              .to.be.true;
         } else {
-          expect(
-              globalScope.workbox.broadcastUpdate.Plugin.calledWith(
-                  options.broadcastUpdate.channelName)
-          ).to.be.true;
+          expect(globalScope.workbox.broadcastUpdate.Plugin.calledWith(
+              {channelName: options.broadcastUpdate.channelName})).to.be.true;
         }
       }
     }


### PR DESCRIPTION
Fixes #2016, by accounting for the fact that the broadcast update plugin is now passed the channel name as a named parameter in the options object.