### PR TITLE
Allow the same swSrc and swDest in injectManifest

### DIFF
--- a/packages/workbox-build/src/lib/errors.js
+++ b/packages/workbox-build/src/lib/errors.js
@@ -90,8 +90,9 @@ module.exports = {
   'invalid-generate-file-manifest-arg': ol`The input to generateFileManifest()
     must be an Object.`,
   'invalid-sw-src': `The 'swSrc' file can't be read.`,
-  'same-src-and-dest': ol`'swSrc' and 'swDest' should not be set to the same ` +
-    `file. Please use a different file path for 'swDest'.`,
+  'same-src-and-dest': ol`Unable to find a place to inject the manifest. This is
+    likely because swSrc and swDest are configured to the same file.
+    Please ensure that your swSrc file contains the following:`,
   'only-regexp-routes-supported': ol`Please use a regular expression object as
     the urlPattern parameter. (Express-style routes are not currently
     supported.)`,

--- a/test/workbox-build/node/inject-manifest.js
+++ b/test/workbox-build/node/inject-manifest.js
@@ -118,38 +118,6 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       }
     });
 
-    it(`should throw the expected error when 'swSrc' and 'swDest' are the same path`, async function() {
-      const path = 'same.js';
-      const options = Object.assign({}, BASE_OPTIONS, {
-        swSrc: path,
-        swDest: path,
-      });
-
-      try {
-        await injectManifest(options);
-        throw new Error('Unexpected success.');
-      } catch (error) {
-        expect(error.message).to.have.string(errors['same-src-and-dest']);
-      }
-    });
-
-    it(`should throw the expected error when a relative 'swSrc' and absolute 'swDest' are the same path`, async function() {
-      const swSrc = 'same.js';
-      const swDest = upath.join(process.cwd(), 'same.js');
-
-      const options = Object.assign({}, BASE_OPTIONS, {
-        swSrc,
-        swDest,
-      });
-
-      try {
-        await injectManifest(options);
-        throw new Error('Unexpected success.');
-      } catch (error) {
-        expect(error.message).to.have.string(errors['same-src-and-dest']);
-      }
-    });
-
     it(`should throw the expected error when there is no match for 'injectionPoint'`, async function() {
       const options = Object.assign({}, BASE_OPTIONS, {
         swSrc: upath.join(SW_SRC_DIR, 'bad-no-injection.js'),
@@ -160,6 +128,21 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
         throw new Error('Unexpected success.');
       } catch (error) {
         expect(error.message).to.have.string(errors['injection-point-not-found']);
+      }
+    });
+
+    it(`should throw the expected error when there is no match for 'injectionPoint' and 'swSrc' and 'swDest' are the same`, async function() {
+      const swFile = upath.join(SW_SRC_DIR, 'bad-no-injection.js');
+      const options = Object.assign({}, BASE_OPTIONS, {
+        swSrc: swFile,
+        swDest: swFile,
+      });
+
+      try {
+        await injectManifest(options);
+        throw new Error('Unexpected success.');
+      } catch (error) {
+        expect(error.message).to.have.string(errors['same-src-and-dest']);
       }
     });
 


### PR DESCRIPTION
R: @philipwalton

Fixes #2230

This allows for a use case that's likely to become more common when folks bundle their own SW and then use our build tools to run `injectManifest`.