### PR TITLE
importScriptsViaChunks checks for .js extension

### DIFF
--- a/packages/workbox-webpack-plugin/src/lib/get-script-files-for-chunks.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-script-files-for-chunks.js
@@ -6,6 +6,8 @@
   https://opensource.org/licenses/MIT.
 */
 
+const upath = require('upath');
+
 const resolveWebpackURL = require('./resolve-webpack-url');
 
 module.exports = (compilation, chunkNames) => {
@@ -17,7 +19,10 @@ module.exports = (compilation, chunkNames) => {
     const chunk = chunks.find((chunk) => chunk.names.includes(chunkName));
     if (chunk) {
       for (const file of chunk.files) {
-        scriptFiles.add(resolveWebpackURL(publicPath, file));
+        // See https://github.com/GoogleChrome/workbox/issues/2161
+        if (upath.extname(file) === '.js') {
+          scriptFiles.add(resolveWebpackURL(publicPath, file));
+        }
       }
     } else {
       compilation.warnings.push(`${chunkName} was provided to ` +

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -106,7 +106,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       });
     });
 
-    it(`•should work when called with importScriptsViaChunks`, function(done) {
+    it(`should work when called with importScriptsViaChunks`, function(done) {
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -106,10 +106,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
       });
     });
 
-    it(`should work when called with importScriptsViaChunks`, function(done) {
+    it(`•should work when called with importScriptsViaChunks`, function(done) {
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',
+        devtool: 'source-map',
         entry: {
           main: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
           imported: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
@@ -139,16 +140,17 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(statsJson.warnings).to.have.length(1);
 
           const files = await globby(outputDir);
-          expect(files).to.have.length(4);
+          expect(files).to.have.length(8);
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
+              // imported-[chunkhash].js.map should *not* be included.
               importScripts: [
                 ['imported-1f6b183815996bd3f526.js'],
               ],
               // imported-[chunkhash].js should *not* be included.
               precacheAndRoute: [[[{
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '39e9dd73c0daacacec3ea359cd47394a',
                 url: 'main-01a6ea3dea62d17888bb.js',
               }], {}]],
             },


### PR DESCRIPTION
R: @philipwalton

Fixes #2161

I think this is a reasonable restriction, and allowing developers to customize things to allow for non-`.js` extensions seems like overkill.

(`importScripts()` will never play nicely with ES modules, so `.mjs` is a non-issue.)
