### PR TITLE
Pass more matchCallback return values through to handlerCallback

### DIFF
--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -293,13 +293,15 @@ class Router {
       let params;
       let matchResult = route.match({url, request, event});
       if (matchResult) {
-        if (Array.isArray(matchResult) && matchResult.length > 0) {
+        // See https://github.com/GoogleChrome/workbox/issues/2079
+        params = matchResult;
+        if (Array.isArray(matchResult) && matchResult.length === 0) {
           // Instead of passing an empty array in as params, use undefined.
-          params = matchResult;
+          params = undefined;
         } else if ((matchResult.constructor === Object &&
-            Object.keys(matchResult).length > 0)) {
+            Object.keys(matchResult).length === 0)) {
           // Instead of passing an empty object in as params, use undefined.
-          params = matchResult;
+          params = undefined;
         }
 
         // Return early if have a match.

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -303,7 +303,7 @@ class Router {
           // Instead of passing an empty object in as params, use undefined.
           params = undefined;
         } else if (typeof matchResult === 'boolean') {
-          // For thee boolean value true (rather than just something truth-y),
+          // For the boolean value true (rather than just something truth-y),
           // don't set params.
           // See https://github.com/GoogleChrome/workbox/pull/2134#issuecomment-513924353
           params = undefined;

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -302,6 +302,11 @@ class Router {
             Object.keys(matchResult).length === 0)) {
           // Instead of passing an empty object in as params, use undefined.
           params = undefined;
+        } else if (typeof matchResult === 'boolean') {
+          // For thee boolean value true (rather than just something truth-y),
+          // don't set params.
+          // See https://github.com/GoogleChrome/workbox/pull/2134#issuecomment-513924353
+          params = undefined;
         }
 
         // Return early if have a match.

--- a/test/workbox-routing/sw/test-Router.mjs
+++ b/test/workbox-routing/sw/test-Router.mjs
@@ -544,7 +544,7 @@ describe(`Router`, function() {
       expect(handler.firstCall.args[0].url).to.deep.equal(url);
       expect(handler.firstCall.args[0].request).to.equal(request);
       expect(handler.firstCall.args[0].event).to.equal(undefined);
-      expect(handler.firstCall.args[0].params).to.equal(true);
+      expect(handler.firstCall.args[0].params).to.equal(undefined);
 
       expect(handler.secondCall.args[0].url).to.deep.equal(url);
       expect(handler.secondCall.args[0].request).to.equal(request);
@@ -552,7 +552,7 @@ describe(`Router`, function() {
       expect(handler.secondCall.args[0].params).to.deep.equal([1, 2, 3]);
     });
 
-    const matchCallbackReturnValues = [{a: 'b'}, [1, 2], true, 'test'];
+    const matchCallbackReturnValues = [{a: 'b'}, [1, 2], 'test'];
     generateTestVariants(`should pass the matchCallback return value to handlerCallback as params`, matchCallbackReturnValues, async function(returnValue) {
       const handlerCallbackStub = sinon.stub().resolves(new Response());
       const router = new Router();
@@ -695,7 +695,7 @@ describe(`Router`, function() {
 
       const result1 = router.findMatchingRoute({url, request, event});
       expect(result1.route).to.equal(route);
-      expect(result1.params).to.equal(true);
+      expect(result1.params).to.equal(undefined);
 
       const result2 = router.findMatchingRoute({url, request, event});
       expect(result2.route).to.equal(route);

--- a/test/workbox-routing/sw/test-Router.mjs
+++ b/test/workbox-routing/sw/test-Router.mjs
@@ -544,7 +544,7 @@ describe(`Router`, function() {
       expect(handler.firstCall.args[0].url).to.deep.equal(url);
       expect(handler.firstCall.args[0].request).to.equal(request);
       expect(handler.firstCall.args[0].event).to.equal(undefined);
-      expect(handler.firstCall.args[0].params).to.equal(undefined);
+      expect(handler.firstCall.args[0].params).to.equal(true);
 
       expect(handler.secondCall.args[0].url).to.deep.equal(url);
       expect(handler.secondCall.args[0].request).to.equal(request);
@@ -552,60 +552,22 @@ describe(`Router`, function() {
       expect(handler.secondCall.args[0].params).to.deep.equal([1, 2, 3]);
     });
 
-    it(`should result in params in handler`, function() {
-      const expectedParams = {
-        test: 'hello',
-      };
+    const matchCallbackReturnValues = [{a: 'b'}, [1, 2], true, 'test'];
+    generateTestVariants(`should pass the matchCallback return value to handlerCallback as params`, matchCallbackReturnValues, async function(returnValue) {
+      const handlerCallbackStub = sinon.stub().resolves(new Response());
       const router = new Router();
       const route = new Route(
-          () => expectedParams,
-          ({params}) => {
-            expect(params).to.equal(expectedParams);
-            return new Response();
-          },
+          sinon.stub().returns(returnValue),
+          handlerCallbackStub,
       );
       router.registerRoute(route);
 
-      // route.match() always returns false, so the Request details don't matter.
       const request = new Request(location);
       const event = new FetchEvent('fetch', {request});
-      router.handleRequest({request, event});
-    });
+      await router.handleRequest({request, event});
 
-    it(`should result in no params in handler`, function() {
-      const router = new Router();
-      const route = new Route(
-          () => {
-            return {};
-          },
-          ({params}) => {
-            expect(params).to.equal(undefined);
-            return new Response();
-          },
-      );
-      router.registerRoute(route);
-
-      // route.match() always returns false, so the Request details don't matter.
-      const request = new Request(location);
-      const event = new FetchEvent('fetch', {request});
-      router.handleRequest({request, event});
-    });
-
-    it(`should result in no params in handler for 'true'`, function() {
-      const router = new Router();
-      const route = new Route(
-          () => true,
-          ({params}) => {
-            expect(params).to.equal(undefined);
-            return new Response();
-          },
-      );
-      router.registerRoute(route);
-
-      // route.match() always returns false, so the Request details don't matter.
-      const request = new Request(location);
-      const event = new FetchEvent('fetch', {request});
-      router.handleRequest({request, event});
+      expect(handlerCallbackStub.calledOnce).to.be.true;
+      expect(handlerCallbackStub.firstCall.args[0].params).to.eql(returnValue);
     });
 
     it(`should not throw for router with no-routes set`, function() {
@@ -733,11 +695,11 @@ describe(`Router`, function() {
 
       const result1 = router.findMatchingRoute({url, request, event});
       expect(result1.route).to.equal(route);
-      expect(result1.params).to.equal(undefined);
+      expect(result1.params).to.equal(true);
 
       const result2 = router.findMatchingRoute({url, request, event});
       expect(result2.route).to.equal(route);
-      expect(result2.params).to.equal(undefined);
+      expect(result2.params).to.equal('truthy');
 
       const result3 = router.findMatchingRoute({url, request, event});
       expect(result3.route).to.equal(route);


### PR DESCRIPTION
R: @philipwalton

Fixes #2079

This change results in more return values from the `matchCallback` being passed through to the `handlerCallback` as the `params` option.

(There is still some special-case logic for `{}` and `[]` being treated as `{params: undefined}`, matching the existing v4 behavior. It's implemented this way to make it easier to deal with a `matchCallback` that uses a `RegExp` with capture groups.)
