### PR TITLE
Workbox event types

### DIFF
--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -392,12 +392,15 @@ class Workbox extends WorkboxEventTarget {
   private _onStateChange = (originalEvent: Event) => {
     // `this._registration` will never be `undefined` after an update is found.
     const registration = this._registration!;
-    const sw = <ServiceWorker>originalEvent.target;
+    const sw = originalEvent.target as ServiceWorker;
     const {state} = sw;
     const isExternal = sw === this._externalSW;
     const eventPrefix = isExternal ? 'external' : '';
 
-    const eventProps: any = {sw, originalEvent};
+    const eventProps: {sw: ServiceWorker, originalEvent: Event, isUpdate?: boolean} = {
+      sw,
+      originalEvent
+    };
     if (!isExternal && this._isUpdate) {
       eventProps.isUpdate = true;
     }

--- a/packages/workbox-window/src/utils/WorkboxEvent.ts
+++ b/packages/workbox-window/src/utils/WorkboxEvent.ts
@@ -16,29 +16,26 @@ import '../_version.js';
  * constructable `EventTarget`, and using a real `Event` will error.
  * @private
  */
-export class WorkboxEvent {
+export class WorkboxEvent<K extends keyof WorkboxEventMap> {
   target?: WorkboxEventTarget;
   sw: ServiceWorker;
+  originalEvent?: Event;
 
-  constructor(public type: keyof WorkboxEventMap, props: Object) {
+  constructor(public type: K, props: Omit<WorkboxEventMap[K], 'target' | 'type'>) {
     Object.assign(this, props);
   }
 }
 
-export interface WorkboxMessageEvent extends WorkboxEvent {
-  type: 'message';
+export interface WorkboxMessageEvent extends WorkboxEvent<'message'> {
   originalEvent: Event;
   data: any;
 }
 
-export interface WorkboxLifecycleEvent extends WorkboxEvent {
-  type: keyof WorkboxLifecycleEventMap;
-  originalEvent: Event;
+export interface WorkboxLifecycleEvent extends WorkboxEvent<keyof WorkboxLifecycleEventMap> {
   isUpdate?: boolean;
 }
 
 export interface WorkboxLifecycleWaitingEvent extends WorkboxLifecycleEvent {
-  type: keyof WorkboxLifecycleEventMap;
   wasWaitingBeforeRegister?: boolean;
 }
 

--- a/packages/workbox-window/src/utils/WorkboxEvent.ts
+++ b/packages/workbox-window/src/utils/WorkboxEvent.ts
@@ -6,18 +6,9 @@
   https://opensource.org/licenses/MIT.
 */
 
-
 import {WorkboxEventTarget} from './WorkboxEventTarget.js';
 import '../_version.js';
 
-
-export interface WorkboxEventProps {
-  sw?: ServiceWorker;
-  data?: any;
-  originalEvent?: Event;
-  isUpdate?: boolean;
-  wasWaitingBeforeRegister?: boolean;
-}
 
 /**
  * A minimal `Event` subclass shim.
@@ -26,9 +17,45 @@ export interface WorkboxEventProps {
  * @private
  */
 export class WorkboxEvent {
-  target: WorkboxEventTarget;
+  target?: WorkboxEventTarget;
+  sw: ServiceWorker;
 
-  constructor(public type: string, props: WorkboxEventProps) {
+  constructor(public type: keyof WorkboxEventMap, props: Object) {
     Object.assign(this, props);
   }
+}
+
+export interface WorkboxMessageEvent extends WorkboxEvent {
+  type: 'message';
+  originalEvent: Event;
+  data: any;
+}
+
+export interface WorkboxLifecycleEvent extends WorkboxEvent {
+  type: keyof WorkboxLifecycleEventMap;
+  originalEvent: Event;
+  isUpdate?: boolean;
+}
+
+export interface WorkboxLifecycleWaitingEvent extends WorkboxLifecycleEvent {
+  type: keyof WorkboxLifecycleEventMap;
+  wasWaitingBeforeRegister?: boolean;
+}
+
+export interface WorkboxLifecycleEventMap {
+  'installing': WorkboxLifecycleEvent;
+  'installed': WorkboxLifecycleEvent;
+  'waiting': WorkboxLifecycleWaitingEvent;
+  'activating': WorkboxLifecycleEvent;
+  'activated': WorkboxLifecycleEvent;
+  'controlling': WorkboxLifecycleEvent;
+  'externalinstalling': WorkboxLifecycleEvent;
+  'externalinstalled': WorkboxLifecycleEvent;
+  'externalwaiting': WorkboxLifecycleWaitingEvent;
+  'externalactivating': WorkboxLifecycleEvent;
+  'externalactivated': WorkboxLifecycleEvent;
+}
+
+export interface WorkboxEventMap extends WorkboxLifecycleEventMap {
+  'message': WorkboxMessageEvent;
 }

--- a/packages/workbox-window/src/utils/WorkboxEventTarget.ts
+++ b/packages/workbox-window/src/utils/WorkboxEventTarget.ts
@@ -6,12 +6,10 @@
   https://opensource.org/licenses/MIT.
 */
 
-import {WorkboxEvent} from './WorkboxEvent.js';
-import '../_version.js';
+import {WorkboxEvent, WorkboxEventMap} from './WorkboxEvent.js';
 
 
-export type ListenerCallback = (event: WorkboxEvent) => void;
-
+export type ListenerCallback = (event: WorkboxEvent) => any;
 
 /**
  * A minimal `EventTarget` shim.
@@ -20,15 +18,16 @@ export type ListenerCallback = (event: WorkboxEvent) => void;
  * @private
  */
 export class WorkboxEventTarget {
-  private _eventListenerRegistry: {[type: string]: Set<ListenerCallback>} = {};
+  private _eventListenerRegistry: Map<keyof WorkboxEventMap, Set<ListenerCallback>> = new Map();
 
   /**
    * @param {string} type
    * @param {Function} listener
    * @private
    */
-  addEventListener(type: string, listener: ListenerCallback) {
-    this._getEventListenersByType(type).add(listener);
+  addEventListener<K extends keyof WorkboxEventMap>(type: K, listener: (event: WorkboxEventMap[K]) => any) {
+    const foo = this._getEventListenersByType(type)
+    foo.add(listener);
   }
 
   /**
@@ -36,7 +35,7 @@ export class WorkboxEventTarget {
    * @param {Function} listener
    * @private
    */
-  removeEventListener(type: string, listener: ListenerCallback) {
+  removeEventListener<K extends keyof WorkboxEventMap>(type: K, listener: (event: WorkboxEventMap[K]) => any) {
     this._getEventListenersByType(type).delete(listener);
   }
 
@@ -61,8 +60,10 @@ export class WorkboxEventTarget {
    * @return {Set<ListenerCallback>} An array of handler functions.
    * @private
    */
-  private _getEventListenersByType(type: string) {
-    return this._eventListenerRegistry[type] =
-        (this._eventListenerRegistry[type] || new Set());
+  private _getEventListenersByType(type: keyof WorkboxEventMap) {
+    if (!this._eventListenerRegistry.has(type)) {
+      this._eventListenerRegistry.set(type, new Set());
+    }
+    return this._eventListenerRegistry.get(type)!;
   }
 }

--- a/packages/workbox-window/src/utils/WorkboxEventTarget.ts
+++ b/packages/workbox-window/src/utils/WorkboxEventTarget.ts
@@ -9,7 +9,7 @@
 import {WorkboxEvent, WorkboxEventMap} from './WorkboxEvent.js';
 
 
-export type ListenerCallback = (event: WorkboxEvent) => any;
+export type ListenerCallback = (event: WorkboxEvent<any>) => any;
 
 /**
  * A minimal `EventTarget` shim.
@@ -43,7 +43,7 @@ export class WorkboxEventTarget {
    * @param {Object} event
    * @private
    */
-  dispatchEvent(event: WorkboxEvent) {
+  dispatchEvent(event: WorkboxEvent<any>) {
     event.target = this;
 
     const listeners = this._getEventListenersByType(event.type)


### PR DESCRIPTION
R: @jeffposnick 

This PR adds some additional type information to address #2144. Primarily, it adds additional event callback types as well as a `WorkboxEventMap` interface so callbacks can declare their event callback argument types based on the event type passed to `addEventListener()`.

This means developer code doesn't have to import the `WorkboxEvent` type and annotate their own callbacks -- the types are inferred from the event type listened to. (Note: I took this pattern from the built-in [`addEventListener()`](https://github.com/microsoft/TypeScript/blob/3f75d2c8790b9e2d5d99b9d2b830a4e6a624151a/src/lib/dom.generated.d.ts#L18602) declaration, so I assume it's how these types of APIs are supposed to be typed.)

/cc @azizhk

