### PR TITLE
strictPropertyInitialization + fixes

### DIFF
--- a/packages/workbox-background-sync/src/_version.ts
+++ b/packages/workbox-background-sync/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:background-sync:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:background-sync:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-background-sync/src/lib/QueueStore.ts
+++ b/packages/workbox-background-sync/src/lib/QueueStore.ts
@@ -30,7 +30,7 @@ export interface QueueStoreEntry extends UnidentifiedQueueStoreEntry {
 }
 
 /**
- * A class to manage storing requests from a Queue in IndexedbDB,
+ * A class to manage storing requests from a Queue in IndexedDB,
  * indexed by their queue name for easier access.
  *
  * @private
@@ -82,11 +82,11 @@ export class QueueStore {
     delete entry.id;
     entry.queueName = this._queueName;
 
-    await this._db.add(OBJECT_STORE_NAME, entry);
+    await this._db.add!(OBJECT_STORE_NAME, entry);
   }
 
   /**
-   * Preppend an entry first in the queue.
+   * Prepend an entry first in the queue.
    *
    * @param {Object} entry
    * @param {Object} entry.requestData
@@ -123,7 +123,7 @@ export class QueueStore {
     }
     entry.queueName = this._queueName;
 
-    await this._db.add(OBJECT_STORE_NAME, entry);
+    await this._db.add!(OBJECT_STORE_NAME, entry);
   }
 
   /**
@@ -172,7 +172,7 @@ export class QueueStore {
    * @param {number} id
    */
   async deleteEntry(id: number) {
-    await this._db.delete(OBJECT_STORE_NAME, id);
+    await this._db.delete!(OBJECT_STORE_NAME, id);
   }
 
   /**

--- a/packages/workbox-broadcast-update/src/_version.ts
+++ b/packages/workbox-broadcast-update/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:broadcast-update:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:broadcast-update:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-build/src/cdn-details.json
+++ b/packages/workbox-build/src/cdn-details.json
@@ -2,5 +2,5 @@
   "origin": "https://storage.googleapis.com",
   "bucketName": "workbox-cdn",
   "releasesDir": "releases",
-  "latestVersion": "5.0.0-beta.0"
+  "latestVersion": "5.0.0-beta.1"
 }

--- a/packages/workbox-cacheable-response/src/_version.ts
+++ b/packages/workbox-cacheable-response/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:cacheable-response:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:cacheable-response:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-core/src/_private/DBWrapper.ts
+++ b/packages/workbox-core/src/_private/DBWrapper.ts
@@ -42,14 +42,14 @@ export class DBWrapper {
   private _db: IDBDatabase | null = null;
 
   // The following IDBObjectStore methods are shadowed on this class.
-  get: Function;
-  count: Function;
-  add: Function;
-  put: Function;
-  clear: Function;
-  delete: Function;
+  add?: Function;
+  clear?: Function;
+  count?: Function;
+  delete?: Function;
+  get?: Function;
+  put?: Function;
 
-  OPEN_TIMEOUT: number;
+  OPEN_TIMEOUT?: number;
 
   /**
    * @param {string} name

--- a/packages/workbox-core/src/_private/Deferred.ts
+++ b/packages/workbox-core/src/_private/Deferred.ts
@@ -19,8 +19,8 @@ import '../_version.js';
  */
 class Deferred<T> {
   promise: Promise<T>;
-  resolve: (value?: T) => void;
-  reject: (reason?: any) => void;
+  resolve?: (value?: T) => void;
+  reject?: (reason?: any) => void;
   
   /**
    * Creates a promise and exposes its resolve and reject functions as methods.

--- a/packages/workbox-core/src/_version.ts
+++ b/packages/workbox-core/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:core:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:core:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-expiration/src/_version.ts
+++ b/packages/workbox-expiration/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:expiration:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:expiration:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-expiration/src/models/CacheTimestampsModel.ts
+++ b/packages/workbox-expiration/src/models/CacheTimestampsModel.ts
@@ -98,7 +98,7 @@ class CacheTimestampsModel {
       id: this._getId(url),
     };
 
-    await this._db.put(OBJECT_STORE_NAME, entry);
+    await this._db.put!(OBJECT_STORE_NAME, entry);
   }
 
   /**
@@ -111,7 +111,7 @@ class CacheTimestampsModel {
    */
   async getTimestamp(url: string): Promise<number> {
     const entry: CacheTimestampsModelEntry =
-        await this._db.get(OBJECT_STORE_NAME, this._getId(url));
+        await this._db.get!(OBJECT_STORE_NAME, this._getId(url));
 
     return entry.timestamp;
   }
@@ -173,7 +173,7 @@ class CacheTimestampsModel {
     // https://github.com/GoogleChrome/workbox/issues/1978
     const urlsDeleted: string[] = [];
     for (const entry of entriesToDelete) {
-      await this._db.delete(OBJECT_STORE_NAME, entry.id);
+      await this._db.delete!(OBJECT_STORE_NAME, entry.id);
       urlsDeleted.push(entry.url);
     }
 

--- a/packages/workbox-google-analytics/src/_version.ts
+++ b/packages/workbox-google-analytics/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:google-analytics:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:google-analytics:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-navigation-preload/src/_version.ts
+++ b/packages/workbox-navigation-preload/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:navigation-preload:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:navigation-preload:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-precaching/src/_version.ts
+++ b/packages/workbox-precaching/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:precaching:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:precaching:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-range-requests/src/_version.ts
+++ b/packages/workbox-range-requests/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:range-requests:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:range-requests:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -46,8 +46,8 @@ interface CacheURLsMessageData {
  */
 class Router {
   private _routes: Map<HTTPMethod, Route[]>;
-  private _defaultHandler: HandlerObject;
-  private _catchHandler: HandlerObject;
+  private _defaultHandler?: HandlerObject;
+  private _catchHandler?: HandlerObject;
 
   /**
    * Initializes a new Router.
@@ -248,7 +248,7 @@ class Router {
           logger.error(err);
           logger.groupEnd();
         }
-        return this._catchHandler.handle({url, request, event});
+        return this._catchHandler!.handle({url, request, event});
       });
     }
 

--- a/packages/workbox-routing/src/_version.ts
+++ b/packages/workbox-routing/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:routing:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:routing:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-strategies/src/_version.ts
+++ b/packages/workbox-strategies/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:strategies:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:strategies:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-streams/src/_version.ts
+++ b/packages/workbox-streams/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:streams:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:streams:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-streams/src/concatenate.ts
+++ b/packages/workbox-streams/src/concatenate.ts
@@ -95,7 +95,7 @@ function concatenate(sourcePromises: Promise<StreamSource>[]): {
                 }
 
                 controller.close();
-                streamDeferred.resolve();
+                streamDeferred.resolve!();
                 return;
               }
 
@@ -108,7 +108,7 @@ function concatenate(sourcePromises: Promise<StreamSource>[]): {
             if (process.env.NODE_ENV !== 'production') {
               logger.error('An error occurred:', error);
             }
-            streamDeferred.reject(error);
+            streamDeferred.reject!(error);
             throw error;
           });
     },
@@ -118,7 +118,7 @@ function concatenate(sourcePromises: Promise<StreamSource>[]): {
         logger.warn('The ReadableStream was cancelled.');
       }
 
-      streamDeferred.resolve();
+      streamDeferred.resolve!();
     },
   });
 

--- a/packages/workbox-sw/_version.mjs
+++ b/packages/workbox-sw/_version.mjs
@@ -1,1 +1,1 @@
-try{self['workbox:sw:5.0.0-beta.0']&&_()}catch(e){}// eslint-disable-line
+try{self['workbox:sw:5.0.0-beta.1']&&_()}catch(e){}// eslint-disable-line

--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -120,8 +120,8 @@ class Workbox extends WorkboxEventTarget {
     // SW, resolve active/controlling deferreds and add necessary listeners.
     if (this._compatibleControllingSW) {
       this._sw = this._compatibleControllingSW;
-      this._activeDeferred.resolve(this._compatibleControllingSW);
-      this._controllingDeferred.resolve(this._compatibleControllingSW);
+      this._activeDeferred.resolve!(this._compatibleControllingSW);
+      this._controllingDeferred.resolve!(this._compatibleControllingSW);
 
       this._compatibleControllingSW.addEventListener(
           'statechange', this._onStateChange, {once: true});
@@ -154,7 +154,7 @@ class Workbox extends WorkboxEventTarget {
 
     // If an "own" SW is already set, resolve the deferred.
     if (this._sw) {
-      this._swDeferred.resolve(this._sw);
+      this._swDeferred.resolve!(this._sw);
       this._ownSWs.add(this._sw);
     }
 
@@ -364,7 +364,7 @@ class Workbox extends WorkboxEventTarget {
       // SW is the one we registered, so we set it.
       this._sw = installingSW;
       this._ownSWs.add(installingSW);
-      this._swDeferred.resolve(installingSW);
+      this._swDeferred.resolve!(installingSW);
 
       // The `installing` state isn't something we have a dedicated
       // callback for, but we do log messages for it in development.
@@ -438,7 +438,7 @@ class Workbox extends WorkboxEventTarget {
     } else if (state === 'activating') {
       clearTimeout(this._waitingTimeout);
       if (!isExternal) {
-        this._activeDeferred.resolve(sw);
+        this._activeDeferred.resolve!(sw);
       }
     }
 
@@ -491,7 +491,7 @@ class Workbox extends WorkboxEventTarget {
       if (process.env.NODE_ENV !== 'production') {
         logger.log('Registered service worker now controlling this page.');
       }
-      this._controllingDeferred.resolve(sw);
+      this._controllingDeferred.resolve!(sw);
     }
   }
 

--- a/packages/workbox-window/src/_version.ts
+++ b/packages/workbox-window/src/_version.ts
@@ -1,2 +1,2 @@
 // @ts-ignore
-try{self['workbox:window:5.0.0-beta.0']&&_()}catch(e){}
+try{self['workbox:window:5.0.0-beta.1']&&_()}catch(e){}

--- a/packages/workbox-window/src/utils/WorkboxEvent.ts
+++ b/packages/workbox-window/src/utils/WorkboxEvent.ts
@@ -18,7 +18,7 @@ import '../_version.js';
  */
 export class WorkboxEvent<K extends keyof WorkboxEventMap> {
   target?: WorkboxEventTarget;
-  sw: ServiceWorker;
+  sw?: ServiceWorker;
   originalEvent?: Event;
 
   constructor(public type: K, props: Omit<WorkboxEventMap[K], 'target' | 'type'>) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,10 +14,11 @@
     "noUnusedParameters": true,
     "preserveConstEnums": true,
     "strictNullChecks": true,
+    "strictPropertyInitialization": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "files": [
-    "./infra/type-overrides.d.ts",
+    "./infra/type-overrides.d.ts"
   ],
   "exclude": [],
   "references": [


### PR DESCRIPTION
R: @philipwalton 

This adds `strictPropertyInitialization` checks to our TypeScript setup, and fixes the associated problems by throwing in a lot of `?` next to the properties that aren't explicitly initialized in the constructor, and the `!` next to the instances where those properties are used.

I think that's safe, but please double-check.