### PR TITLE
Define WorkboxGlobalScope in workbox-precaching

### DIFF
--- a/packages/workbox-precaching/src/precache.ts
+++ b/packages/workbox-precaching/src/precache.ts
@@ -12,6 +12,9 @@ import {precachePlugins} from './utils/precachePlugins.js';
 import {PrecacheEntry} from './_types.js';
 import './_version.js';
 
+export interface WorkboxGlobalScope extends ServiceWorkerGlobalScope {
+  '__WB_MANIFEST': Array<PrecacheEntry|string>;
+}
 
 const installListener = (event: ExtendableEvent) => {
   const precacheController = getOrCreatePrecacheController();

--- a/packages/workbox-precaching/src/precache.ts
+++ b/packages/workbox-precaching/src/precache.ts
@@ -13,8 +13,8 @@ import {PrecacheEntry} from './_types.js';
 import './_version.js';
 
 declare global {
-  interface ServiceWorkerGlobalScope {
-    '__WB_MANIFEST': Array<PrecacheEntry|string>;
+  interface WorkerGlobalScope {
+    __WB_MANIFEST: Array<PrecacheEntry|string>;
   }
 }
 

--- a/packages/workbox-precaching/src/precache.ts
+++ b/packages/workbox-precaching/src/precache.ts
@@ -12,8 +12,10 @@ import {precachePlugins} from './utils/precachePlugins.js';
 import {PrecacheEntry} from './_types.js';
 import './_version.js';
 
-export interface WorkboxGlobalScope extends ServiceWorkerGlobalScope {
-  '__WB_MANIFEST': Array<PrecacheEntry|string>;
+declare global {
+  interface ServiceWorkerGlobalScope {
+    '__WB_MANIFEST': Array<PrecacheEntry|string>;
+  }
 }
 
 const installListener = (event: ExtendableEvent) => {

--- a/packages/workbox-precaching/src/precacheAndRoute.ts
+++ b/packages/workbox-precaching/src/precacheAndRoute.ts
@@ -13,8 +13,8 @@ import {PrecacheEntry} from './_types.js';
 import './_version.js';
 
 declare global {
-  interface ServiceWorkerGlobalScope {
-    '__WB_MANIFEST': Array<PrecacheEntry|string>;
+  interface WorkerGlobalScope {
+    __WB_MANIFEST: Array<PrecacheEntry|string>;
   }
 }
 

--- a/packages/workbox-precaching/src/precacheAndRoute.ts
+++ b/packages/workbox-precaching/src/precacheAndRoute.ts
@@ -12,8 +12,10 @@ import {precache} from './precache.js';
 import {PrecacheEntry} from './_types.js';
 import './_version.js';
 
-export interface WorkboxGlobalScope extends ServiceWorkerGlobalScope {
-  '__WB_MANIFEST': Array<PrecacheEntry|string>;
+declare global {
+  interface ServiceWorkerGlobalScope {
+    '__WB_MANIFEST': Array<PrecacheEntry|string>;
+  }
 }
 
 /**

--- a/packages/workbox-precaching/src/precacheAndRoute.ts
+++ b/packages/workbox-precaching/src/precacheAndRoute.ts
@@ -12,6 +12,9 @@ import {precache} from './precache.js';
 import {PrecacheEntry} from './_types.js';
 import './_version.js';
 
+export interface WorkboxGlobalScope extends ServiceWorkerGlobalScope {
+  '__WB_MANIFEST': Array<PrecacheEntry|string>;
+}
 
 /**
  * This method will add entries to the precache list and add a route to


### PR DESCRIPTION
R: @philipwalton 

I'm not 100% sure that this is the right way to do things, so please review this with skepticism, but this definition is the cleanest way I could come up with to support using `self.__WB_MANIFEST` inside of a TypeScript `swSrc` file.

The usage ends up looking like:

```typescript
import {precacheAndRoute, WorkboxGlobalScope} from 'workbox-precaching/precacheAndRoute';

declare const self: WorkboxGlobalScope;

precacheAndRoute(self.__WB_MANIFEST);
```

Maybe we should have a separate `WorkboxGlobalScope` declaration inside of `workbox-core` instead, which would presumably make it cleaner if we ever added in custom global properties that weren't related to `workbox-precaching`?