### PR TITLE
Replace " with ' when stringifying the manifest

### DIFF
--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -174,8 +174,7 @@ class InjectManifest {
         compilation, config);
 
     // See https://github.com/GoogleChrome/workbox/issues/2263
-    const manifestString = stringify(manifestEntries)
-        .replace(/"/g, `'`);
+    const manifestString = stringify(manifestEntries).replace(/"/g, `'`);
 
     const sourcemapAssetName = getSourcemapAssetName(
         compilation, initialSWAssetString, config.swDest);

--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -173,7 +173,9 @@ class InjectManifest {
     const manifestEntries = await getManifestEntriesFromCompilation(
         compilation, config);
 
-    const manifestString = stringify(manifestEntries);
+    // See https://github.com/GoogleChrome/workbox/issues/2263
+    const manifestString = stringify(manifestEntries)
+        .replace(/"/g, `'`);
 
     const sourcemapAssetName = getSourcemapAssetName(
         compilation, initialSWAssetString, config.swDest);

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -1445,4 +1445,52 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
       });
     });
   });
+
+  describe(`[workbox-webpack-plugin] Manifest injection in development mode`, function() {
+    it(`•should produce valid, parsable JavaScript`, function(done) {
+      const outputDir = tempy.directory();
+      const config = {
+        mode: 'development',
+        entry: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        output: {
+          filename: '[name].[hash:6].js',
+          path: outputDir,
+        },
+        plugins: [
+          new InjectManifest({
+            exclude: [/sw\d.js/],
+            swDest: 'sw.js',
+            swSrc: upath.join(__dirname, '..', 'static', 'sw-src.js'),
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError, stats) => {
+        const swFile = upath.join(outputDir, 'sw.js');
+
+        try {
+          webpackBuildCheck(webpackError, stats);
+
+          const files = await globby(outputDir);
+          expect(files).to.have.length(2);
+
+          await validateServiceWorkerRuntime({
+            swFile: swFile,
+            entryPoint: 'injectManifest',
+            expectedMethodCalls: {
+              precacheAndRoute: [[[{
+                revision: 'a2baa2e58fe291932f000f0217579e97',
+                url: 'main.43096b.js',
+              }], {}]],
+            },
+          });
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+  });
 });

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -1447,7 +1447,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
   });
 
   describe(`[workbox-webpack-plugin] Manifest injection in development mode`, function() {
-    it(`•should produce valid, parsable JavaScript`, function(done) {
+    it(`should produce valid, parsable JavaScript`, function(done) {
       const outputDir = tempy.directory();
       const config = {
         mode: 'development',


### PR DESCRIPTION
R: @philipwalton

Fixes #2263

I could go down a rabbit hole a bit with either pre-escaping `'` characters in the manifest, or throwing an error when there are `'` characters there for some reason, but I think it would be sufficiently difficult to end up with a `'` organically in your manifest URLs that I'm not sure it's worth it.