### PR TITLE
[workbox-strategies] Fix StaleWhileRevalidate docs

### DIFF
--- a/packages/workbox-strategies/src/StaleWhileRevalidate.ts
+++ b/packages/workbox-strategies/src/StaleWhileRevalidate.ts
@@ -38,7 +38,7 @@ interface StaleWhileRevalidateOptions {
  *
  * By default, this strategy will cache responses with a 200 status code as
  * well as [opaque responses]{@link https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests}.
- * Opaque responses are are cross-origin requests where the response doesn't
+ * Opaque responses are cross-origin requests where the response doesn't
  * support [CORS]{@link https://enable-cors.org/}.
  *
  * If the network request fails, and there is no cache match, this will throw


### PR DESCRIPTION
**Prior to filing a PR, please:**
- [open an issue](https://github.com/GoogleChrome/workbox/issues/new) to discuss your proposed change.
- ensure that `gulp lint test` passes locally.

(This is not an actual issue fix, it's a typo fix. I think creating issue would be redundant.)

R: @jeffposnick @philipwalton

*Description of what's changed/fixed.*

Fixes typo in StaleWhileRevalidate docs. 