### PR TITLE
Upgrade strip-comments to 2.0.1 from 1.0.2

### DIFF
--- a/packages/workbox-build/package-lock.json
+++ b/packages/workbox-build/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "workbox-build",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -870,14 +870,6 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
-    "babel-extract-comments": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
-      "integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
-      "requires": {
-        "babylon": "^6.18.0"
-      }
-    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
@@ -885,41 +877,6 @@
       "requires": {
         "object.assign": "^4.1.0"
       }
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
-    },
-    "babel-plugin-transform-object-rest-spread": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.26.0"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1138,11 +1095,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-    },
-    "core-js": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
     },
     "core-js-compat": {
       "version": "3.1.4",
@@ -2402,13 +2354,9 @@
       }
     },
     "strip-comments": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
-      "integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
-      "requires": {
-        "babel-extract-comments": "^1.0.0",
-        "babel-plugin-transform-object-rest-spread": "^6.26.0"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -2627,117 +2575,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "workbox-background-sync": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-5.0.0-beta.0.tgz",
-      "integrity": "sha512-D4x/ZdqRrN2iYkbIoeE/AMWQJIjppPMWU4jb0/0Ur8egyDm/oaIV5/1tAyLoMQr0O2qJT90+uxqk8/lLF19r2A==",
-      "requires": {
-        "workbox-core": "^5.0.0-beta.0"
-      }
-    },
-    "workbox-broadcast-update": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-5.0.0-beta.0.tgz",
-      "integrity": "sha512-AXtwmiHU8Ca4qVGHenSJH6VFhpyDiyRHgA/Ul4DQRRC2iv14wJrwcNP2aoGEdkCDqMPaQaydRJYHKHN4DWUIuQ==",
-      "requires": {
-        "workbox-core": "^5.0.0-beta.0"
-      }
-    },
-    "workbox-cacheable-response": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-5.0.0-beta.0.tgz",
-      "integrity": "sha512-41l7TpFDRpQIZm8mzQGPvM1zTVmKAbjpPdfF8GxhMHQm0tF07IqC/JqRtDy4kao7ssDITcJBKAzA7s4nCXnKkA==",
-      "requires": {
-        "workbox-core": "^5.0.0-beta.0"
-      }
-    },
-    "workbox-core": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-5.0.0-beta.0.tgz",
-      "integrity": "sha512-J++OJd7hX7XTmNQ9GZEikwyfCaEYf3/oN1h6KC3Fs0ZuwJ9RJpbfoyvTRcDwrIN3sVrfHOhAIWjT5BGeRv15OA=="
-    },
-    "workbox-expiration": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-5.0.0-beta.0.tgz",
-      "integrity": "sha512-sxnnECke9grQAKCKX7C6OgnsnVUAbR687oh0/r4aGu7SA+bGeM7rwWat1VeRdv1OVt+C5QsBpk7TbTwlwBS4VQ==",
-      "requires": {
-        "workbox-core": "^5.0.0-beta.0"
-      }
-    },
-    "workbox-google-analytics": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-5.0.0-beta.0.tgz",
-      "integrity": "sha512-RFckekMMthMwMzxu2vA6O65gWHSwt46lehUK/5K7rvqlWf0R3ZjkPbT6F97aDq852jQrQjd2ZSvhhqJAcpCXdA==",
-      "requires": {
-        "workbox-background-sync": "^5.0.0-beta.0",
-        "workbox-core": "^5.0.0-beta.0",
-        "workbox-routing": "^5.0.0-beta.0",
-        "workbox-strategies": "^5.0.0-beta.0"
-      }
-    },
-    "workbox-navigation-preload": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-5.0.0-beta.0.tgz",
-      "integrity": "sha512-lK/lYODt32tD/xkOge24Pyhs5HN7R+rEQSFif9JFwlNxDq+xRWyqGH8VavpNylW+6iCM6Pl4PQEMqH3zjjyeBw==",
-      "requires": {
-        "workbox-core": "^5.0.0-beta.0"
-      }
-    },
-    "workbox-precaching": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-5.0.0-beta.0.tgz",
-      "integrity": "sha512-7Hu1K66KrbN4Y3YosAF+pDmb1xV/LgD7VPGQ1+hkMzNFP138Mso3HvVb3M6U4aLG3lJT/sJR3h/EeqpGPVFGPw==",
-      "requires": {
-        "workbox-core": "^5.0.0-beta.0"
-      }
-    },
-    "workbox-range-requests": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-5.0.0-beta.0.tgz",
-      "integrity": "sha512-wkjgHwMdmIW9FnK25c4TGc4iYZsLo4br8BpQln/Qp9FINsHK2M+ba0v3bMLt2nSq6cWcj1knZkdXMNDS99qrqg==",
-      "requires": {
-        "workbox-core": "^5.0.0-beta.0"
-      }
-    },
-    "workbox-routing": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-5.0.0-beta.0.tgz",
-      "integrity": "sha512-TlTWD6Aa+1Z/Nt5lR55j5Ctk4IYN7nCzT6BpFLanVkFnLc3RcASkuxH0WhLyAywwY+m6wYTxvwvfGFy3npivew==",
-      "requires": {
-        "workbox-core": "^5.0.0-beta.0"
-      }
-    },
-    "workbox-strategies": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-5.0.0-beta.0.tgz",
-      "integrity": "sha512-bej7tOovHKr5UnnonLoYZh7Euv5Dhd+X2jgw3XfIxHhYqjW0aQI7NDsZrKqigB414MGls8Tr9kykSs2oc971HQ==",
-      "requires": {
-        "workbox-core": "^5.0.0-beta.0",
-        "workbox-routing": "^5.0.0-beta.0"
-      }
-    },
-    "workbox-streams": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-5.0.0-beta.0.tgz",
-      "integrity": "sha512-ZAq1tC33lkmsg4CQMRyZBj6fh5ShVXPDybs5M3cCHcYn2fZSyP3QMENaHbXw62ebyT8/OGt2HTFc7v64lLpH6w==",
-      "requires": {
-        "workbox-core": "^5.0.0-beta.0",
-        "workbox-routing": "^5.0.0-beta.0"
-      }
-    },
-    "workbox-sw": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-5.0.0-beta.0.tgz",
-      "integrity": "sha512-sA1DWNcgMBL3qOd+FEpkn105/V4BAFb6toZp94djSV0S9ERVpTb5Uqo8flTBuvYj5m7jeekhLa+bfWEAlYBgbQ=="
-    },
-    "workbox-window": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-5.0.0-beta.0.tgz",
-      "integrity": "sha512-ozuvyr+6bhfkxuFpE6EdoqNTg9ygt0Dk4KRcHCaWUJiRbxNXA6HaFWIMeL8AFMdtdkRB3SZ+/TJeEu7JepHFrg==",
-      "requires": {
-        "workbox-core": "^5.0.0-beta.0"
-      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -39,7 +39,7 @@
     "source-map": "^0.7.3",
     "source-map-url": "^0.4.0",
     "stringify-object": "^3.3.0",
-    "strip-comments": "^1.0.2",
+    "strip-comments": "^2.0.1",
     "tempy": "^0.3.0",
     "upath": "^1.1.2",
     "workbox-background-sync": "^5.0.0-rc.0",


### PR DESCRIPTION
Upgrade strip-comments to 2.0.1 from 1.0.2

This upgrade will remove dependency to core-js annoying ads.