### PR TITLE
Don't double-prepend the output dir

### DIFF
--- a/packages/workbox-build/src/lib/write-sw-using-default-template.js
+++ b/packages/workbox-build/src/lib/write-sw-using-default-template.js
@@ -72,7 +72,7 @@ module.exports = async ({
     const filePaths = [];
 
     for (const file of files) {
-      const filePath = upath.resolve(outputDir, file.name);
+      const filePath = upath.resolve(file.name);
       filePaths.push(filePath);
       await fse.writeFile(filePath, file.contents);
     }

--- a/test/workbox-build/node/lib/write-sw-using-default-template.js
+++ b/test/workbox-build/node/lib/write-sw-using-default-template.js
@@ -98,10 +98,10 @@ describe(`[workbox-build] lib/write-sw-using-default-template.js`, function() {
         writeFile: writeFileStub,
       },
       './bundle': async () => [{
-        name: file1,
+        name: upath.join(expectedPath, file1),
         contents: contents1,
       }, {
-        name: file2,
+        name: upath.join(expectedPath, file2),
         contents: contents2,
       }],
       './populate-sw-template': () => '',


### PR DESCRIPTION
R: @philipwalton 

I came across this issue when manually testing v5 using a config like:

```
module.exports = {
  globDirectory: 'public',
  swDest: 'public/service-worker.js',
};
```

Prior to this change, the code would attempt to write the generated service worker to `public/public/service-worker.js`, because the filenames returned from Rollup would already include the `public/` prefix.

(The original test unfortunately did not catch this because the wrong assumption was made when stubbing out Rollup's behavior.)