### PR TITLE
New precache helper functions + removal of createHandlerForURL

### DIFF
--- a/infra/testing/validator/service-worker-runtime.js
+++ b/infra/testing/validator/service-worker-runtime.js
@@ -109,7 +109,7 @@ function setupSpiesAndContextForGenerateSW() {
     importScripts,
     CacheFirst: sinon.stub().returns({name: 'CacheFirst'}),
     clientsClaim: sinon.spy(),
-    createHandlerForURL: sinon.stub().returns('/urlWithCacheKey'),
+    createHandlerBoundToURL: sinon.stub().returns('/urlWithCacheKey'),
     enable: sinon.spy(),
     initialize: sinon.spy(),
     NavigationRoute: sinon.stub().returns({name: 'NavigationRoute'}),

--- a/packages/workbox-build/src/templates/sw-template.js
+++ b/packages/workbox-build/src/templates/sw-template.js
@@ -47,7 +47,7 @@ self.addEventListener('message', (event) => {
  */
 <%= use('workbox-precaching', 'precacheAndRoute') %>(<%= JSON.stringify(manifestEntries, null, 2) %>, <%= precacheOptionsString %>);
 <% if (cleanupOutdatedCaches) { %><%= use('workbox-precaching', 'cleanupOutdatedCaches') %>();<% } %>
-<% if (navigateFallback) { %><%= use('workbox-routing', 'registerRoute') %>(new <%= use('workbox-routing', 'NavigationRoute') %>(<%= use('workbox-precaching', 'createHandlerForURL') %>(<%= JSON.stringify(navigateFallback) %>)<% if (navigateFallbackWhitelist || navigateFallbackBlacklist) { %>, {
+<% if (navigateFallback) { %><%= use('workbox-routing', 'registerRoute') %>(new <%= use('workbox-routing', 'NavigationRoute') %>(<%= use('workbox-precaching', 'createHandlerBoundToURL') %>(<%= JSON.stringify(navigateFallback) %>)<% if (navigateFallbackWhitelist || navigateFallbackBlacklist) { %>, {
   <% if (navigateFallbackWhitelist) { %>whitelist: [<%= navigateFallbackWhitelist %>],<% } %>
   <% if (navigateFallbackBlacklist) { %>blacklist: [<%= navigateFallbackBlacklist %>],<% } %>
 }<% } %>));<% } %>

--- a/packages/workbox-core/src/models/messages/messages.ts
+++ b/packages/workbox-core/src/models/messages/messages.ts
@@ -258,8 +258,8 @@ export const messages : MessageMap = {
   },
 
   'non-precached-url': ({url}) => {
-    return `createHandlerForURL('${url}') was called, but that URL is not ` +
-      `precached. Please pass in a URL that is precached instead.`;
+    return `createHandlerBoundToURL('${url}') was called, but that URL is ` +
+      `not precached. Please pass in a URL that is precached instead.`;
   },
 
   'add-to-cache-list-conflicting-integrities': ({url}) => {

--- a/packages/workbox-core/src/models/messages/messages.ts
+++ b/packages/workbox-core/src/models/messages/messages.ts
@@ -267,4 +267,8 @@ export const messages : MessageMap = {
       `'workbox-precaching.PrecacheController.addToCacheList()' had the URL ` +
       `${url} with different integrity values. Please remove one of them.`;
   },
+
+  'missing-precache-entry': ({cacheName, url}) => {
+    return `Unable to find a precached response in ${cacheName} for ${url}.`;
+  },
 };

--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -359,8 +359,10 @@ class PrecacheController {
 
         // This shouldn't normally happen, but there are edge cases:
         // https://github.com/GoogleChrome/workbox/issues/1441
-        throw new Error(`The cache ${this._cacheName} did not have an entry ` +
-            `for ${request.url}.`);
+        throw new WorkboxError('missing-precache-entry', {
+          cacheName: this._cacheName,
+          url: request.url,
+        });
       } catch (error) {
         if (fallbackToNetwork) {
           if (process.env.NODE_ENV !== 'production') {

--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -1,5 +1,5 @@
 /*
-  Copyright 2018 Google LLC
+  Copyright 2019 Google LLC
 
   Use of this source code is governed by an MIT-style
   license that can be found in the LICENSE file or at
@@ -13,7 +13,8 @@ import {fetchWrapper} from 'workbox-core/_private/fetchWrapper.js';
 import {logger} from 'workbox-core/_private/logger.js';
 import {WorkboxError} from 'workbox-core/_private/WorkboxError.js';
 import {copyResponse} from 'workbox-core/copyResponse.js';
-import {RouteHandlerCallback} from 'workbox-core/types.js';
+import {RouteHandlerCallback, RouteHandlerCallbackOptions}
+    from 'workbox-core/types.js';
 import {WorkboxPlugin} from 'workbox-core/types.js';
 
 import {PrecacheEntry} from './_types.js';
@@ -310,35 +311,48 @@ class PrecacheController {
   }
 
   /**
-   * Returns a function that looks up `url` in the precache (taking into
-   * account revision information), and returns the corresponding `Response`.
+   * This acts as a drop-in replacement for [`cache.match()`](https://developer.mozilla.org/en-US/docs/Web/API/Cache/match)
+   * with the following differences:
+   * 
+   * - It knows what the name of the precache is, and only checks in that cache.
+   * - It allows you to pass in an "original" URL without versioning parameters,
+   * and it will automatically look up the correct cache key for the currently
+   * active revision of that URL.
+   * 
+   * E.g., `matchPrecache('index.html')` will find the correct precached
+   * response for the currently active service worker, even if the actual cache
+   * key is `'/index.html?__WB_REVISION__=1234abcd'`.
    *
-   * If for an unexpected reason there is a cache miss when looking up `url`,
-   * this will fall back to retrieving the `Response` via `fetch()`.
+   * @param {string|Request} request The key (without revisioning parameters)
+   * to look up in the precache.
+   * @return {Promise<Response|undefined>}
+   */
+  async matchPrecache(request: string|Request): Promise<Response|undefined> {
+    const url = request instanceof Request ? request.url : request;
+    const cacheKey = this.getCacheKeyForURL(url);
+    if (cacheKey) {
+      const cache = await caches.open(this._cacheName);
+      return cache.match(cacheKey);
+    }
+    return undefined;
+  }
+
+  /**
+   * Returns a function that can be used within a {@link workbox.routing.Route}
+   * that will find a response for the incoming request against the precache.
    *
-   * @param {string} url The precached URL which will be used to lookup the
-   * `Response`.
+   * If for an unexpected reason there is a cache miss for the request,
+   * this will fall back to retrieving the `Response` via `fetch()` when
+   * `fallbackToNetwork` is `true`.
+   *
+   * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
+   * response from the network if there's a precache miss.
    * @return {workbox.routing.Route~handlerCallback}
    */
-  createHandlerForURL(url: string): RouteHandlerCallback {
-    if (process.env.NODE_ENV !== 'production') {
-      assert!.isType(url, 'string', {
-        moduleName: 'workbox-precaching',
-        funcName: 'createHandlerForURL',
-        paramName: 'url',
-      });
-    }
-
-    const cacheKey = this.getCacheKeyForURL(url);
-    if (!cacheKey) {
-      throw new WorkboxError('non-precached-url', {url});
-    }
-
-    return async () => {
+  createHandler(fallbackToNetwork = true): RouteHandlerCallback {
+    return async ({request}: RouteHandlerCallbackOptions) => {
       try {
-        const cache = await caches.open(this._cacheName);
-        const response = await cache.match(cacheKey);
-
+        const response = await this.matchPrecache(request);
         if (response) {
           return response;
         }
@@ -346,22 +360,45 @@ class PrecacheController {
         // This shouldn't normally happen, but there are edge cases:
         // https://github.com/GoogleChrome/workbox/issues/1441
         throw new Error(`The cache ${this._cacheName} did not have an entry ` +
-            `for ${cacheKey}.`);
+            `for ${request.url}.`);
       } catch (error) {
-        // If there's either a cache miss, or the caches.match() call threw
-        // an exception, then attempt to fulfill the navigation request with
-        // a response from the network rather than leaving the user with a
-        // failed navigation.
-        if (process.env.NODE_ENV !== 'production') {
-          logger.debug(`Unable to respond to navigation request with ` +
-              `cached response. Falling back to network.`, error);
+        if (fallbackToNetwork) {
+          if (process.env.NODE_ENV !== 'production') {
+            logger.debug(`Unable to respond with precached response. ` +
+                `Falling back to network.`, error);
+          }
+          return fetch(request);
         }
 
-        // This might still fail if the browser is offline...
-        return fetch(cacheKey);
+        throw error;
       }
     };
-  };
+  }
+
+  /**
+   * Returns a function that looks up `url` in the precache (taking into
+   * account revision information), and returns the corresponding `Response`.
+   *
+   * If for an unexpected reason there is a cache miss when looking up `url`,
+   * this will fall back to retrieving the `Response` via `fetch()` when
+   * `fallbackToNetwork` is `true`.
+   *
+   * @param {string} url The precached URL which will be used to lookup the
+   * `Response`.
+   * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
+   * response from the network if there's a precache miss.
+   * @return {workbox.routing.Route~handlerCallback}
+   */
+  createHandlerBoundToURL(url: string, fallbackToNetwork = true): RouteHandlerCallback {
+    const cacheKey = this.getCacheKeyForURL(url);
+    if (!cacheKey) {
+      throw new WorkboxError('non-precached-url', {url});
+    }
+
+    const handler = this.createHandler(fallbackToNetwork);
+    const request = new Request(url);
+    return () => handler({request});
+  }
 }
 
 export {PrecacheController};

--- a/packages/workbox-precaching/src/createHandler.ts
+++ b/packages/workbox-precaching/src/createHandler.ts
@@ -12,20 +12,20 @@ import './_version.js';
 
 /**
  * Helper function that calls
- * {@link PrecacheController#createHandlerForURL} on the default
+ * {@link PrecacheController#createHandler} on the default
  * {@link PrecacheController} instance.
  * 
  * If you are creating your own {@link PrecacheController}, then call the
- * {@link PrecacheController#createHandlerForURL} on that instance,
+ * {@link PrecacheController#createHandler} on that instance,
  * instead of using this function.
  *
- * @param {string} url The precached URL which will be used to lookup the
- * `Response`.
+ * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
+ * response from the network if there's a precache miss.
  * @return {workbox.routing.Route~handlerCallback}
  *
- * @alias workbox.precaching.createHandlerForURL
+ * @alias workbox.precaching.createHandler
  */
-export const createHandlerForURL = (url: string) => {
+export const createHandler = (fallbackToNetwork = true) => {
   const precacheController = getOrCreatePrecacheController();
-  return precacheController.createHandlerForURL(url);
+  return precacheController.createHandler(fallbackToNetwork);
 };

--- a/packages/workbox-precaching/src/createHandlerBoundToURL.ts
+++ b/packages/workbox-precaching/src/createHandlerBoundToURL.ts
@@ -1,0 +1,33 @@
+/*
+  Copyright 2019 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import {getOrCreatePrecacheController} from './utils/getOrCreatePrecacheController.js';
+
+import './_version.js';
+
+/**
+ * Helper function that calls
+ * {@link PrecacheController#createHandlerBoundToURL} on the default
+ * {@link PrecacheController} instance.
+ * 
+ * If you are creating your own {@link PrecacheController}, then call the
+ * {@link PrecacheController#createHandlerBoundToURL} on that instance,
+ * instead of using this function.
+ *
+ * @param {string} url The precached URL which will be used to lookup the
+ * `Response`.
+ * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
+ * response from the network if there's a precache miss.
+ * @return {workbox.routing.Route~handlerCallback}
+ *
+ * @alias workbox.precaching.createHandlerBoundToURL
+ */
+export const createHandlerBoundToURL = (url: string) => {
+  const precacheController = getOrCreatePrecacheController();
+  return precacheController.createHandlerBoundToURL(url);
+};

--- a/packages/workbox-precaching/src/index.ts
+++ b/packages/workbox-precaching/src/index.ts
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Google LLC
+  Copyright 2018 Google LLC
 
   Use of this source code is governed by an MIT-style
   license that can be found in the LICENSE file or at

--- a/packages/workbox-precaching/src/index.ts
+++ b/packages/workbox-precaching/src/index.ts
@@ -1,5 +1,5 @@
 /*
-  Copyright 2018 Google LLC
+  Copyright 2019 Google LLC
 
   Use of this source code is governed by an MIT-style
   license that can be found in the LICENSE file or at
@@ -7,16 +7,19 @@
 */
 
 import {assert} from 'workbox-core/_private/assert.js';
+
 import {addPlugins} from './addPlugins.js';
 import {addRoute} from './addRoute.js';
 import {cleanupOutdatedCaches} from './cleanupOutdatedCaches.js';
-import {createHandlerForURL} from './createHandlerForURL.js';
+import {createHandler} from './createHandler.js';
+import {createHandlerBoundToURL} from './createHandlerBoundToURL.js';
 import {getCacheKeyForURL} from './getCacheKeyForURL.js';
+import {matchPrecache} from './matchPrecache.js';
 import {precache} from './precache.js';
 import {precacheAndRoute} from './precacheAndRoute.js';
 import {PrecacheController} from './PrecacheController.js';
-import './_version.js';
 
+import './_version.js';
 
 if (process.env.NODE_ENV !== 'production') {
   assert!.isSWEnv('workbox-precaching');
@@ -39,8 +42,10 @@ export {
   addPlugins,
   addRoute,
   cleanupOutdatedCaches,
-  createHandlerForURL,
+  createHandler,
+  createHandlerBoundToURL,
   getCacheKeyForURL,
+  matchPrecache,
   precache,
   precacheAndRoute,
   PrecacheController,

--- a/packages/workbox-precaching/src/matchPrecache.ts
+++ b/packages/workbox-precaching/src/matchPrecache.ts
@@ -1,0 +1,31 @@
+/*
+  Copyright 2019 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import {getOrCreatePrecacheController} from './utils/getOrCreatePrecacheController.js';
+
+import './_version.js';
+
+/**
+ * Helper function that calls
+ * {@link PrecacheController#matchPrecache} on the default
+ * {@link PrecacheController} instance.
+ * 
+ * If you are creating your own {@link PrecacheController}, then call
+ * {@link PrecacheController#matchPrecache} on that instance,
+ * instead of using this function.
+ *
+ * @param {string|Request} request The key (without revisioning parameters)
+ * to look up in the precache.
+ * @return {Promise<Response|undefined>}
+ *
+ * @alias workbox.precaching.matchPrecache
+ */
+export const matchPrecache = (request: string|Request) => {
+  const precacheController = getOrCreatePrecacheController();
+  return precacheController.matchPrecache(request);
+};

--- a/test/workbox-build/node/generate-sw.js
+++ b/test/workbox-build/node/generate-sw.js
@@ -370,7 +370,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        createHandlerForURL: [[navigateFallback]],
+        createHandlerBoundToURL: [[navigateFallback]],
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',

--- a/test/workbox-precaching/sw/test-createHandler.mjs
+++ b/test/workbox-precaching/sw/test-createHandler.mjs
@@ -20,6 +20,18 @@ describe(`createHandler()`, function() {
     sandbox.restore();
   });
 
+  it(`should throw the expected error when there's a cache miss and fallbackToNetwork is false`, async function() {
+    precache([]);
+    const handler = createHandler(false);
+
+    return expectError(async () => {
+      await handler({request: new Request('/cache-miss')});
+    }, 'missing-precache-entry', (error) => {
+      expect(error.details.url).to.eql(`${location.origin}/cache-miss`);
+      expect(error.details.cacheName).to.eql(`workbox-precache-v2-${location.origin}/test/workbox-precaching/sw/`);
+    });
+  });
+
   it(`should return the expected handlerCallback for precached URLs`, async function() {
     // Simulate the following: first two handlerCallbacks have cache.match()
     // calls that return a hit. Third, and subsequent handlerCallback has a

--- a/test/workbox-precaching/sw/test-createHandlerBoundToURL.mjs
+++ b/test/workbox-precaching/sw/test-createHandlerBoundToURL.mjs
@@ -1,0 +1,92 @@
+/*
+  Copyright 2019 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import {createHandlerBoundToURL} from 'workbox-precaching/createHandlerBoundToURL.mjs';
+import {precache} from 'workbox-precaching/precache.mjs';
+
+describe(`createHandlerBoundToURL()`, function() {
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(function() {
+    sandbox.stub(self, 'addEventListener');
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  it(`should throw when passed a URL that isn't precached`, function() {
+    precache([]);
+
+    return expectError(() => {
+      createHandlerBoundToURL('/does-not-exist');
+    }, 'non-precached-url', (error) => expect(error.details.url).to.eql('/does-not-exist'));
+  });
+
+  it(`should return the expected handlerCallback for precached URLs`, async function() {
+    // Simulate the following: first two handlerCallbacks have cache.match()
+    // calls that return a hit. Third, and subsequent handlerCallback has a
+    // cache.match() call that's a miss, which will lead to a call to fetch().
+    const matchStub = sandbox.stub()
+        .onFirstCall().resolves(new Response('response 1'))
+        .onSecondCall().resolves(new Response('response 2'))
+        .resolves(undefined);
+
+    sandbox.stub(self.caches, 'open').resolves({
+      match: matchStub,
+    });
+
+    const fetchStub = sandbox.stub(self, 'fetch')
+        .onFirstCall().resolves(new Response('response 3'))
+        .onSecondCall().resolves(new Response('response 4'));
+
+    precache([
+      '/url1',
+      {url: '/url2', revision: 'abc123'},
+      '/url3',
+      {url: '/url4', revision: 'def456'},
+    ]);
+
+    const handler1 = createHandlerBoundToURL('/url1');
+    const response1 = await handler1();
+
+    expect(matchStub.calledOnce).to.be.true;
+    expect(matchStub.firstCall.args).to.eql([`${location.origin}/url1`]);
+    expect(fetchStub.notCalled).to.be.true;
+    expect(await response1.text()).to.eql('response 1');
+
+    const handler2 = createHandlerBoundToURL('/url2');
+    const response2 = await handler2();
+
+    expect(matchStub.calledTwice).to.be.true;
+    expect(matchStub.secondCall.args).to.eql([`${location.origin}/url2?__WB_REVISION__=abc123`]);
+    expect(fetchStub.notCalled).to.be.true;
+    expect(await response2.text()).to.eql('response 2');
+
+    const handler3 = createHandlerBoundToURL('/url3');
+    const response3 = await handler3();
+
+    expect(matchStub.calledThrice).to.be.true;
+    expect(matchStub.thirdCall.args).to.eql([`${location.origin}/url3`]);
+    expect(fetchStub.calledOnce).to.be.true;
+    // firstCall.args[0] is a Request object.
+    expect(fetchStub.firstCall.args[0].url).to.eql(`${location.origin}/url3`);
+    expect(await response3.text()).to.eql('response 3');
+
+    const handler4 = createHandlerBoundToURL('/url4');
+    const response4 = await handler4();
+
+    expect(matchStub.callCount).to.eql(4);
+    // Call #3 is the fourth call due to zero-indexing.
+    expect(matchStub.getCall(3).args).to.eql([`${location.origin}/url4?__WB_REVISION__=def456`]);
+    expect(fetchStub.calledTwice).to.be.true;
+    // secondCall.args[0] is a Request object.
+    expect(fetchStub.secondCall.args[0].url).to.eql(`${location.origin}/url4`);
+    expect(await response4.text()).to.eql('response 4');
+  });
+});

--- a/test/workbox-precaching/sw/test-matchPrecache.mjs
+++ b/test/workbox-precaching/sw/test-matchPrecache.mjs
@@ -1,0 +1,56 @@
+/*
+  Copyright 2019 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import {matchPrecache} from 'workbox-precaching/matchPrecache.mjs';
+import {precache} from 'workbox-precaching/precache.mjs';
+
+describe(`matchPrecache()`, function() {
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(function() {
+    sandbox.stub(self, 'addEventListener');
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  // This is all into one big test with multiple expects() as that plays nicer
+  // with precache()'s behavior.
+  it(`should behave as expected`, async function() {
+    const matchStub = sandbox.stub()
+        .onFirstCall().resolves(new Response('response 1'))
+        .onSecondCall().resolves(new Response('response 2'))
+        .resolves(undefined);
+
+    sandbox.stub(self.caches, 'open').resolves({
+      match: matchStub,
+    });
+
+    precache([
+      '/url1',
+      {url: '/url2', revision: 'abc123'},
+    ]);
+
+    const noMatchResponse = await matchPrecache('does-not-match');
+    expect(noMatchResponse).to.be.undefined;
+    expect(matchStub.notCalled).to.be.true;
+
+    const response1 = await matchPrecache('/url1');
+
+    expect(matchStub.calledOnce).to.be.true;
+    expect(matchStub.firstCall.args).to.eql([`${location.origin}/url1`]);
+    expect(await response1.text()).to.eql('response 1');
+
+    const response2 = await matchPrecache(new Request('/url2'));
+
+    expect(matchStub.calledTwice).to.be.true;
+    expect(matchStub.secondCall.args).to.eql([`${location.origin}/url2?__WB_REVISION__=abc123`]);
+    expect(await response2.text()).to.eql('response 2');
+  });
+});


### PR DESCRIPTION
R: @philipwalton

Fixes #2249

Exposes three new functions:

- `async function matchPrecache(request: string|Request): Promise<Response|null>`
- `function createHandler(fallbackToNetwork = true): RouteHandlerCallback`
- `function createHandlerBoundToURL(url: string, fallbackToNetwork = true): RouteHandlerCallback`

`createHandlerBoundToURL` replaces `createHandlerForURL`, and serves the same purpose.