### PR TITLE
Don't treat lack of sourcemap asset as a fatal error

### DIFF
--- a/packages/workbox-webpack-plugin/src/lib/get-sourcemap-asset-name.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-sourcemap-asset-name.js
@@ -1,0 +1,46 @@
+/*
+  Copyright 2019 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+const sourceMapURL = require('source-map-url');
+const upath = require('upath');
+
+/**
+ * If our bundled swDest file contains a sourcemap, we would invalidate that
+ * mapping if we just replaced injectionPoint with the stringified manifest.
+ * Instead, we need to update the swDest contents as well as the sourcemap
+ * at the same time.
+ *
+ * See https://github.com/GoogleChrome/workbox/issues/2235
+ *
+ * @param {Object} compilation The current webpack compilation.
+ * @param {string} swContents The contents of the swSrc file, which may or
+ * may not include a valid sourcemap comment.
+ * @param {string} swDest The configured swDest value.
+ * @return {string|undefined} If the swContents contains a valid soucemap
+ * comment pointing to an asset present in the compilation, this will return the
+ * name of that asset. Otherwise, it will return undefined.
+ *
+ * @private
+ */
+module.exports = (compilation, swContents, swDest) => {
+  const url = sourceMapURL.getFrom(swContents);
+  if (url) {
+    // Translate the relative URL to what the presumed name for the webpack
+    // asset should be.
+    // This *might* not be a valid asset if the sourcemap URL that was found
+    // was added by another module incidentally.
+    // See https://github.com/GoogleChrome/workbox/issues/2250
+    const swAssetDirname = upath.dirname(swDest);
+    const sourcemapURLAssetName = upath.normalize(
+        upath.join(swAssetDirname, url));
+
+    if (sourcemapURLAssetName in compilation.assets) {
+      return sourcemapURLAssetName;
+    }
+  }
+};

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -578,6 +578,53 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         }
       });
     });
+
+    it(`should not fail if the sourcemap is missing from the assets`, function(done) {
+      const outputDir = tempy.directory();
+      const swSrc = upath.join(__dirname, '..', 'static', 'sw-src-missing-sourcemap.js');
+
+      const config = {
+        mode: 'development',
+        entry: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        output: {
+          filename: WEBPACK_ENTRY_FILENAME,
+          path: outputDir,
+        },
+        devtool: false,
+        plugins: [
+          new InjectManifest({
+            swSrc,
+            swDest: 'service-worker.js',
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError, stats) => {
+        const swFile = upath.join(outputDir, 'service-worker.js');
+        try {
+          webpackBuildCheck(webpackError, stats);
+
+          const files = await globby(outputDir);
+          expect(files).to.have.length(2);
+
+          await validateServiceWorkerRuntime({
+            swFile,
+            entryPoint: 'injectManifest',
+            expectedMethodCalls: {
+              precacheAndRoute: [[[{
+                revision: 'f59ecc599c17c2bbc03a212969e13ee7',
+                url: 'webpackEntry.js',
+              }], {}]],
+            },
+          });
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
   });
 
   describe(`[workbox-webpack-plugin] Filtering via include/exclude`, function() {
@@ -1283,7 +1330,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
   describe(`[workbox-webpack-plugin] Multiple invocation scenarios`, function() {
     // See https://github.com/GoogleChrome/workbox/issues/2158
-    it(`•should support multiple compilations using the same plugin instance`, async function() {
+    it(`should support multiple compilations using the same plugin instance`, async function() {
       const outputDir = tempy.directory();
       const config = {
         mode: 'production',

--- a/test/workbox-webpack-plugin/static/sw-src-missing-sourcemap.js
+++ b/test/workbox-webpack-plugin/static/sw-src-missing-sourcemap.js
@@ -1,0 +1,10 @@
+/*
+  Copyright 2018 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST, {});
+//# sourceMappingURL=does-not-exist.js.map

--- a/test/workbox-webpack-plugin/static/sw-src-missing-sourcemap.js
+++ b/test/workbox-webpack-plugin/static/sw-src-missing-sourcemap.js
@@ -6,5 +6,6 @@
   https://opensource.org/licenses/MIT.
 */
 
+/* eslint-disable */
 workbox.precaching.precacheAndRoute(self.__WB_MANIFEST, {});
 //# sourceMappingURL=does-not-exist.js.map


### PR DESCRIPTION
R: @philipwalton

Fixes #2250

Treating a failure to find the sourcemap in the webpack compilation as a fatal error is problematic (since it's possible for invalid sourcemap URLs to make it into the `swSrc` asset), so this relaxes that requirement.