### PR TITLE
Strict TypeScript cleanup

### DIFF
--- a/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts
+++ b/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts
@@ -151,8 +151,10 @@ class BroadcastCacheUpdate {
       // For navigation requests, wait until the new window client exists
       // before sending the message
       if (options.request.mode === 'navigate') {
-        const resultingClientId =
-            options.event && options.event.resultingClientId;
+        let resultingClientId: string | undefined;
+        if (options.event instanceof FetchEvent) {
+          resultingClientId = options.event.resultingClientId;
+        }
 
         const resultingWin = await resultingClientExists(resultingClientId);
 

--- a/packages/workbox-core/src/_private/DBWrapper.ts
+++ b/packages/workbox-core/src/_private/DBWrapper.ts
@@ -266,7 +266,9 @@ export class DBWrapper {
     ...args: any[]
   ) {
     const callback = (txn: IDBTransaction, done: Function) => {
-      const objStore = txn.objectStore(storeName)
+      const objStore = txn.objectStore(storeName);
+      // TODO(philipwalton): Fix this underlying TS2684 error.
+      // @ts-ignore
       const request = <IDBRequest> objStore[method].apply(objStore, args);
 
       request.onsuccess = () => done(request.result);

--- a/packages/workbox-core/src/_private/cacheWrapper.ts
+++ b/packages/workbox-core/src/_private/cacheWrapper.ts
@@ -6,16 +6,16 @@
   https://opensource.org/licenses/MIT.
 */
 
-import {WorkboxError} from './WorkboxError.js';
 import {assert} from './assert.js';
+import {executeQuotaErrorCallbacks} from './executeQuotaErrorCallbacks.js';
 import {getFriendlyURL} from './getFriendlyURL.js';
 import {logger} from './logger.js';
-import {executeQuotaErrorCallbacks} from './executeQuotaErrorCallbacks.js';
 import {pluginEvents} from '../models/pluginEvents.js';
-import {WorkboxPlugin} from '../types.js';
 import {pluginUtils} from '../utils/pluginUtils.js';
-import '../_version.js';
+import {WorkboxError} from './WorkboxError.js';
+import {WorkboxPlugin} from '../types.js';
 
+import '../_version.js';
 
 interface MatchWrapperOptions {
   cacheName: string;
@@ -140,7 +140,7 @@ const putWrapper = async ({
  * @param {string} options.cacheName Name of the cache to match against.
  * @param {Request} options.request The Request that will be used to look up
  *     cache entries.
- * @param {Event} [options.event] The event that propted the action.
+ * @param {Event} [options.event] The event that prompted the action.
  * @param {Object} [options.matchOptions] Options passed to cache.match().
  * @param {Array<Object>} [options.plugins=[]] Array of plugins.
  * @return {Response} A cached response if available.
@@ -298,7 +298,7 @@ const _getEffectiveRequest = async ({
   const cacheKeyWillBeUsedPlugins = pluginUtils.filter(
       plugins, pluginEvents.CACHE_KEY_WILL_BE_USED);
 
-  let effectiveRequest = request;
+  let effectiveRequest: Request | string = request;
   for (const plugin of cacheKeyWillBeUsedPlugins) {
     effectiveRequest = await plugin[pluginEvents.CACHE_KEY_WILL_BE_USED]!.call(
         plugin, {mode, request: effectiveRequest});

--- a/packages/workbox-core/src/_private/fetchWrapper.ts
+++ b/packages/workbox-core/src/_private/fetchWrapper.ts
@@ -18,7 +18,7 @@ import '../_version.js';
 
 interface WrappedFetchOptions {
   request: Request | string;
-  event?: FetchEvent | Event;
+  event?: ExtendableEvent;
   plugins?: WorkboxPlugin[];
   fetchOptions?: RequestInit;
 }
@@ -31,7 +31,7 @@ interface WrappedFetchOptions {
  * @param {Object} options
  * @param {Request|string} options.request
  * @param {Object} [options.fetchOptions]
- * @param {Event} [options.event]
+ * @param {ExtendableEvent} [options.event]
  * @param {Array<Object>} [options.plugins=[]]
  * @return {Promise<Response>}
  *

--- a/packages/workbox-core/src/types.ts
+++ b/packages/workbox-core/src/types.ts
@@ -74,10 +74,10 @@ export type RouteHandler = RouteHandlerCallback | RouteHandlerObject;
 
 export interface CacheDidUpdateCallbackParam {
   cacheName: string;
-  oldResponse?: Response;
+  oldResponse?: Response | null;
   newResponse: Response;
   request: Request;
-  event?: FetchEvent;
+  event?: Event;
 }
 
 export interface CacheDidUpdateCallback {

--- a/packages/workbox-precaching/src/cleanupOutdatedCaches.ts
+++ b/packages/workbox-precaching/src/cleanupOutdatedCaches.ts
@@ -19,7 +19,8 @@ import './_version.js';
  * @alias workbox.precaching.cleanupOutdatedCaches
  */
 export const cleanupOutdatedCaches = () => {
-  addEventListener('activate', (event: ExtendableEvent) => {
+  // See https://github.com/Microsoft/TypeScript/issues/28357#issuecomment-436484705
+  addEventListener('activate', ((event: ExtendableEvent) => {
     const cacheName = cacheNames.getPrecacheName();
 
     event.waitUntil(deleteOutdatedCaches(cacheName).then((cachesDeleted) => {
@@ -30,5 +31,5 @@ export const cleanupOutdatedCaches = () => {
         }
       }
     }));
-  });
+  }) as EventListener);
 };

--- a/packages/workbox-precaching/src/precache.ts
+++ b/packages/workbox-precaching/src/precache.ts
@@ -68,7 +68,8 @@ export const precache = (entries: Array<PrecacheEntry|string>) => {
     // NOTE: these listeners will only be added once (even if the `precache()`
     // method is called multiple times) because event listeners are implemented
     // as a set, where each listener must be unique.
-    addEventListener('install', installListener);
-    addEventListener('activate', activateListener);
+    // See https://github.com/Microsoft/TypeScript/issues/28357#issuecomment-436484705
+    addEventListener('install', installListener as EventListener);
+    addEventListener('activate', activateListener as EventListener);
   }
 };

--- a/packages/workbox-precaching/src/utils/addFetchListener.ts
+++ b/packages/workbox-precaching/src/utils/addFetchListener.ts
@@ -56,7 +56,8 @@ export const addFetchListener = ({
 }: FetchListenerOptions = {}) => {
   const cacheName = cacheNames.getPrecacheName();
 
-  addEventListener('fetch', (event: FetchEvent) => {
+  // See https://github.com/Microsoft/TypeScript/issues/28357#issuecomment-436484705
+  addEventListener('fetch', ((event: FetchEvent) => {
     const precachedURL = getCacheKeyForURL(event.request.url, {
       cleanURLs,
       directoryIndex,
@@ -111,5 +112,5 @@ export const addFetchListener = ({
     }
 
     event.respondWith(responsePromise);
-  });
+  }) as EventListener);
 };

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -70,13 +70,14 @@ class Router {
    * the event's request.
    */
   addFetchListener() {
-    self.addEventListener('fetch', (event: FetchEvent) => {
+    // See https://github.com/Microsoft/TypeScript/issues/28357#issuecomment-436484705
+    self.addEventListener('fetch', ((event: FetchEvent) => {
       const {request} = event;
       const responsePromise = this.handleRequest({request, event});
       if (responsePromise) {
         event.respondWith(responsePromise);
       }
-    });
+    }) as EventListener);
   }
 
   /**
@@ -102,7 +103,8 @@ class Router {
    * ```
    */
   addCacheListener() {
-    self.addEventListener('message', async (event: ExtendableMessageEvent) => {
+    // See https://github.com/Microsoft/TypeScript/issues/28357#issuecomment-436484705
+    self.addEventListener('message', ((event: ExtendableMessageEvent) => {
       if (event.data && event.data.type === 'CACHE_URLS') {
         const {payload}: CacheURLsMessageData = event.data;
 
@@ -128,11 +130,10 @@ class Router {
 
         // If a MessageChannel was used, reply to the message on success.
         if (event.ports && event.ports[0]) {
-          await requestPromises;
-          event.ports[0].postMessage(true);
+          requestPromises.then(() => event.ports[0].postMessage(true));
         }
       }
-    });
+    }) as EventListener);
   }
 
   /**

--- a/packages/workbox-window/src/utils/WorkboxEventTarget.ts
+++ b/packages/workbox-window/src/utils/WorkboxEventTarget.ts
@@ -27,7 +27,7 @@ export class WorkboxEventTarget {
    */
   addEventListener<K extends keyof WorkboxEventMap>(type: K, listener: (event: WorkboxEventMap[K]) => any) {
     const foo = this._getEventListenersByType(type)
-    foo.add(listener);
+    foo.add(listener as ListenerCallback);
   }
 
   /**
@@ -36,7 +36,7 @@ export class WorkboxEventTarget {
    * @private
    */
   removeEventListener<K extends keyof WorkboxEventMap>(type: K, listener: (event: WorkboxEventMap[K]) => any) {
-    this._getEventListenersByType(type).delete(listener);
+    this._getEventListenersByType(type).delete(listener as ListenerCallback);
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,17 @@
 {
   "compilerOptions": {
-    "lib": ["es2017", "webworker"],
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
     "composite": true,
     "declaration": true,
+    "lib": ["es2017", "webworker"],
+    "module": "esnext",
+    "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "preserveConstEnums": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true,
+    "strict": true,
+    "target": "esnext",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "files": [


### PR DESCRIPTION
R: @philipwalton

Fixes #2242 

This cleans up a number of problems that were found by switching to using `strict: true` in the TypeScript compiler options.

There are some... questionable?... casts going on, so I'll address them via comments on the specific lines to see whether there are better approaches.