### PR TITLE
Don't log the request object in the router

### DIFF
--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -212,6 +212,7 @@ class Router {
       // We have a handler, meaning Workbox is going to handle the route.
       // print the routing details to the console.
       logger.groupCollapsed(`Router is responding to: ${getFriendlyURL(url)}`);
+
       debugMessages.forEach((msg) => {
         if (Array.isArray(msg)) {
           logger.log(...msg);
@@ -219,12 +220,6 @@ class Router {
           logger.log(msg);
         }
       });
-
-      // The Request and Response objects contains a great deal of information,
-      // hide it under a group in case developers want to see it.
-      logger.groupCollapsed(`View request details here.`);
-      logger.log(request);
-      logger.groupEnd();
 
       logger.groupEnd();
     }


### PR DESCRIPTION
R: @philipwalton

Fixes #1732 

The log message didn't add a ton of value anyway, and this should work around [the bug in Safari](https://bugs.webkit.org/show_bug.cgi?id=203617).