### PR TITLE
feat: workbox-window method to trigger SW update check 

### DIFF
--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -196,6 +196,27 @@ class Workbox extends WorkboxEventTarget {
   }
 
   /**
+   * Checks for updates of the registered service worker.
+   */
+  async update() {
+      if (!this._registration) {
+        if (process.env.NODE_ENV !== 'production') {
+        logger.error('Cannot update a Workbox instance without ' +
+            'being registered. Register the Workbox instance first.');
+          }
+        return;
+      }
+
+    // Reset the registration time and update count so it's not treated as 
+    // external in the `this._onUpdateFound` heuristic.
+    this._registrationTime = performance.now();
+    this._updateFoundCount = 0;
+
+    // Try to update registration
+    await this._registration.update();
+  }
+
+  /**
    * Resolves to the service worker registered by this instance as soon as it
    * is active. If a service worker was already controlling at registration
    * time then it will resolve to that if the script URLs (and optionally

--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -199,18 +199,13 @@ class Workbox extends WorkboxEventTarget {
    * Checks for updates of the registered service worker.
    */
   async update() {
-      if (!this._registration) {
-        if (process.env.NODE_ENV !== 'production') {
+    if (!this._registration) {
+      if (process.env.NODE_ENV !== 'production') {
         logger.error('Cannot update a Workbox instance without ' +
-            'being registered. Register the Workbox instance first.');
-          }
-        return;
+          'being registered. Register the Workbox instance first.');
       }
-
-    // Reset the registration time and update count so it's not treated as 
-    // external in the `this._onUpdateFound` heuristic.
-    this._registrationTime = performance.now();
-    this._updateFoundCount = 0;
+      return;
+    }
 
     // Try to update registration
     await this._registration.update();

--- a/test/workbox-window/window/test-Workbox.mjs
+++ b/test/workbox-window/window/test-Workbox.mjs
@@ -313,7 +313,7 @@ describe(`[workbox-window] Workbox`, function() {
       const controllerBeforeTest = navigator.serviceWorker.controller;
       const scriptURL = controllerBeforeTest.scriptURL;
       const wb = new Workbox(scriptURL);
-     
+
       const reg = await wb.register();
       const newReg = await wb.update();
 

--- a/test/workbox-window/window/test-Workbox.mjs
+++ b/test/workbox-window/window/test-Workbox.mjs
@@ -308,6 +308,31 @@ describe(`[workbox-window] Workbox`, function() {
     });
   });
 
+  describe(`update`, function() {
+    it(`updates service worker and resolves with the new registration`, async function() {
+      const controllerBeforeTest = navigator.serviceWorker.controller;
+      const scriptURL = controllerBeforeTest.scriptURL;
+      const wb = new Workbox(scriptURL);
+     
+      const reg = await wb.register();
+      const newReg = await wb.update();
+
+      expect(reg).not.to.equal(newReg);
+    });
+
+    describe(`logs in development-only`, function() {
+      it(`(error) if calling without registration`, async function() {
+        if (!isDev()) this.skip();
+
+        const wb = new Workbox(uniq('sw-clients-claim.js.njk'));
+
+        await wb.update();
+        expect(console.error.callCount).to.equal(1);
+        expect(console.error.args[0][2]).to.match(/cannot update/i);
+      });
+    });
+  });
+
   describe(`active`, function() {
     it(`resolves as soon as the registered SW is active`, async function() {
       const controllerBeforeTest = navigator.serviceWorker.controller;


### PR DESCRIPTION
R: @jeffposnick @philipwalton

Fixes #2130

This PR introduces an `update` method on the `Workbox` instance in order to check for updates after the page has loaded. This is useful for long running applications that are seldom closed (e.g. mail applications) and where you need to check for updates on regular time interval.
