### PR TITLE
Adds importScriptsViaChunks option to webpack plugin

### DIFF
--- a/packages/workbox-build/src/entry-points/options/webpack-generate-sw-schema.js
+++ b/packages/workbox-build/src/entry-points/options/webpack-generate-sw-schema.js
@@ -13,5 +13,6 @@ const defaults = require('./defaults');
 const webpackCommon = require('./webpack-common');
 
 module.exports = commonGenerateSchema.keys(Object.assign({
+  importScriptsViaChunks: joi.array().items(joi.string()),
   swDest: joi.string().default(defaults.swDestFilename),
 }, webpackCommon));

--- a/packages/workbox-webpack-plugin/src/lib/get-script-files-for-chunks.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-script-files-for-chunks.js
@@ -1,0 +1,34 @@
+/*
+  Copyright 2019 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+const resolveWebpackURL = require('./resolve-webpack-url');
+
+module.exports = (compilation, chunkNames) => {
+  const {chunks} = compilation.getStats().toJson({chunks: true});
+  const {publicPath} = compilation.options.output;
+  const scriptFiles = new Set();
+
+  for (const chunkName of chunkNames) {
+    const chunk = chunks.find((chunk) => chunk.names.includes(chunkName));
+    if (chunk) {
+      for (const file of chunk.files) {
+        scriptFiles.add(resolveWebpackURL(publicPath, file));
+      }
+    } else {
+      compilation.warnings.push(`${chunkName} was provided to ` +
+        `importScriptsViaChunks, but didn't match any named chunks.`);
+    }
+  }
+
+  if (scriptFiles.size === 0) {
+    compilation.warnings.push(`There were no assets matching ` +
+        `importScriptsViaChunks: [${chunkNames}].`);
+  }
+
+  return Array.from(scriptFiles);
+};

--- a/test/workbox-build/node/entry-points/generate-sw.js
+++ b/test/workbox-build/node/entry-points/generate-sw.js
@@ -125,7 +125,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-9eb92ebe']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -165,7 +165,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-9eb92ebe'], [...importScripts]],
+        importScripts: [[...importScripts]],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -211,7 +211,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-4a41d90a']],
+        importScripts: [],
         clientsClaim: [[]],
         skipWaiting: [[]],
         setCacheNameDetails: [[{prefix: cacheId}]],
@@ -261,7 +261,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-4a41d90a']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -306,7 +306,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-9eb92ebe']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -356,7 +356,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         getCacheKeyForURL: [[navigateFallback]],
-        importScripts: [['./workbox-808eb12e']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -402,7 +402,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-9eb92ebe']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'link/index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -446,7 +446,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-9eb92ebe']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'link/index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -479,7 +479,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-76e7a865']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -523,7 +523,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-76e7a865']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -641,7 +641,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       expect(size).to.eql(2604);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [STRING_HANDLER]: [[]],
-        importScripts: [['./workbox-b880c8c0']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -682,7 +682,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       expect(size).to.eql(2604);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [STRING_HANDLER]: [[]],
-        importScripts: [['./workbox-b880c8c0']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -756,7 +756,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
         }]],
         Plugin: [[firstRuntimeCachingOptions.expiration]],
         Plugin$1: [[secondRuntimeCachingOptions.cacheableResponse]],
-        importScripts: [['./workbox-aad11b65']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -831,7 +831,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       expect(size).to.eql(2604);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [handler]: [[runtimeCachingOptions]],
-        importScripts: [['./workbox-44e55206']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
@@ -927,7 +927,7 @@ describe(`[workbox-build] entry-points/generate-sw.js (End to End)`, function() 
       expect(size).to.eql(2604);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [handler]: [[]],
-        importScripts: [['./workbox-1229ecdd']],
+        importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '3883c45b119c9d7e9ad75a1b4a4672ac',

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -86,6 +86,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
+              importScripts: [],
               precacheAndRoute: [[[
                 {
                   revision: '0fae6a991467bd40263a3ba8cd82835d',
@@ -95,6 +96,61 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
                   url: 'entry2-aa21f43434f29ed0c946.js',
                 },
               ], {}]],
+            },
+          });
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+
+    it(`should work when called with importScriptsViaChunks`, function(done) {
+      const outputDir = tempy.directory();
+      const config = {
+        mode: 'production',
+        entry: {
+          main: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+          imported: path.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        },
+        output: {
+          filename: '[name]-[chunkhash].js',
+          path: outputDir,
+        },
+        plugins: [
+          new GenerateSW({
+            importScriptsViaChunks: [
+              'imported',
+              'INVALID_CHUNK_NAME',
+            ],
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError, stats) => {
+        const swFile = path.join(outputDir, 'service-worker.js');
+        try {
+          const statsJson = stats.toJson('verbose');
+          expect(webpackError).not.to.exist;
+          expect(statsJson.errors).to.be.empty;
+          // There should be a warning logged, due to INVALID_CHUNK_NAME.
+          expect(statsJson.warnings).to.have.length(1);
+
+          const files = await globby(outputDir);
+          expect(files).to.have.length(4);
+
+          await validateServiceWorkerRuntime({
+            swFile, expectedMethodCalls: {
+              importScripts: [
+                ['imported-1f6b183815996bd3f526.js'],
+              ],
+              // imported-[chunkhash].js should *not* be included.
+              precacheAndRoute: [[[{
+                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                url: 'main-01a6ea3dea62d17888bb.js',
+              }], {}]],
             },
           });
 
@@ -143,6 +199,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
+              importScripts: [],
               precacheAndRoute: [[[
                 {
                   revision: '0fae6a991467bd40263a3ba8cd82835d',
@@ -198,6 +255,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [],
             precacheAndRoute: [[[
               {
                 revision: '0fae6a991467bd40263a3ba8cd82835d',
@@ -250,6 +308,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(4);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [],
             precacheAndRoute: [[[
               {
                 revision: '112b1ad19c141f739a7ef2b803e83a6d',
@@ -298,6 +357,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [],
             precacheAndRoute: [[[
               {
                 revision: '0fae6a991467bd40263a3ba8cd82835d',
@@ -347,6 +407,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [],
             precacheAndRoute: [[[
               {
                 revision: '0fae6a991467bd40263a3ba8cd82835d',
@@ -392,6 +453,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [],
             precacheAndRoute: [[[
               {
                 revision: '0fae6a991467bd40263a3ba8cd82835d',
@@ -444,6 +506,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
+              importScripts: [],
               precacheAndRoute: [[[
                 {
                   revision: '452b0a9f3978190f4c77997ab23473db',
@@ -763,6 +826,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
+              importScripts: [],
               precacheAndRoute: [[[
                 {
                   revision: '0fae6a991467bd40263a3ba8cd82835d',
@@ -820,6 +884,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(12);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [],
             precacheAndRoute: [[[
               {
                 revision: '0fae6a991467bd40263a3ba8cd82835d',
@@ -897,6 +962,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
+            importScripts: [],
             precacheAndRoute: [[[
               {
                 revision: 'c00d58015497c84d6fa4eaa9ee31678d',


### PR DESCRIPTION
R: @philipwalton

Fixes #1752

This new option in `workbox-webpack-plugin`'s `GenerateSW` mode allows you to use the name of chunks from your `webpack` compilation as the source for `importScripts()`. It also takes steps to exclude whatever's imported via `importScripts()` from the precache manifest, since the service worker maintains its own cache of imported scripts.

It's important that developers use this with versioned filenames (i.e. including a hash), since the current service worker implementations in browsers won't check for updates to imported scripts unless their URL changes.

In the course of writing tests for this, I also fixed some of the validation logic around calls to `importScripts`, making it so that we can check to make sure that the Workbox runtime is imported without having to hardcode the exact filename. This should lead to less test case churn resulting from small changes in the Workbox runtime code leading to new hashed filenames.