### PR TITLE
feat: output precache-manifest directly inside the service-worker.js

### DIFF
--- a/packages/workbox-build/src/entry-points/options/generate-sw-string-schema.js
+++ b/packages/workbox-build/src/entry-points/options/generate-sw-string-schema.js
@@ -14,6 +14,7 @@ const commonGenerateSchema = require('./common-generate-schema');
 module.exports = commonGenerateSchema.keys({
   globDirectory: joi.string(),
   importScripts: joi.array().items(joi.string()).required(),
+  manifestEntries: joi.array().items(joi.object()).optional(),
   modulePathPrefix: joi.string(),
   workboxSWImport: joi.string(),
 });

--- a/packages/workbox-build/src/templates/sw-template.js
+++ b/packages/workbox-build/src/templates/sw-template.js
@@ -25,7 +25,7 @@ module.exports = `/**
 importScripts(<%= JSON.stringify(workboxSWImport) %>);
 <% if (modulePathPrefix) { %>workbox.setConfig({modulePathPrefix: <%= JSON.stringify(modulePathPrefix) %>});<% } %>
 <% } %>
-<% if (importScripts) { %>
+<% if ((importScripts || []).length) { %>
 importScripts(
   <%= importScripts.map(JSON.stringify).join(',\\n  ') %>
 );


### PR DESCRIPTION
R: @jeffposnick @philipwalton

fix #1774

lt lets us choose if we want one and separated.
