### PR TITLE
Add missing isUpdate to the controlling evnet

### DIFF
--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -480,7 +480,11 @@ class Workbox extends WorkboxEventTarget {
   _onControllerChange = (originalEvent: Event) => {
     const sw = this._sw;
     if (sw === navigator.serviceWorker.controller) {
-      this.dispatchEvent(new WorkboxEvent('controlling', {sw, originalEvent}));
+      this.dispatchEvent(new WorkboxEvent('controlling', {
+        sw,
+        originalEvent,
+        isUpdate: this._isUpdate,
+      }));
       if (process.env.NODE_ENV !== 'production') {
         logger.log('Registered service worker now controlling this page.');
       }

--- a/test/workbox-window/window/test-Workbox.mjs
+++ b/test/workbox-window/window/test-Workbox.mjs
@@ -719,6 +719,7 @@ describe(`[workbox-window] Workbox`, function() {
           target: wb1,
           sw: await wb1.getSW(),
           originalEvent: {type: 'controllerchange'},
+          isUpdate: true,
         });
 
         expect(controlling2Spy.callCount).to.equal(0);


### PR DESCRIPTION
R: @jeffposnick

Fixes #2101

Adds the missing `isUpdate` property to the `controlling` event in `workbox-window`.
