### PR TITLE
Reduce GA integration test flakiness

### DIFF
--- a/test/workbox-google-analytics/integration/test-all.js
+++ b/test/workbox-google-analytics/integration/test-all.js
@@ -6,7 +6,6 @@
   https://opensource.org/licenses/MIT.
 */
 
-const {By} = require('selenium-webdriver');
 const expect = require('chai').expect;
 const qs = require('qs');
 
@@ -74,9 +73,6 @@ describe(`[workbox-google-analytics] initialize`, function() {
       return 'SyncManager' in window;
     });
     if (!browserSupportsSync) this.skip();
-
-    const simulateOfflineEl =
-        await webdriver.findElement(By.id('simulate-offline'));
 
     // Send a hit while online to ensure regular requests work.
     await webdriver.executeAsyncScript((done) => {

--- a/test/workbox-google-analytics/integration/test-all.js
+++ b/test/workbox-google-analytics/integration/test-all.js
@@ -6,13 +6,13 @@
   https://opensource.org/licenses/MIT.
 */
 
+const {By} = require('selenium-webdriver');
 const expect = require('chai').expect;
 const qs = require('qs');
-const {By} = require('selenium-webdriver');
+
+const {runUnitTests} = require('../../../infra/testing/webdriver/runUnitTests');
 const activateAndControlSW = require('../../../infra/testing/activate-and-control');
 const waitUntil = require('../../../infra/testing/wait-until');
-const {runUnitTests} = require('../../../infra/testing/webdriver/runUnitTests');
-
 
 // Store local references of these globals.
 const {webdriver, server} = global.__workbox;
@@ -98,20 +98,27 @@ describe(`[workbox-google-analytics] initialize`, function() {
 
     // Check the "simulate offline" checkbox and make some requests.
     await simulateOfflineEl.click();
+
     await webdriver.executeAsyncScript((done) => {
       window.gtag('event', 'beacon', {
         transport_type: 'beacon',
         event_label: Date.now(),
-        event_callback: () => done(),
+        event_callback: () => {
+          setTimeout(done, 50);
+        },
       });
     });
+
     await webdriver.executeAsyncScript((done) => {
       window.gtag('event', 'pixel', {
         transport_type: 'image',
         event_label: Date.now(),
-        event_callback: () => done(),
+        event_callback: () => {
+          setTimeout(done, 50);
+        },
       });
     });
+
     // This request should not match GA routes, so it shouldn't be replayed.
     await webdriver.executeAsyncScript((done) => {
       fetch('https://httpbin.org/get').then(() => done());
@@ -152,7 +159,7 @@ describe(`[workbox-google-analytics] initialize`, function() {
     // Ensure the hit's qt params were present and greater than 0,
     // and ensure those values reflect the original order of the hits.
     expect(requests[0].params.qt > 0).to.be.true;
-    expect(requests[0].params.qt > 0).to.be.true;
+    expect(requests[1].params.qt > 0).to.be.true;
     expect(requests[0].originalTime < requests[1].originalTime).to.be.true;
   });
 });

--- a/test/workbox-google-analytics/integration/test-all.js
+++ b/test/workbox-google-analytics/integration/test-all.js
@@ -103,6 +103,7 @@ describe(`[workbox-google-analytics] initialize`, function() {
         transport_type: 'beacon',
         event_label: Date.now(),
         event_callback: () => {
+          // See https://github.com/GoogleChrome/workbox/issues/2168
           setTimeout(done, 50);
         },
       });
@@ -113,6 +114,7 @@ describe(`[workbox-google-analytics] initialize`, function() {
         transport_type: 'image',
         event_label: Date.now(),
         event_callback: () => {
+          // See https://github.com/GoogleChrome/workbox/issues/2168
           setTimeout(done, 50);
         },
       });

--- a/test/workbox-google-analytics/integration/test-all.js
+++ b/test/workbox-google-analytics/integration/test-all.js
@@ -102,7 +102,9 @@ describe(`[workbox-google-analytics] initialize`, function() {
       window.gtag('event', 'beacon', {
         transport_type: 'beacon',
         event_label: Date.now(),
-        event_callback: done,
+        event_callback: () => {
+          setTimeout(done, 50);
+        },
       });
     });
 
@@ -110,7 +112,9 @@ describe(`[workbox-google-analytics] initialize`, function() {
       window.gtag('event', 'pixel', {
         transport_type: 'image',
         event_label: Date.now(),
-        event_callback: done,
+        event_callback: () => {
+          setTimeout(done, 50);
+        },
       });
     });
 
@@ -160,8 +164,6 @@ describe(`[workbox-google-analytics] initialize`, function() {
     // and ensure those values reflect the original order of the hits.
     expect(requests[0].params.qt > 0).to.be.true;
     expect(requests[1].params.qt > 0).to.be.true;
-    // This should be <= instead of less than, since a ms didn't necessarily
-    // pass in between the two events.
-    expect(requests[0].originalTime <= requests[1].originalTime).to.be.true;
+    expect(requests[0].originalTime < requests[1].originalTime).to.be.true;
   });
 });


### PR DESCRIPTION
R: @philipwalton

Fixes #2168

I'm not super-familiar with this test, but I could plausibly see how sending both of the GA events back-to-back could cause the replay order to get out of whack. So I'm taking the coward's way out and adding a short timeout in between each.