### PR TITLE
Adds the private TS annotation to _methods()

### DIFF
--- a/packages/workbox-background-sync/src/Queue.ts
+++ b/packages/workbox-background-sync/src/Queue.ts
@@ -339,7 +339,7 @@ class Queue {
    *
    * @private
    */
-  _addSyncListener() {
+  private _addSyncListener() {
     if ('sync' in self.registration) {
       self.addEventListener('sync', (event: SyncEvent) => {
         if (event.tag === `${TAG_PREFIX}:${this._name}`) {

--- a/packages/workbox-background-sync/src/lib/QueueStore.ts
+++ b/packages/workbox-background-sync/src/lib/QueueStore.ts
@@ -202,7 +202,7 @@ export class QueueStore {
    * @param {Event} event
    * @private
    */
-  _upgradeDb(event: IDBVersionChangeEvent) {
+  private _upgradeDb(event: IDBVersionChangeEvent) {
     const db = (<IDBOpenDBRequest> event.target).result;
 
     if (event.oldVersion > 0 && event.oldVersion < DB_VERSION) {

--- a/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts
+++ b/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts
@@ -174,7 +174,7 @@ class BroadcastCacheUpdate {
    *
    * @private
    */
-  _getChannel() {
+  private _getChannel() {
     if (('BroadcastChannel' in self) && !this._channel) {
       this._channel = new BroadcastChannel(this._channelName);
     }
@@ -190,7 +190,7 @@ class BroadcastCacheUpdate {
    * @return {Promise}
    * @private
    */
-  _windowReadyOrTimeout(event: Event) {
+  private _windowReadyOrTimeout(event: Event) {
     if (!this._navigationEventsDeferreds!.has(event)) {
       const deferred = new Deferred();
 
@@ -225,7 +225,7 @@ class BroadcastCacheUpdate {
    *
    * @private
    */
-  _initWindowReadyDeferreds() {
+  private _initWindowReadyDeferreds() {
     // A mapping between navigation events and their deferreds.
     this._navigationEventsDeferreds = new Map();
 

--- a/packages/workbox-expiration/src/Plugin.ts
+++ b/packages/workbox-expiration/src/Plugin.ts
@@ -99,7 +99,7 @@ class Plugin implements WorkboxPlugin {
    *
    * @private
    */
-  _getCacheExpiration(cacheName: string): CacheExpiration {
+  private _getCacheExpiration(cacheName: string): CacheExpiration {
     if (cacheName === cacheNames.getRuntimeName()) {
       throw new WorkboxError('expire-custom-caches-only');
     }
@@ -173,7 +173,7 @@ class Plugin implements WorkboxPlugin {
    *
    * @private
    */
-  _isResponseDateFresh(cachedResponse: Response): boolean {
+  private _isResponseDateFresh(cachedResponse: Response): boolean {
     if (!this._maxAgeSeconds) {
       // We aren't expiring by age, so return true, it's fresh
       return true;
@@ -203,7 +203,7 @@ class Plugin implements WorkboxPlugin {
    *
    * @private
    */
-  _getDateHeaderTimestamp(cachedResponse: Response): number | null {
+  private _getDateHeaderTimestamp(cachedResponse: Response): number | null {
     if (!cachedResponse.headers.has('date')) {
       return null;
     }

--- a/packages/workbox-expiration/src/models/CacheTimestampsModel.ts
+++ b/packages/workbox-expiration/src/models/CacheTimestampsModel.ts
@@ -59,7 +59,7 @@ class CacheTimestampsModel {
    *
    * @private
    */
-  _handleUpgrade(event: IDBVersionChangeEvent) {
+  private _handleUpgrade(event: IDBVersionChangeEvent) {
     const db = (<IDBOpenDBRequest> event.target).result;
 
     // TODO(philipwalton): EdgeHTML doesn't support arrays as a keyPath, so we
@@ -188,7 +188,7 @@ class CacheTimestampsModel {
    *
    * @private
    */
-  _getId(url: string): string {
+  private _getId(url: string): string {
     // Creating an ID from the URL and cache name won't be necessary once
     // Edge switches to Chromium and all browsers we support work with
     // array keyPaths.

--- a/packages/workbox-routing/src/NavigationRoute.ts
+++ b/packages/workbox-routing/src/NavigationRoute.ts
@@ -88,7 +88,7 @@ class NavigationRoute extends Route {
    *
    * @private
    */
-  _match({url, request}: MatchCallbackOptions): boolean {
+  private _match({url, request}: MatchCallbackOptions): boolean {
     if (request && request.mode !== 'navigate') {
       return false;
     }

--- a/packages/workbox-strategies/src/NetworkFirst.ts
+++ b/packages/workbox-strategies/src/NetworkFirst.ts
@@ -196,7 +196,7 @@ class NetworkFirst implements RouteHandler {
    *
    * @private
    */
-  _getTimeoutPromise({request, logs, event}: {
+  private _getTimeoutPromise({request, logs, event}: {
     request: Request,
     logs: any[],
     event?: ExtendableEvent,
@@ -314,7 +314,7 @@ class NetworkFirst implements RouteHandler {
    *
    * @private
    */
-  _respondFromCache({event, request}: {
+  private _respondFromCache({event, request}: {
     request: Request,
     event?: ExtendableEvent,
   }): Promise<Response | undefined> {

--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -265,12 +265,12 @@ class Workbox extends WorkboxEventTarget {
 
   /**
    * Checks for a service worker already controlling the page and returns
-   * it if its script URL matchs.
+   * it if its script URL matches.
    *
    * @private
    * @return {ServiceWorker|undefined}
    */
-  _getControllingSWIfCompatible() {
+  private _getControllingSWIfCompatible() {
     const controller = navigator.serviceWorker.controller;
     if (controller && urlsMatch(controller.scriptURL, this._scriptURL)) {
       return controller;
@@ -285,7 +285,7 @@ class Workbox extends WorkboxEventTarget {
    *
    * @private
    */
-  async _registerScript() {
+  private async _registerScript() {
     try {
       const reg = await navigator.serviceWorker.register(
           this._scriptURL, this._registerOptions);
@@ -312,7 +312,7 @@ class Workbox extends WorkboxEventTarget {
    * @param {ServiceWorker} sw
    * @private
    */
-  _reportWindowReady(sw: ServiceWorker) {
+  private _reportWindowReady(sw: ServiceWorker) {
     messageSW(sw, {
       type: 'WINDOW_READY',
       meta: 'workbox-window',
@@ -322,7 +322,7 @@ class Workbox extends WorkboxEventTarget {
   /**
    * @private
    */
-  _onUpdateFound = () => {
+  private _onUpdateFound = () => {
     // `this._registration` will never be `undefined` after an update is found.
     const registration = this._registration!;
     const installingSW = <ServiceWorker> registration.installing;
@@ -391,7 +391,7 @@ class Workbox extends WorkboxEventTarget {
    * @private
    * @param {Event} originalEvent
    */
-  _onStateChange = (originalEvent: Event) => {
+  private _onStateChange = (originalEvent: Event) => {
     // `this._registration` will never be `undefined` after an update is found.
     const registration = this._registration!;
     const sw = <ServiceWorker>originalEvent.target;
@@ -477,7 +477,7 @@ class Workbox extends WorkboxEventTarget {
    * @private
    * @param {Event} originalEvent
    */
-  _onControllerChange = (originalEvent: Event) => {
+  private _onControllerChange = (originalEvent: Event) => {
     const sw = this._sw;
     if (sw === navigator.serviceWorker.controller) {
       this.dispatchEvent(new WorkboxEvent('controlling', {

--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -496,7 +496,7 @@ class Workbox extends WorkboxEventTarget {
    * @private
    * @param {Event} originalEvent
    */
-  _onMessage = (originalEvent: MessageEvent) => {
+  private _onMessage = (originalEvent: MessageEvent) => {
     const {data} = originalEvent;
     this.dispatchEvent(new WorkboxEvent('message', {data, originalEvent}));
   }


### PR DESCRIPTION
R: @philipwalton

When testing out the TypeScript functionality, I noticed that there were a bunch of methods on `workbox-window` that started with `_` and were `@private` in JSDoc, but weren't marked `private` in TypeScript.

I wonder if this is something we could catch via linting or some sort of post-TypeScript-compilation test?