### PR TITLE
Set cache: 'reload' on precaching requests

### DIFF
--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -113,8 +113,8 @@ class PrecacheController {
       }
     }
 
-    const toBePrecached = [];
-    const alreadyPrecached = [];
+    const toBePrecached: {cacheKey: string, url: string}[] = [];
+    const alreadyPrecached: string[] = [];
 
     const cache = await caches.open(this._cacheName);
     const alreadyCachedRequests = await cache.keys();

--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -113,35 +113,37 @@ class PrecacheController {
       }
     }
 
-    const urlsToPrecache = [];
-    const urlsAlreadyPrecached = [];
+    const toBePrecached = [];
+    const alreadyPrecached = [];
 
     const cache = await caches.open(this._cacheName);
     const alreadyCachedRequests = await cache.keys();
-    const alreadyCachedURLs = new Set(alreadyCachedRequests.map(
+    const existingCacheKeys = new Set(alreadyCachedRequests.map(
         (request) => request.url));
 
-    for (const cacheKey of this._urlsToCacheKeys.values()) {
-      if (alreadyCachedURLs.has(cacheKey)) {
-        urlsAlreadyPrecached.push(cacheKey);
+    for (const [url, cacheKey] of this._urlsToCacheKeys) {
+      if (existingCacheKeys.has(cacheKey)) {
+        alreadyPrecached.push(url);
       } else {
-        urlsToPrecache.push(cacheKey);
+        toBePrecached.push({cacheKey, url});
       }
     }
 
-    const precacheRequests = urlsToPrecache.map((url) => {
-      const integrity = this._cacheKeysToIntegrities.get(url);
-      return this._addURLToCache({event, plugins, url, integrity});
+    const precacheRequests = toBePrecached.map(({cacheKey, url}) => {
+      const integrity = this._cacheKeysToIntegrities.get(cacheKey);
+      return this._addURLToCache({cacheKey, event, plugins, url, integrity});
     });
     await Promise.all(precacheRequests);
 
+    const updatedURLs = toBePrecached.map((item) => item.url);
+
     if (process.env.NODE_ENV !== 'production') {
-      printInstallDetails(urlsToPrecache, urlsAlreadyPrecached);
+      printInstallDetails(updatedURLs, alreadyPrecached);
     }
 
     return {
-      updatedURLs: urlsToPrecache,
-      notUpdatedURLs: urlsAlreadyPrecached,
+      updatedURLs,
+      notUpdatedURLs: alreadyPrecached,
     };
   }
 
@@ -182,12 +184,16 @@ class PrecacheController {
    *
    * @private
    * @param {Object} options
+   * @param {string} options.cacheKey The string to use a cache key.
    * @param {string} options.url The URL to fetch and cache.
    * @param {Event} [options.event] The install event (if passed).
    * @param {Array<Object>} [options.plugins] An array of plugins to apply to
    * fetch and caching.
+   * @param {string} [options.integrity] The value to use for the `integrity`
+   * field when making the request.
    */
-  async _addURLToCache({url, event, plugins, integrity}: {
+  async _addURLToCache({cacheKey, url, event, plugins, integrity}: {
+    cacheKey: string,
     url: string,
     event?: ExtendableEvent,
     plugins?: WorkboxPlugin[],
@@ -195,6 +201,7 @@ class PrecacheController {
   }) {
     const request = new Request(url, {
       integrity,
+      cache: 'reload',
       credentials: 'same-origin',
     });
 
@@ -239,8 +246,9 @@ class PrecacheController {
     await cacheWrapper.put({
       event,
       plugins,
-      request,
       response,
+      // `request` already uses `url`. We may be able to reuse it.
+      request: cacheKey === url ? request : new Request(cacheKey),
       cacheName: this._cacheName,
       matchOptions: {
         ignoreSearch: true,

--- a/test/workbox-precaching/integration/test-precache-and-update.js
+++ b/test/workbox-precaching/integration/test-precache-and-update.js
@@ -44,8 +44,8 @@ describe(`[workbox-precaching] Precache and Update`, function() {
       'http://localhost:3004/test/workbox-precaching/static/precache-and-update/styles/index.css?__WB_REVISION__=1',
     ]);
 
-    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/styles/index.css?__WB_REVISION__=1')).to.equal(1);
-    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html?__WB_REVISION__=1')).to.equal(1);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/styles/index.css')).to.equal(1);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html')).to.equal(1);
 
     // Unregister the old counter, and start a new count.
     global.__workbox.server.stopCountingRequests(requestCounter);
@@ -67,7 +67,7 @@ describe(`[workbox-precaching] Precache and Update`, function() {
     // Add a slight delay for the caching operation to complete.
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
-    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html?__WB_REVISION__=2')).to.equal(1);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html')).to.equal(1);
     expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/hashed-file.abcd1234.txt')).to.equal(1);
 
     // Check that the cached entries were deleted / added as expected when


### PR DESCRIPTION
R: @philipwalton

Fixes #2146

This PR sets `cache: 'reload'` as an alternative to using the `__WB_REVISION=...` URL query parameter on the outgoing network requests used to populate the precache.

I also renamed some variables to clarify the distinction between `cacheKey` & `url` within the `install()` method.

The underlying precache keys still use the `__WB_REVISION=...` query parameters, as we continue to use those parameters as versioning metadata.

There's a slight breaking change in the `updatedURLs` & `notUpdatedURLs` values that are returned by `install()`: the previously would include `__WB_REVISION` query parameters, and now they won't. Since those return values are only used for logging/display purposes, this change is probably an improvement.