### PR TITLE
Ignore both swSrc and swDest when globbing for the manifest

### DIFF
--- a/packages/workbox-build/src/generate-sw.js
+++ b/packages/workbox-build/src/generate-sw.js
@@ -8,6 +8,7 @@
 
 const generateSWSchema = require('./options/schema/generate-sw');
 const getFileManifestEntries = require('./lib/get-file-manifest-entries');
+const upath = require('upath');
 const validate = require('./lib/validate-options');
 const writeServiceWorkerUsingDefaultTemplate =
   require('./lib/write-sw-using-default-template');
@@ -35,6 +36,14 @@ const writeServiceWorkerUsingDefaultTemplate =
  */
 async function generateSW(config) {
   const options = validate(config, generateSWSchema);
+
+  if (options.globDirectory) {
+    // Make sure we leave swDest out of the precache manifest.
+    const absoluteSWDest = upath.resolve(options.swDest);
+    const swDestRelativeToGlobDirectory = upath.relative(options.globDirectory,
+        absoluteSWDest);
+    options.globIgnores.push(swDestRelativeToGlobDirectory);
+  }
 
   const {count, size, manifestEntries, warnings} =
     await getFileManifestEntries(options);

--- a/packages/workbox-build/src/inject-manifest.js
+++ b/packages/workbox-build/src/inject-manifest.js
@@ -14,6 +14,7 @@ const errors = require('./lib/errors');
 const escapeRegexp = require('./lib/escape-regexp');
 const getFileManifestEntries = require('./lib/get-file-manifest-entries');
 const injectManifestSchema = require('./options/schema/inject-manifest');
+const rebasePath = require('./lib/rebase-path');
 const validate = require('./lib/validate-options');
 
 /**
@@ -42,10 +43,10 @@ async function injectManifest(config) {
 
   // Make sure we leave swSrc and swDest out of the precache manifest.
   for (const file of [options.swSrc, options.swDest]) {
-    const absolutePath = upath.resolve(file);
-    const pathRelativeToGlobDirectory = upath.relative(options.globDirectory,
-        absolutePath);
-    options.globIgnores.push(pathRelativeToGlobDirectory);
+    options.globIgnores.push(rebasePath({
+      file,
+      baseDirectory: options.globDirectory,
+    }));
   }
 
 

--- a/packages/workbox-build/src/inject-manifest.js
+++ b/packages/workbox-build/src/inject-manifest.js
@@ -40,6 +40,15 @@ const validate = require('./lib/validate-options');
 async function injectManifest(config) {
   const options = validate(config, injectManifestSchema);
 
+  // Make sure we leave swSrc and swDest out of the precache manifest.
+  for (const file of [options.swSrc, options.swDest]) {
+    const absolutePath = upath.resolve(file);
+    const pathRelativeToGlobDirectory = upath.relative(options.globDirectory,
+        absolutePath);
+    options.globIgnores.push(pathRelativeToGlobDirectory);
+  }
+
+
   if (upath.resolve(config.swSrc) === upath.resolve(config.swDest)) {
     throw new Error(errors['same-src-and-dest']);
   }

--- a/packages/workbox-build/src/lib/get-file-manifest-entries.js
+++ b/packages/workbox-build/src/lib/get-file-manifest-entries.js
@@ -7,7 +7,6 @@
 */
 
 const assert = require('assert');
-const upath = require('upath');
 
 const errors = require('./errors');
 const transformManifest = require('./transform-manifest');

--- a/packages/workbox-build/src/lib/get-file-manifest-entries.js
+++ b/packages/workbox-build/src/lib/get-file-manifest-entries.js
@@ -36,11 +36,6 @@ module.exports = async ({
   const fileSet = new Set();
 
   if (globDirectory) {
-    if (swDest) {
-      // Ensure that we ignore the SW file we're eventually writing to disk.
-      globIgnores.push(`**/${upath.basename(swDest)}`);
-    }
-
     try {
       fileDetails = globPatterns.reduce((accumulated, globPattern) => {
         const {globbedFileDetails, warning} = getFileDetails({

--- a/packages/workbox-build/src/lib/rebase-path.js
+++ b/packages/workbox-build/src/lib/rebase-path.js
@@ -1,0 +1,22 @@
+/*
+  Copyright 2018 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+const upath = require('upath');
+
+module.exports = ({baseDirectory, file}) => {
+  // file starts our relative to the current directory, so make it absolute.
+  const absolutePath = upath.resolve(file);
+
+  // Convert the absolute path so that it's relative to the baseDirectory.
+  const relativePath = upath.relative(baseDirectory, absolutePath);
+
+  // Remove any leading ./ as it won't work in a glob pattern.
+  const normalizedPath = upath.normalize(relativePath);
+
+  return normalizedPath;
+};

--- a/packages/workbox-build/src/lib/rebase-path.js
+++ b/packages/workbox-build/src/lib/rebase-path.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2018 Google LLC
+  Copyright 2019 Google LLC
 
   Use of this source code is governed by an MIT-style
   license that can be found in the LICENSE file or at
@@ -9,7 +9,7 @@
 const upath = require('upath');
 
 module.exports = ({baseDirectory, file}) => {
-  // file starts our relative to the current directory, so make it absolute.
+  // The initial path is relative to the current directory, so make it absolute.
   const absolutePath = upath.resolve(file);
 
   // Convert the absolute path so that it's relative to the baseDirectory.

--- a/test/workbox-build/node/generate-sw.js
+++ b/test/workbox-build/node/generate-sw.js
@@ -936,11 +936,13 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       }
     });
 
-    it(`should ignore swDest when generating manifest entries`, async function() {
+    it(`should ignore swDest and workbox-*.js when generating manifest entries`, async function() {
       const tempDirectory = tempy.directory();
       await fse.copy(BASE_OPTIONS.globDirectory, tempDirectory);
       const swDest = upath.join(tempDirectory, 'service-worker.js');
       await fse.createFile(swDest);
+      // See https://rollupjs.org/guide/en/#outputchunkfilenames
+      await fse.createFile(upath.join(tempDirectory, 'workbox-abcd1234.js'));
       const options = Object.assign({}, BASE_OPTIONS, {
         globDirectory: tempDirectory,
         swDest,

--- a/test/workbox-build/node/generate-sw.js
+++ b/test/workbox-build/node/generate-sw.js
@@ -935,6 +935,44 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         expect(error.details[0].context.key).to.eql('expiration');
       }
     });
+
+    it(`should ignore swDest when generating manifest entries`, async function() {
+      const tempDirectory = tempy.directory();
+      await fse.copy(BASE_OPTIONS.globDirectory, tempDirectory);
+      const swDest = upath.join(tempDirectory, 'service-worker.js');
+      await fse.createFile(swDest);
+      const options = Object.assign({}, BASE_OPTIONS, {
+        globDirectory: tempDirectory,
+        swDest,
+      });
+
+      const {count, size, warnings} = await generateSW(options);
+      expect(warnings).to.be.empty;
+      expect(count).to.eql(6);
+      expect(size).to.eql(2604);
+      await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
+        importScripts: [],
+        precacheAndRoute: [[[{
+          url: 'index.html',
+          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+        }, {
+          url: 'page-1.html',
+          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+        }, {
+          url: 'page-2.html',
+          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+        }, {
+          url: 'styles/stylesheet-1.css',
+          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+        }, {
+          url: 'styles/stylesheet-2.css',
+          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+        }, {
+          url: 'webpackEntry.js',
+          revision: '5b652181a25e96f255d0490203d3c47e',
+        }], {}]],
+      }});
+    });
   });
 
   describe(`[workbox-build] behavior with 'navigationPreload'`, function() {

--- a/test/workbox-build/node/inject-manifest.js
+++ b/test/workbox-build/node/inject-manifest.js
@@ -7,6 +7,7 @@
 */
 
 const expect = require('chai').expect;
+const fse = require('fs-extra');
 const upath = require('upath');
 const tempy = require('tempy');
 
@@ -338,6 +339,50 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
           }], {
             cleanURLs: true,
           }]],
+        },
+      });
+    });
+
+    it(`should ignore swSrc and swDest when generating manifest entries`, async function() {
+      const tempDirectory = tempy.directory();
+      await fse.copy(BASE_OPTIONS.globDirectory, tempDirectory);
+      const swSrc = upath.join(tempDirectory, 'sw-src-service-worker.js');
+      await fse.copyFile(upath.join(SW_SRC_DIR, 'basic.js'), swSrc);
+      const swDest = upath.join(tempDirectory, 'sw-dest-service-worker.js');
+      await fse.createFile(swDest);
+      const options = Object.assign({}, BASE_OPTIONS, {
+        swSrc,
+        swDest,
+        globDirectory: tempDirectory,
+      });
+
+      const {count, size, warnings} = await injectManifest(options);
+      expect(warnings).to.be.empty;
+      expect(count).to.eql(6);
+      expect(size).to.eql(2604);
+      await validateServiceWorkerRuntime({
+        entryPoint: 'injectManifest',
+        swFile: swDest,
+        expectedMethodCalls: {
+          precacheAndRoute: [[[{
+            url: 'index.html',
+            revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          }, {
+            url: 'page-1.html',
+            revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          }, {
+            url: 'page-2.html',
+            revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          }, {
+            url: 'styles/stylesheet-1.css',
+            revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          }, {
+            url: 'styles/stylesheet-2.css',
+            revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          }, {
+            url: 'webpackEntry.js',
+            revision: '5b652181a25e96f255d0490203d3c47e',
+          }]]],
         },
       });
     });


### PR DESCRIPTION
R: @philipwalton

Fixes #2229

We previously had some code that ensured that `swDest` was omitted from the `glob` matches when generating the precache manifest.

This extends that to also ignore `swSrc` in `injectManifest` mode.

I also improved the that generates the `globIgnores` value so that instead of just matching anything that has the same basename as `swSrc`/`swDest`, it actually uses a full path to the file, relative to `globDirectory`. This should reduce the chance of a false positive.