### PR TITLE
Installing Race Condition Test

### DIFF
--- a/infra/testing/server/templates/sw-installed-on-message.js.njk
+++ b/infra/testing/server/templates/sw-installed-on-message.js.njk
@@ -1,0 +1,36 @@
+/*
+  Copyright 2019 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+// {{ version }}
+
+// From packages/workbox-core/src/_private/Deferred.ts
+// TODO figure out how to import from there
+class Deferred {
+  constructor() {
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+const installedDeferred = new Deferred();
+addEventListener('install', (event) => {
+  return event.waitUntil(
+    installedDeferred.promise
+      .then(() => skipWaiting())
+  );
+})
+
+addEventListener('message', (event) => {
+  if (event.data.type === 'FINISH_INSTALL') {
+    installedDeferred.resolve();
+  }
+});
+
+addEventListener('activate', (event) => event.waitUntil(clients.claim()));

--- a/test/workbox-window/static/index.html
+++ b/test/workbox-window/static/index.html
@@ -22,10 +22,11 @@
   <p>You need to manually register a service worker</p>
 
   <script type="module">
-  import {Workbox} from '/__WORKBOX/buildFile/workbox-window'
+  import {Workbox, messageSW} from '/__WORKBOX/buildFile/workbox-window'
 
   // Expose on the global object so it can be referenced by webdriver.
   window.Workbox = Workbox;
+  window.messageSW = messageSW;
   </script>
 </body>
 </html>


### PR DESCRIPTION
**Prior to filing a PR, please:**
Based on discussion in #2209 #2216 
This is a test case trying to recreate a race condition where the service worker is in `"installing"` state when the user/developer calls `wb.register()`.

Workbox does not add listeners to pre-existing `registration.installing` service worker but only when `updatefound` event is triggered.

R: @jeffposnick @philipwalton