### PR TITLE
Add redundant to WorkboxLifecycleEventMap

### DIFF
--- a/packages/workbox-window/src/utils/WorkboxEvent.ts
+++ b/packages/workbox-window/src/utils/WorkboxEvent.ts
@@ -51,6 +51,7 @@ export interface WorkboxLifecycleEventMap {
   'externalwaiting': WorkboxLifecycleWaitingEvent;
   'externalactivating': WorkboxLifecycleEvent;
   'externalactivated': WorkboxLifecycleEvent;
+  'redundant': WorkboxLifecycleEvent;
 }
 
 export interface WorkboxEventMap extends WorkboxLifecycleEventMap {


### PR DESCRIPTION
R: @jeffposnick @philipwalton
Fixes #2199 

Should I add externalredundant as well? I don't think that exists right?