### PR TITLE
Guard against undefined reference in webpack plugin

### DIFF
--- a/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-from-compilation.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-from-compilation.js
@@ -66,7 +66,10 @@ function assetToChunkNameMapping(stats) {
 
   for (const [chunkName, {assets}] of Object.entries(stats.namedChunkGroups)) {
     for (const assetName of assets) {
-      mapping[assetName].add(chunkName);
+      // See https://github.com/GoogleChrome/workbox/issues/2194
+      if (mapping[assetName]) {
+        mapping[assetName].add(chunkName);
+      }
     }
   }
 


### PR DESCRIPTION
R: @philipwalton

Fixes #2194

The code in question should be safe to skip if the condition is false.