### PR TITLE
Limit the webpack stats to what we need

### DIFF
--- a/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-from-compilation.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-from-compilation.js
@@ -86,7 +86,12 @@ function assetToChunkNameMapping(stats) {
  */
 function filterAssets(compilation, config) {
   const filteredAssets = new Set();
-  const stats = compilation.getStats().toJson();
+  // See https://webpack.js.org/configuration/stats/#stats
+  // We only need assets and chunkGroups here.
+  const stats = compilation.getStats().toJson({
+    assets: true,
+    chunkGroups: true,
+  });
 
   const assetNameToChunkNames = assetToChunkNameMapping(stats);
 

--- a/test/workbox-precaching/sw/test-PrecacheController.mjs
+++ b/test/workbox-precaching/sw/test-PrecacheController.mjs
@@ -614,7 +614,7 @@ describe(`PrecacheController`, function() {
       }
 
       const cleanupDetailsTwo = await precacheControllerTwo.activate();
-      expect(cleanupDetailsTwo.deletedURLs).to.deep.equal([
+      expect(cleanupDetailsTwo.deletedURLs).to.have.members([
         `${location.origin}/index.1234.html`,
         `${location.origin}/scripts/stress.js?test=search&foo=bar&__WB_REVISION__=1234`,
       ]);


### PR DESCRIPTION
I realized in https://github.com/GoogleChrome/workbox/pull/2131 that we can limit the fields returned by the `compilation.getStats().toJson()` call so that it only includes what we need.

This PR changes an existing usage to just return fields we need for a different use case.