### PR TITLE
Ignore NoSuchWindowError in workbox-window test

### DIFF
--- a/test/workbox-window/integration/test-all.js
+++ b/test/workbox-window/integration/test-all.js
@@ -36,7 +36,11 @@ describe(`[workbox-window] Workbox`, function() {
   });
 
   afterEach(async function() {
-    await unregisterAllSWs();
+    try {
+      await unregisterAllSWs();
+    } catch (error) {
+      // no-op
+    }
   });
 
   describe('register', () => {
@@ -147,8 +151,7 @@ describe(`[workbox-window] Workbox`, function() {
       expect(result.controllingSpyCallCount).to.equal(1);
     });
 
-    // TODO: https://github.com/GoogleChrome/workbox/issues/2150
-    it.skip(`reports all events for an external SW registration`, async function() {
+    it(`reports all events for an external SW registration`, async function() {
       const firstTab = await getLastWindowHandle();
 
       await executeAsyncAndCatch(async (cb) => {


### PR DESCRIPTION
R: @philipwalton

Fixes #2150

Just a hunch that ignoring this error might work around what appears to be a timing problem in Travis CI. (I can't reproduce it locally.)