### PR TITLE
Use cache: default for precaching requests when it's safe to

### DIFF
--- a/test/workbox-precaching/sw/test-PrecacheController.mjs
+++ b/test/workbox-precaching/sw/test-PrecacheController.mjs
@@ -491,7 +491,7 @@ describe(`PrecacheController`, function() {
       expect(request.credentials).to.eql('same-origin');
     });
 
-    it(`should set cache: 'reload' on the precaching requests`, async function() {
+    it(`should use cache: 'reload' on the precaching requests when there's a revision field`, async function() {
       const fetchStub = sandbox.stub(fetchWrapper, 'fetch').resolves(new Response('test'));
 
       const precacheController = new PrecacheController();
@@ -506,6 +506,23 @@ describe(`PrecacheController`, function() {
       const {request} = fetchStub.firstCall.args[0];
       expect(request.url).to.eql(`${location.origin}/test`);
       expect(request.cache).to.eql('reload');
+    });
+
+    it(`should use cache: 'default' on the precaching requests when there's no revision field`, async function() {
+      const fetchStub = sandbox.stub(fetchWrapper, 'fetch').resolves(new Response('test'));
+
+      const precacheController = new PrecacheController();
+      const cacheList = [
+        {url: '/test'},
+      ];
+      precacheController.addToCacheList(cacheList);
+
+      await precacheController.install();
+
+      expect(fetchStub.calledOnce).to.be.true;
+      const {request} = fetchStub.firstCall.args[0];
+      expect(request.url).to.eql(`${location.origin}/test`);
+      expect(request.cache).to.eql('default');
     });
 
     it(`should pass in a request that includes the revision to cacheWrapper.put()`, async function() {


### PR DESCRIPTION
I was revisiting the changes in #2176, and realized that one unintended consequence was that if the HTTP cache contained a valid entry for a URL that could be safely read from the cache (i.e. there's no `revision` field for the precache manifest entry), the precaching  request would still go to the network.

While this is "safe", it's less efficient.

This change accounts for that, and will set `cache: 'default'` for those requests that could be safely satisfied by the HTTP cache,  with `cache: 'reload'` still being set for requests that should always ignore the cache and go against the network.