### PR TITLE
Make FetchListenerOptions optional

### DIFF
--- a/packages/workbox-precaching/src/addRoute.ts
+++ b/packages/workbox-precaching/src/addRoute.ts
@@ -22,7 +22,7 @@ let listenerAdded = false;
  * responded to, allowing the event to fall through to other `fetch` event
  * listeners.
  *
- * @param {Object} options
+ * @param {Object} [options]
  * @param {string} [options.directoryIndex=index.html] The `directoryIndex` will
  * check cache entries for a URLs ending with '/' to see if there is a hit when
  * appending the `directoryIndex` value.
@@ -32,11 +32,11 @@ let listenerAdded = false;
  * check the cache for the URL with a `.html` added to the end of the end.
  * @param {workbox.precaching~urlManipulation} [options.urlManipulation]
  * This is a function that should take a URL and return an array of
- * alternative URL's that should be checked for precache matches.
+ * alternative URLs that should be checked for precache matches.
  *
  * @alias workbox.precaching.addRoute
  */
-export const addRoute = (options: FetchListenerOptions) => {
+export const addRoute = (options?: FetchListenerOptions) => {
   if (!listenerAdded) {
     addFetchListener(options);
     listenerAdded = true;

--- a/packages/workbox-precaching/src/precacheAndRoute.ts
+++ b/packages/workbox-precaching/src/precacheAndRoute.ts
@@ -22,13 +22,13 @@ import './_version.js';
  * [addRoute()]{@link module:workbox-precaching.addRoute} in a single call.
  *
  * @param {Array<Object|string>} entries Array of entries to precache.
- * @param {Object} options See
+ * @param {Object} [options] See
  * [addRoute() options]{@link module:workbox-precaching.addRoute}.
  *
  * @alias workbox.precaching.precacheAndRoute
  */
 export const precacheAndRoute =
-    (entries: Array<PrecacheEntry|string>, options: FetchListenerOptions) => {
+    (entries: Array<PrecacheEntry|string>, options?: FetchListenerOptions) => {
   precache(entries);
   addRoute(options);
 };

--- a/packages/workbox-precaching/src/utils/addFetchListener.ts
+++ b/packages/workbox-precaching/src/utils/addFetchListener.ts
@@ -36,7 +36,7 @@ export interface FetchListenerOptions {
  * of tests.
  *
  * @private
- * @param {Object} options
+ * @param {Object} [options]
  * @param {string} [options.directoryIndex=index.html] The `directoryIndex` will
  * check cache entries for a URLs ending with '/' to see if there is a hit when
  * appending the `directoryIndex` value.
@@ -46,7 +46,7 @@ export interface FetchListenerOptions {
  * check the cache for the URL with a `.html` added to the end of the end.
  * @param {workbox.precaching~urlManipulation} [options.urlManipulation]
  * This is a function that should take a URL and return an array of
- * alternative URL's that should be checked for precache matches.
+ * alternative URLs that should be checked for precache matches.
  */
 export const addFetchListener = ({
   ignoreURLParametersMatching = [/^utm_/],


### PR DESCRIPTION
R: @philipwalton

The `FetchListenerOptions` parameter to `precacheAndRoute()` should be marked as optional. If it's not set, it will end up being set to some defaults by https://github.com/GoogleChrome/workbox/blob/b32a0823c942d49567d3f2bd49c0a92815476910/packages/workbox-precaching/src/utils/addFetchListener.ts#L51-L56