### PR TITLE
Export all public types directly from workbox-core

### DIFF
--- a/packages/workbox-core/src/index.ts
+++ b/packages/workbox-core/src/index.ts
@@ -32,3 +32,5 @@ export {
   setCacheNameDetails,
   skipWaiting,
 };
+
+export * from './types.js';


### PR DESCRIPTION
R: @jeffposnick

Fixes #2252 

This PR exports all public TypeScript types directly from `workbox-core`, so developers can import them without needing sub-package references.

It also keeps all the types defined in a single `types.ts` file at the root level, so developers wanting to make it clear in their source code what is a type and what is a part of the API can do something like this:

```js
import {somePublicMethod} from 'workbox-core';
import {SomeTypeDefinition} from 'workbox-core/types';
```
