### PR TITLE
Use a .js extension when generating a default swDest

### DIFF
--- a/packages/workbox-build/src/entry-points/options/webpack-inject-manifest-schema.js
+++ b/packages/workbox-build/src/entry-points/options/webpack-inject-manifest-schema.js
@@ -14,7 +14,11 @@ const defaults = require('./defaults');
 const webpackCommon = require('./webpack-common');
 
 // See https://github.com/hapijs/joi/blob/v16.0.0-rc2/API.md#anydefaultvalue-description
-const swSrcBasename = (context) => upath.basename(context.swSrc);
+const swSrcBasename = (context) => {
+  const {name} = upath.parse(context.swSrc);
+  // Always use the .js extension when generating a default filename.
+  return name + '.js';
+};
 swSrcBasename.description = 'derived from the swSrc file name';
 
 module.exports = baseSchema.keys(Object.assign({

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -1140,4 +1140,37 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       });
     });
   });
+
+  describe(`[workbox-webpack-plugin] TypeScript compilation`, function() {
+    it(`should rename a swSrc with a .ts extension to .js`, function(done) {
+      const outputDir = tempy.directory();
+      const config = {
+        mode: 'production',
+        entry: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        output: {
+          filename: '[name].[hash:6].js',
+          path: outputDir,
+        },
+        plugins: [
+          new InjectManifest({
+            swSrc: path.join(__dirname, '..', 'static', 'sw.ts'),
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError, stats) => {
+        try {
+          webpackBuildCheck(webpackError, stats);
+
+          const files = await globby('*', {cwd: outputDir});
+          expect(files).to.contain('sw.js');
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+  });
 });

--- a/test/workbox-webpack-plugin/static/sw.ts
+++ b/test/workbox-webpack-plugin/static/sw.ts
@@ -1,0 +1,10 @@
+/*
+  Copyright 2019 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+// At the moment, this is just used to test the extension renaming.
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST, {});


### PR DESCRIPTION
R: @philipwalton

Our webpack plugin will generate a default output service worker filename (`swDest`) using the basename of the required `swSrc` parameter when `swDest` isn't explicitly provided.

If the `swSrc` file is TypeScript, then chances are it has a `.ts` extension, and we don't want that to be used as the extension in `swDest`. (Ideally, the developer will have set up `ts-loader` to automatically compile the TypeScript file in their build process, so the output will be JavaScript.)

This change forces the `.js` file extension whenever we're calculating a default `swDest` value.