### PR TITLE
Add a size method to the Queue class

### DIFF
--- a/packages/workbox-background-sync/Queue.mjs
+++ b/packages/workbox-background-sync/Queue.mjs
@@ -172,7 +172,7 @@ class Queue {
     const allEntries = await this._queueStore.getAll();
     const now = Date.now();
 
-    const unexpirtedEntries = [];
+    const unexpiredEntries = [];
     for (const entry of allEntries) {
       // Ignore requests older than maxRetentionTime. Call this function
       // recursively until an unexpired request is found.
@@ -180,11 +180,11 @@ class Queue {
       if (now - entry.timestamp > maxRetentionTimeInMs) {
         await this._queueStore.deleteEntry(entry.id);
       } else {
-        unexpirtedEntries.push(convertEntry(entry));
+        unexpiredEntries.push(convertEntry(entry));
       }
     }
 
-    return unexpirtedEntries;
+    return unexpiredEntries;
   }
 
 

--- a/packages/workbox-background-sync/Queue.mjs
+++ b/packages/workbox-background-sync/Queue.mjs
@@ -163,6 +163,32 @@ class Queue {
   }
 
   /**
+   * Returns all the entries that have not expired (per `maxRetentionTime`).
+   * Any expired entries are removed from the queue.
+   *
+   * @return {Promise<Array<Object>>}
+   */
+  async getAll() {
+    const allEntries = await this._queueStore.getAll();
+    const now = Date.now();
+
+    const unexpirtedEntries = [];
+    for (const entry of allEntries) {
+      // Ignore requests older than maxRetentionTime. Call this function
+      // recursively until an unexpired request is found.
+      const maxRetentionTimeInMs = this._maxRetentionTime * 60 * 1000;
+      if (now - entry.timestamp > maxRetentionTimeInMs) {
+        await this._queueStore.deleteEntry(entry.id);
+      } else {
+        unexpirtedEntries.push(convertEntry(entry));
+      }
+    }
+
+    return unexpirtedEntries;
+  }
+
+
+  /**
    * Adds the entry to the QueueStore and registers for a sync event.
    *
    * @param {Object} entry
@@ -204,7 +230,7 @@ class Queue {
 
   /**
    * Removes and returns the first or last (depending on `operation`) entry
-   * form the QueueStore that's not older than the `maxRetentionTime`.
+   * from the QueueStore that's not older than the `maxRetentionTime`.
    *
    * @param {string} operation ('pop' or 'shift')
    * @return {Object|undefined}
@@ -214,7 +240,7 @@ class Queue {
     const now = Date.now();
     const entry = await this._queueStore[`${operation}Entry`]();
 
-    if (entry ) {
+    if (entry) {
       // Ignore requests older than maxRetentionTime. Call this function
       // recursively until an unexpired request is found.
       const maxRetentionTimeInMs = this._maxRetentionTime * 60 * 1000;
@@ -222,10 +248,7 @@ class Queue {
         return this._removeRequest(operation);
       }
 
-      entry.request = new StorableRequest(entry.requestData).toRequest();
-      delete entry.requestData;
-
-      return entry;
+      return convertEntry(entry);
     }
   }
 
@@ -346,5 +369,26 @@ class Queue {
     return queueNames;
   }
 }
+
+
+/**
+ * Converts a QueueStore entry into the format exposed by Queue. This entails
+ * converting the request data into a real request and omitting the `id` and
+ * `queueName` properties.
+ *
+ * @param {Object} queueStoreEntry
+ * @return {Object}
+ * @private
+ */
+const convertEntry = (queueStoreEntry) => {
+  const queueEntry = {
+    request: new StorableRequest(queueStoreEntry.requestData).toRequest(),
+    timestamp: queueStoreEntry.timestamp,
+  };
+  if (queueStoreEntry.metadata) {
+    queueEntry.metadata = queueStoreEntry.metadata;
+  }
+  return queueEntry;
+};
 
 export {Queue};

--- a/packages/workbox-expiration/Plugin.mjs
+++ b/packages/workbox-expiration/Plugin.mjs
@@ -31,7 +31,6 @@ import './_version.mjs';
  * used immediately.
  *
  * When using `maxEntries`, the entry least-recently requested will be removed from the cache first.
- * 
  *
  * @memberof workbox.expiration
  */

--- a/test/workbox-background-sync/sw/lib/test-QueueStore.mjs
+++ b/test/workbox-background-sync/sw/lib/test-QueueStore.mjs
@@ -419,9 +419,8 @@ describe(`QueueStore`, function() {
       expect(sr2a.requestData).to.deep.equal(sr2.toObject());
       expect(sr2a.timestamp).to.equal(2000);
       expect(sr2a.metadata).to.deep.equal({name: 'meta2'});
-      // It should not return the ID or queue name.
-      expect(sr2a.id).to.be.undefined;
-      expect(sr2a.queueName).to.be.undefined;
+      expect(sr2a.id).to.equal(firstId + 1);
+      expect(sr2a.queueName).to.equal('b');
 
       entries = await db.getAll('requests');
       expect(entries).to.have.lengthOf(4);
@@ -434,9 +433,8 @@ describe(`QueueStore`, function() {
       expect(sr1a.requestData).to.deep.equal(sr1.toObject());
       expect(sr1a.timestamp).to.equal(1000);
       expect(sr1a.metadata).to.deep.equal({name: 'meta1'});
-      // It should not return the ID or queue name.
-      expect(sr1a.id).to.be.undefined;
-      expect(sr1a.queueName).to.be.undefined;
+      expect(sr1a.id).to.equal(firstId);
+      expect(sr1a.queueName).to.equal('a');
 
       entries = await db.getAll('requests');
       expect(entries).to.have.lengthOf(3);
@@ -494,9 +492,8 @@ describe(`QueueStore`, function() {
       expect(sr4a.requestData).to.deep.equal(sr4.toObject());
       expect(sr4a.timestamp).to.equal(4000);
       expect(sr4a.metadata).to.deep.equal({name: 'meta4'});
-      // It should not return the ID or queue name.
-      expect(sr4a.id).to.be.undefined;
-      expect(sr4a.queueName).to.be.undefined;
+      expect(sr4a.id).to.equal(firstId + 3);
+      expect(sr4a.queueName).to.equal('b');
 
       entries = await db.getAll('requests');
       expect(entries).to.have.lengthOf(4);
@@ -517,15 +514,152 @@ describe(`QueueStore`, function() {
       expect(sr5a.requestData).to.deep.equal(sr5.toObject());
       expect(sr5a.timestamp).to.equal(5000);
       expect(sr5a.metadata).to.deep.equal({name: 'meta5'});
-      // It should not return the ID or queue name.
-      expect(sr5a.id).to.be.undefined;
-      expect(sr5a.queueName).to.be.undefined;
+      expect(sr5a.id).to.equal(firstId + 4);
+      expect(sr5a.queueName).to.equal('a');
 
       entries = await db.getAll('requests');
       expect(entries).to.have.lengthOf(3);
       expect(entries[0].id).to.equal(firstId);
       expect(entries[1].id).to.equal(firstId + 1);
       expect(entries[2].id).to.equal(firstId + 2);
+    });
+  });
+
+  describe(`getAll`, function() {
+    it(`should return all entries in IDB with the right queue name`, async function() {
+      const queueStore1 = new QueueStore('a');
+      const queueStore2 = new QueueStore('b');
+
+      const sr1 = await StorableRequest.fromRequest(new Request('/one'));
+      const sr2 = await StorableRequest.fromRequest(new Request('/two'));
+      const sr3 = await StorableRequest.fromRequest(new Request('/three'));
+      const sr4 = await StorableRequest.fromRequest(new Request('/four'));
+      const sr5 = await StorableRequest.fromRequest(new Request('/five'));
+
+      await queueStore1.pushEntry({
+        requestData: sr1.toObject(),
+        timestamp: 1000,
+        metadata: {name: 'meta1'},
+      });
+
+      let entries = await db.getAll('requests');
+      const firstId = entries[0].id;
+
+      await queueStore2.pushEntry({
+        requestData: sr2.toObject(),
+        timestamp: 2000,
+        metadata: {name: 'meta2'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr3.toObject(),
+        timestamp: 3000,
+        metadata: {name: 'meta3'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr4.toObject(),
+        timestamp: 4000,
+        metadata: {name: 'meta4'},
+      });
+      await queueStore1.pushEntry({
+        requestData: sr5.toObject(),
+        timestamp: 5000,
+        metadata: {name: 'meta5'},
+      });
+
+      expect(await queueStore1.getAll()).to.deep.equal([
+        {
+          id: firstId,
+          queueName: 'a',
+          requestData: sr1.toObject(),
+          timestamp: 1000,
+          metadata: {name: 'meta1'},
+        },
+        {
+          id: firstId + 4,
+          queueName: 'a',
+          requestData: sr5.toObject(),
+          timestamp: 5000,
+          metadata: {name: 'meta5'},
+        },
+      ]);
+
+      expect(await queueStore2.getAll()).to.deep.equal([
+        {
+          id: firstId + 1,
+          queueName: 'b',
+          requestData: sr2.toObject(),
+          timestamp: 2000,
+          metadata: {name: 'meta2'},
+        },
+        {
+          id: firstId + 2,
+          queueName: 'b',
+          requestData: sr3.toObject(),
+          timestamp: 3000,
+          metadata: {name: 'meta3'},
+        },
+        {
+          id: firstId + 3,
+          queueName: 'b',
+          requestData: sr4.toObject(),
+          timestamp: 4000,
+          metadata: {name: 'meta4'},
+        },
+      ]);
+
+      await db.clear('requests');
+
+      expect(await queueStore1.getAll()).to.deep.equal([]);
+      expect(await queueStore2.getAll()).to.deep.equal([]);
+    });
+  });
+
+  describe(`delete`, function() {
+    it(`should delete an entry for the given ID`, async function() {
+      const queueStore = new QueueStore('a');
+
+      const sr1 = await StorableRequest.fromRequest(new Request('/one'));
+      const sr2 = await StorableRequest.fromRequest(new Request('/two'));
+      const sr3 = await StorableRequest.fromRequest(new Request('/three'));
+
+      await queueStore.pushEntry({
+        requestData: sr1.toObject(),
+        timestamp: 1000,
+        metadata: {name: 'meta1'},
+      });
+
+      let entries = await db.getAll('requests');
+      const firstId = entries[0].id;
+
+      await queueStore.pushEntry({
+        requestData: sr2.toObject(),
+        timestamp: 2000,
+        metadata: {name: 'meta2'},
+      });
+      await queueStore.pushEntry({
+        requestData: sr3.toObject(),
+        timestamp: 3000,
+        metadata: {name: 'meta3'},
+      });
+
+      await queueStore.deleteEntry(firstId + 1);
+
+      expect(await db.getAll('requests')).to.deep.equal([
+        {
+          id: firstId,
+          queueName: 'a',
+          requestData: sr1.toObject(),
+          timestamp: 1000,
+          metadata: {name: 'meta1'},
+        },
+        {
+          id: firstId + 2,
+          queueName: 'a',
+          requestData: sr3.toObject(),
+          timestamp: 3000,
+          metadata: {name: 'meta3'},
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
R: @jeffposnick

Fixes #2011

This PR adds a method to count the number of entries in the queue store for the given queue name.

***

**UPDATE:** Given https://github.com/GoogleChrome/workbox/issues/2011#issuecomment-480731157 and the fact that the initial changes in the PR didn't consider that a simple IndexedDB count operation wouldn't account for entries that have expired, I decided to just add a single `getAll()` method that returns an array of unexpired entries. Users who need a count can access that array's length.


