### PR TITLE
Adds in explicit self/window in a few places

### DIFF
--- a/packages/workbox-core/src/_private/cacheWrapper.ts
+++ b/packages/workbox-core/src/_private/cacheWrapper.ts
@@ -98,7 +98,7 @@ const putWrapper = async ({
     return;
   }
 
-  const cache = await caches.open(cacheName);
+  const cache = await self.caches.open(cacheName);
 
   const updatePlugins = pluginUtils.filter(
       plugins, pluginEvents.CACHE_DID_UPDATE);
@@ -155,7 +155,7 @@ const matchWrapper = async ({
   matchOptions,
   plugins = [],
 } : MatchWrapperOptions) : Promise<Response|undefined> => {
-  const cache = await caches.open(cacheName);
+  const cache = await self.caches.open(cacheName);
 
   const effectiveRequest = await _getEffectiveRequest({
     plugins, request, mode: 'read'});

--- a/packages/workbox-core/src/clientsClaim.ts
+++ b/packages/workbox-core/src/clientsClaim.ts
@@ -19,5 +19,5 @@ declare var self: ServiceWorkerGlobalScope;
  * @alias workbox.core.clientsClaim
  */
 export const clientsClaim = () => {
-  addEventListener('activate', () => self.clients.claim());
+  self.addEventListener('activate', () => self.clients.claim());
 };

--- a/packages/workbox-core/src/skipWaiting.ts
+++ b/packages/workbox-core/src/skipWaiting.ts
@@ -21,5 +21,5 @@ declare var self: ServiceWorkerGlobalScope;
 export const skipWaiting = () => {
   // We need to explicitly call `self.skipWaiting()` here because we're
   // shadowing `skipWaiting` with this local function.
-  addEventListener('install', () => self.skipWaiting());
+  self.addEventListener('install', () => self.skipWaiting());
 };

--- a/packages/workbox-expiration/src/CacheExpiration.ts
+++ b/packages/workbox-expiration/src/CacheExpiration.ts
@@ -110,7 +110,7 @@ class CacheExpiration {
         minTimestamp, this._maxEntries);
 
     // Delete URLs from the cache
-    const cache = await caches.open(this._cacheName);
+    const cache = await self.caches.open(this._cacheName);
     for (const url of urlsExpired) {
       await cache.delete(url);
     }

--- a/packages/workbox-expiration/src/ExpirationPlugin.ts
+++ b/packages/workbox-expiration/src/ExpirationPlugin.ts
@@ -279,7 +279,7 @@ class ExpirationPlugin implements WorkboxPlugin {
     // Do this one at a time instead of all at once via `Promise.all()` to
     // reduce the chance of inconsistency if a promise rejects.
     for (const [cacheName, cacheExpiration] of this._cacheExpirations) {
-      await caches.delete(cacheName);
+      await self.caches.delete(cacheName);
       await cacheExpiration.delete();
     }
 

--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -143,7 +143,7 @@ class PrecacheController {
     const toBePrecached: {cacheKey: string, url: string}[] = [];
     const alreadyPrecached: string[] = [];
 
-    const cache = await caches.open(this._cacheName);
+    const cache = await self.caches.open(this._cacheName);
     const alreadyCachedRequests = await cache.keys();
     const existingCacheKeys = new Set(alreadyCachedRequests.map(
         (request) => request.url));
@@ -189,7 +189,7 @@ class PrecacheController {
    * @return {Promise<workbox.precaching.CleanupResult>}
    */
   async activate() {
-    const cache = await caches.open(this._cacheName);
+    const cache = await self.caches.open(this._cacheName);
     const currentlyCachedRequests = await cache.keys();
     const expectedCacheKeys = new Set(this._urlsToCacheKeys.values());
 
@@ -352,7 +352,7 @@ class PrecacheController {
     const url = request instanceof Request ? request.url : request;
     const cacheKey = this.getCacheKeyForURL(url);
     if (cacheKey) {
-      const cache = await caches.open(this._cacheName);
+      const cache = await self.caches.open(this._cacheName);
       return cache.match(cacheKey);
     }
     return undefined;

--- a/packages/workbox-precaching/src/cleanupOutdatedCaches.ts
+++ b/packages/workbox-precaching/src/cleanupOutdatedCaches.ts
@@ -20,7 +20,7 @@ import './_version.js';
  */
 export const cleanupOutdatedCaches = () => {
   // See https://github.com/Microsoft/TypeScript/issues/28357#issuecomment-436484705
-  addEventListener('activate', ((event: ExtendableEvent) => {
+  self.addEventListener('activate', ((event: ExtendableEvent) => {
     const cacheName = cacheNames.getPrecacheName();
 
     event.waitUntil(deleteOutdatedCaches(cacheName).then((cachesDeleted) => {

--- a/packages/workbox-precaching/src/precache.ts
+++ b/packages/workbox-precaching/src/precache.ts
@@ -69,7 +69,7 @@ export const precache = (entries: Array<PrecacheEntry|string>) => {
     // method is called multiple times) because event listeners are implemented
     // as a set, where each listener must be unique.
     // See https://github.com/Microsoft/TypeScript/issues/28357#issuecomment-436484705
-    addEventListener('install', installListener as EventListener);
-    addEventListener('activate', activateListener as EventListener);
+    self.addEventListener('install', installListener as EventListener);
+    self.addEventListener('activate', activateListener as EventListener);
   }
 };

--- a/packages/workbox-precaching/src/utils/addFetchListener.ts
+++ b/packages/workbox-precaching/src/utils/addFetchListener.ts
@@ -57,7 +57,7 @@ export const addFetchListener = ({
   const cacheName = cacheNames.getPrecacheName();
 
   // See https://github.com/Microsoft/TypeScript/issues/28357#issuecomment-436484705
-  addEventListener('fetch', ((event: FetchEvent) => {
+  self.addEventListener('fetch', ((event: FetchEvent) => {
     const precachedURL = getCacheKeyForURL(event.request.url, {
       cleanURLs,
       directoryIndex,
@@ -72,7 +72,7 @@ export const addFetchListener = ({
       return;
     }
 
-    let responsePromise = caches.open(cacheName).then((cache) => {
+    let responsePromise = self.caches.open(cacheName).then((cache) => {
       return cache.match(precachedURL);
     }).then((cachedResponse) => {
       if (cachedResponse) {

--- a/packages/workbox-precaching/src/utils/deleteOutdatedCaches.ts
+++ b/packages/workbox-precaching/src/utils/deleteOutdatedCaches.ts
@@ -35,7 +35,7 @@ const SUBSTRING_TO_FIND = '-precache-';
 const deleteOutdatedCaches = async (
     currentPrecacheName: string,
     substringToFind:string = SUBSTRING_TO_FIND) => {
-  const cacheNames = await caches.keys();
+  const cacheNames = await self.caches.keys();
 
   const cacheNamesToDelete = cacheNames.filter((cacheName) => {
     return cacheName.includes(substringToFind) &&
@@ -44,7 +44,7 @@ const deleteOutdatedCaches = async (
   });
 
   await Promise.all(
-      cacheNamesToDelete.map((cacheName) => caches.delete(cacheName)));
+      cacheNamesToDelete.map((cacheName) => self.caches.delete(cacheName)));
 
   return cacheNamesToDelete;
 };

--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -104,7 +104,7 @@ class Workbox extends WorkboxEventTarget {
     }
 
     if (!immediate && document.readyState !== 'complete') {
-      await new Promise((res) => addEventListener('load', res));
+      await new Promise((res) => window.addEventListener('load', res));
     }
 
     // Set this flag to true if any service worker was controlling the page


### PR DESCRIPTION
**Prior to filing a PR, please:**
- [open an issue](https://github.com/GoogleChrome/workbox/issues/new) to discuss your proposed change.
- ensure that `gulp lint test` passes locally.

R: @philipwalton

There are a few instances where using the implicit global (`window` or `self`) was making JS Compiler with a specific set of `externs` unhappy.