### PR TITLE
window.__WB_DISABLE_DEV_LOGS  declaration

### DIFF
--- a/packages/workbox-core/src/_private/logger.ts
+++ b/packages/workbox-core/src/_private/logger.ts
@@ -7,8 +7,13 @@
 
 import '../_version.js';
 
+// logger is used inside of both service workers and the window global scope.
 declare global {
   interface WorkerGlobalScope {
+    __WB_DISABLE_DEV_LOGS: boolean;
+  }
+
+  interface Window {
     __WB_DISABLE_DEV_LOGS: boolean;
   }
 }


### PR DESCRIPTION
R: @philipwalton

We need this extra declaration because `workbox-core`'s `logger` can be used in the `window` context as well.