### PR TITLE
Add a RouteHandlerObject type

### DIFF
--- a/packages/workbox-core/src/types.ts
+++ b/packages/workbox-core/src/types.ts
@@ -59,9 +59,15 @@ export interface RouteHandlerCallback {
  * function or this `RouteHandler` object. The benefit of the `RouteHandler`
  * is it can be extended (as is done by the `workbox-strategies` package).
  */
-export interface RouteHandler {
-  handle(opts: RouteHandlerCallbackOptions): Promise<Response>;
+export interface RouteHandlerObject {
+  handle: RouteHandlerCallback;
 }
+
+/**
+ * Either a `RouteHandlerCallback` or a `RouteHandlerObject`.
+ * Most APIs in `workbox-routing` that accept route handlers take either.
+ */
+export type RouteHandler = RouteHandlerCallback | RouteHandlerObject;
 
 interface CacheDidUpdateCallback {
   ({cacheName, oldResponse, newResponse, request, event}: {

--- a/packages/workbox-routing/src/NavigationRoute.ts
+++ b/packages/workbox-routing/src/NavigationRoute.ts
@@ -9,7 +9,7 @@
 import {assert} from 'workbox-core/_private/assert.js';
 import {logger} from 'workbox-core/_private/logger.js';
 import {Route} from './Route.js';
-import {HandlerCallback, MatchCallbackOptions} from './_types.js';
+import {Handler, MatchCallbackOptions} from './_types.js';
 import './_version.js';
 
 export interface NavigationRouteMatchOptions {
@@ -55,7 +55,7 @@ class NavigationRoute extends Route {
    * match the URL's pathname and search parameter, the route will handle the
    * request (assuming the blacklist doesn't match).
    */
-  constructor(handler: HandlerCallback,
+  constructor(handler: Handler,
       {whitelist = [/./], blacklist = []}: NavigationRouteMatchOptions = {}) {
     if (process.env.NODE_ENV !== 'production') {
       assert!.isArrayOfClass(whitelist, RegExp, {

--- a/packages/workbox-routing/src/RegExpRoute.ts
+++ b/packages/workbox-routing/src/RegExpRoute.ts
@@ -10,7 +10,7 @@ import {assert} from 'workbox-core/_private/assert.js';
 import {logger} from 'workbox-core/_private/logger.js';
 import {HTTPMethod} from './utils/constants.js';
 import {Route} from './Route.js';
-import {MatchCallbackOptions, HandlerCallback, MatchCallback} from './_types.js';
+import {Handler, MatchCallbackOptions, MatchCallback} from './_types.js';
 import './_version.js';
 
 
@@ -41,7 +41,7 @@ class RegExpRoute extends Route {
    * @param {string} [method='GET'] The HTTP method to match the Route
    * against.
    */
-  constructor(regExp: RegExp, handler: HandlerCallback, method?: HTTPMethod) {
+  constructor(regExp: RegExp, handler: Handler, method?: HTTPMethod) {
     if (process.env.NODE_ENV !== 'production') {
       assert!.isInstance(regExp, RegExp, {
         moduleName: 'workbox-routing',

--- a/packages/workbox-routing/src/Route.ts
+++ b/packages/workbox-routing/src/Route.ts
@@ -9,7 +9,7 @@
 import {assert} from 'workbox-core/_private/assert.js';
 import {HTTPMethod, defaultMethod, validMethods} from './utils/constants.js';
 import {normalizeHandler} from './utils/normalizeHandler.js';
-import {Handler, HandlerCallback, MatchCallback} from './_types.js';
+import {Handler, HandlerObject, MatchCallback} from './_types.js';
 import './_version.js';
 
 
@@ -23,7 +23,7 @@ import './_version.js';
  * @memberof workbox.routing
  */
 class Route {
-  handler: Handler;
+  handler: HandlerObject;
   match: MatchCallback;
   method: HTTPMethod;
 
@@ -40,7 +40,7 @@ class Route {
    */
   constructor(
       match: MatchCallback,
-      handler: HandlerCallback | Handler,
+      handler: Handler,
       method: HTTPMethod = defaultMethod) {
     if (process.env.NODE_ENV !== 'production') {
       assert!.isType(match, 'function', {

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -13,7 +13,7 @@ import {getFriendlyURL} from 'workbox-core/_private/getFriendlyURL.js';
 import {Route} from './Route.js';
 import {HTTPMethod} from './utils/constants.js';
 import {normalizeHandler} from './utils/normalizeHandler.js';
-import {Handler, HandlerCallback, HandlerCallbackOptions} from './_types.js';
+import {Handler, HandlerObject, HandlerCallbackOptions} from './_types.js';
 import './_version.js';
 
 
@@ -46,8 +46,8 @@ interface CacheURLsMessageData {
  */
 class Router {
   private _routes: Map<HTTPMethod, Route[]>;
-  private _defaultHandler: Handler;
-  private _catchHandler: Handler;
+  private _defaultHandler: HandlerObject;
+  private _catchHandler: HandlerObject;
 
   /**
    * Initializes a new Router.
@@ -327,7 +327,7 @@ class Router {
    * @param {workbox.routing.Route~handlerCallback} handler A callback
    * function that returns a Promise resulting in a Response.
    */
-  setDefaultHandler(handler: HandlerCallback) {
+  setDefaultHandler(handler: Handler) {
     this._defaultHandler = normalizeHandler(handler);
   }
 
@@ -338,7 +338,7 @@ class Router {
    * @param {workbox.routing.Route~handlerCallback} handler A callback
    * function that returns a Promise resulting in a Response.
    */
-  setCatchHandler(handler: HandlerCallback) {
+  setCatchHandler(handler: Handler) {
     this._catchHandler = normalizeHandler(handler);
   }
 

--- a/packages/workbox-routing/src/_types.ts
+++ b/packages/workbox-routing/src/_types.ts
@@ -8,6 +8,7 @@
 
 import {
   RouteHandler,
+  RouteHandlerObject,
   RouteHandlerCallback,
   RouteHandlerCallbackOptions,
   RouteMatchCallback,
@@ -66,6 +67,7 @@ import './_version.js';
 
  export {
   RouteHandler as Handler,
+  RouteHandlerObject as HandlerObject,
   RouteHandlerCallback as HandlerCallback,
   RouteHandlerCallbackOptions as HandlerCallbackOptions,
   RouteMatchCallback as MatchCallback,

--- a/packages/workbox-routing/src/registerRoute.ts
+++ b/packages/workbox-routing/src/registerRoute.ts
@@ -12,7 +12,7 @@ import {Route} from './Route.js';
 import {RegExpRoute} from './RegExpRoute.js';
 import {HTTPMethod} from './utils/constants.js';
 import {getOrCreateDefaultRouter} from './utils/getOrCreateDefaultRouter.js';
-import {MatchCallback, HandlerCallback} from './_types.js';
+import {Handler, MatchCallback} from './_types.js';
 import './_version.js';
 
 
@@ -43,7 +43,7 @@ import './_version.js';
  */
 export const registerRoute = (
     capture: RegExp | string | MatchCallback | Route,
-    handler?: HandlerCallback,
+    handler?: Handler,
     method?: HTTPMethod): Route => {
   let route;
 

--- a/packages/workbox-routing/src/setCatchHandler.ts
+++ b/packages/workbox-routing/src/setCatchHandler.ts
@@ -7,7 +7,7 @@
 */
 
 import {getOrCreateDefaultRouter} from './utils/getOrCreateDefaultRouter.js';
-import {HandlerCallback} from './_types.js';
+import {Handler} from './_types.js';
 import './_version.js';
 
 
@@ -20,7 +20,7 @@ import './_version.js';
  *
  * @alias workbox.routing.setCatchHandler
  */
-export const setCatchHandler = (handler: HandlerCallback) => {
+export const setCatchHandler = (handler: Handler) => {
   const defaultRouter = getOrCreateDefaultRouter();
   defaultRouter.setCatchHandler(handler);
 };

--- a/packages/workbox-routing/src/setDefaultHandler.ts
+++ b/packages/workbox-routing/src/setDefaultHandler.ts
@@ -7,7 +7,7 @@
 */
 
 import {getOrCreateDefaultRouter} from './utils/getOrCreateDefaultRouter.js';
-import {HandlerCallback} from './_types.js';
+import {Handler} from './_types.js';
 import './_version.js';
 
 
@@ -23,7 +23,7 @@ import './_version.js';
  *
  * @alias workbox.routing.setDefaultHandler
  */
-export const setDefaultHandler = (handler: HandlerCallback) => {
+export const setDefaultHandler = (handler: Handler) => {
   const defaultRouter = getOrCreateDefaultRouter();
   defaultRouter.setDefaultHandler(handler);
 };

--- a/packages/workbox-routing/src/utils/normalizeHandler.ts
+++ b/packages/workbox-routing/src/utils/normalizeHandler.ts
@@ -7,7 +7,7 @@
 */
 
 import {assert} from 'workbox-core/_private/assert.js';
-import {Handler, HandlerCallback} from '../_types.js';
+import {Handler, HandlerObject} from '../_types.js';
 import '../_version.js';
 
 
@@ -19,8 +19,8 @@ import '../_version.js';
  * @private
  */
 export const normalizeHandler = (
-  handler: Handler | HandlerCallback
-): Handler => {
+  handler: Handler
+): HandlerObject => {
   if (handler && typeof handler === 'object') {
     if (process.env.NODE_ENV !== 'production') {
       assert!.hasMethod(handler, 'handle', {

--- a/packages/workbox-strategies/src/CacheFirst.ts
+++ b/packages/workbox-strategies/src/CacheFirst.ts
@@ -13,7 +13,7 @@ import {fetchWrapper} from 'workbox-core/_private/fetchWrapper.js';
 import {getFriendlyURL} from 'workbox-core/_private/getFriendlyURL.js';
 import {logger} from 'workbox-core/_private/logger.js';
 import {WorkboxError} from 'workbox-core/_private/WorkboxError.js';
-import {RouteHandler, RouteHandlerCallbackOptions, WorkboxPlugin} from 'workbox-core/types.js';
+import {RouteHandlerObject, RouteHandlerCallbackOptions, WorkboxPlugin} from 'workbox-core/types.js';
 import {messages} from './utils/messages.js';
 import './_version.js';
 
@@ -38,7 +38,7 @@ interface CacheFirstOptions {
  *
  * @memberof workbox.strategies
  */
-class CacheFirst implements RouteHandler {
+class CacheFirst implements RouteHandlerObject {
   private _cacheName: string;
   private _plugins: WorkboxPlugin[];
   private _fetchOptions?: RequestInit;

--- a/packages/workbox-strategies/src/CacheOnly.ts
+++ b/packages/workbox-strategies/src/CacheOnly.ts
@@ -11,7 +11,7 @@ import {cacheNames} from 'workbox-core/_private/cacheNames.js';
 import {cacheWrapper} from 'workbox-core/_private/cacheWrapper.js';
 import {logger} from 'workbox-core/_private/logger.js';
 import {WorkboxError} from 'workbox-core/_private/WorkboxError.js';
-import {RouteHandler, RouteHandlerCallbackOptions, WorkboxPlugin} from 'workbox-core/types.js';
+import {RouteHandlerObject, RouteHandlerCallbackOptions, WorkboxPlugin} from 'workbox-core/types.js';
 import {messages} from './utils/messages.js';
 import './_version.js';
 
@@ -34,7 +34,7 @@ interface CacheOnlyOptions {
  *
  * @memberof workbox.strategies
  */
-class CacheOnly implements RouteHandler {
+class CacheOnly implements RouteHandlerObject {
   private _cacheName: string;
   private _plugins: WorkboxPlugin[];
   private _matchOptions?: CacheQueryOptions;

--- a/packages/workbox-strategies/src/NetworkFirst.ts
+++ b/packages/workbox-strategies/src/NetworkFirst.ts
@@ -13,7 +13,7 @@ import {fetchWrapper} from 'workbox-core/_private/fetchWrapper.js';
 import {getFriendlyURL} from 'workbox-core/_private/getFriendlyURL.js';
 import {logger} from 'workbox-core/_private/logger.js';
 import {WorkboxError} from 'workbox-core/_private/WorkboxError.js';
-import {RouteHandler, RouteHandlerCallbackOptions, WorkboxPlugin} from 'workbox-core/types.js';
+import {RouteHandlerObject, RouteHandlerCallbackOptions, WorkboxPlugin} from 'workbox-core/types.js';
 import {messages} from './utils/messages.js';
 import {cacheOkAndOpaquePlugin} from './plugins/cacheOkAndOpaquePlugin.js';
 import './_version.js';
@@ -42,7 +42,7 @@ interface NetworkFirstOptions {
  *
  * @memberof workbox.strategies
  */
-class NetworkFirst implements RouteHandler {
+class NetworkFirst implements RouteHandlerObject {
   private _cacheName: string;
   private _plugins: WorkboxPlugin[];
   private _fetchOptions?: RequestInit;

--- a/packages/workbox-strategies/src/NetworkOnly.ts
+++ b/packages/workbox-strategies/src/NetworkOnly.ts
@@ -10,7 +10,7 @@ import {assert} from 'workbox-core/_private/assert.js';
 import {fetchWrapper} from 'workbox-core/_private/fetchWrapper.js';
 import {logger} from 'workbox-core/_private/logger.js';
 import {WorkboxError} from 'workbox-core/_private/WorkboxError.js';
-import {RouteHandler, RouteHandlerCallbackOptions, WorkboxPlugin} from 'workbox-core/types.js';
+import {RouteHandlerObject, RouteHandlerCallbackOptions, WorkboxPlugin} from 'workbox-core/types.js';
 import {messages} from './utils/messages.js';
 import './_version.js';
 
@@ -32,7 +32,7 @@ interface NetworkFirstOptions {
  *
  * @memberof workbox.strategies
  */
-class NetworkOnly implements RouteHandler {
+class NetworkOnly implements RouteHandlerObject {
   private _plugins: WorkboxPlugin[];
   private _fetchOptions?: RequestInit;
 

--- a/packages/workbox-strategies/src/StaleWhileRevalidate.ts
+++ b/packages/workbox-strategies/src/StaleWhileRevalidate.ts
@@ -13,7 +13,7 @@ import {fetchWrapper} from 'workbox-core/_private/fetchWrapper.js';
 import {getFriendlyURL} from 'workbox-core/_private/getFriendlyURL.js';
 import {logger} from 'workbox-core/_private/logger.js';
 import {WorkboxError} from 'workbox-core/_private/WorkboxError.js';
-import {RouteHandler, RouteHandlerCallbackOptions, WorkboxPlugin} from 'workbox-core/types.js';
+import {RouteHandlerObject, RouteHandlerCallbackOptions, WorkboxPlugin} from 'workbox-core/types.js';
 import {messages} from './utils/messages.js';
 import {cacheOkAndOpaquePlugin} from './plugins/cacheOkAndOpaquePlugin.js';
 import './_version.js';
@@ -46,7 +46,7 @@ interface StaleWhileRevalidateOptions {
  *
  * @memberof workbox.strategies
  */
-class StaleWhileRevalidate implements RouteHandler {
+class StaleWhileRevalidate implements RouteHandlerObject {
   private _cacheName: string;
   private _plugins: WorkboxPlugin[];
   private _fetchOptions?: RequestInit;


### PR DESCRIPTION
R: @jeffposnick

Fixes #2171, fixes #2180.

The were several places in the existing `workbox-routing` code where our type definitions claim to only accept `HandlerCallback`, but in reality we accept `Handler | HandlerCallback`.

Instead of adding both types everywhere, I opted to renamed the old `Handler` type to `HandlerObject`, and then re-add `Handler` as `HandlerObject | HandlerCallback` (since that's what's exposed to most public APIs).

The end result was about the same about of code/changes, but I think calling it `HandlerObject` (or `RouteHandlerObject` in the core) is a bit more explicit.
