### PR TITLE
Bypass local Babel config files in workbox-build's bundling step

### DIFF
--- a/packages/workbox-build/src/lib/bundle.js
+++ b/packages/workbox-build/src/lib/bundle.js
@@ -34,6 +34,10 @@ module.exports = async ({
     resolve(),
     replace({'process.env.NODE_ENV': JSON.stringify(mode)}),
     babel({
+      // Disable the logic that checks for local Babel config files:
+      // https://github.com/GoogleChrome/workbox/issues/2111
+      babelrc: false,
+      configFile: false,
       presets: [[presetEnv, {
         targets: {
           browsers: babelPresetEnvTargets,

--- a/test/workbox-build/node/lib/bundle.js
+++ b/test/workbox-build/node/lib/bundle.js
@@ -68,6 +68,8 @@ describe(`[workbox-build] lib/bundle.js`, function() {
     });
 
     expect(stubs['rollup-plugin-babel'].args).to.eql([[{
+      babelrc: false,
+      configFile: false,
       presets: [[stubs['@babel/preset-env'], {
         targets: {
           browsers: babelPresetEnvTargets,


### PR DESCRIPTION
R: @philipwalton

Fixes #2111

Thanks for pointing this out, @kaykayehnn! This PR seems to address the issue in the test case you provided.