### PR TITLE
Await an async cacheWillUpdate in PrecacheController.install()

### DIFF
--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -262,7 +262,7 @@ class PrecacheController {
       // Use a callback if provided. It returns a truthy value if valid.
       // NOTE: invoke the method on the plugin instance so the `this` context
       // is correct.
-      cacheWillUpdatePlugin.cacheWillUpdate!({event, request, response}) :
+      await cacheWillUpdatePlugin.cacheWillUpdate!({event, request, response}) :
       // Otherwise, default to considering any response status under 400 valid.
       // This includes, by default, considering opaque responses valid.
       response.status < 400;

--- a/test/workbox-precaching/sw/test-PrecacheController.mjs
+++ b/test/workbox-precaching/sw/test-PrecacheController.mjs
@@ -656,6 +656,36 @@ describe(`PrecacheController`, function() {
       // This should succeed.
       await precacheController.install({plugins});
     });
+
+    it(`should properly await an async cacheWillUpdate plugin`, async function() {
+      sandbox.stub(fetchWrapper, 'fetch').resolves(new Response('', {
+        status: 203,
+      }));
+
+      const precacheController = new PrecacheController();
+      const cacheList = [
+        '/will-be-error.html',
+      ];
+      precacheController.addToCacheList(cacheList);
+
+      const plugins = [{
+        cacheWillUpdate: async ({request, response}) => {
+          expect(request).to.exist;
+
+          if (response.status === 203) {
+            return null;
+          }
+          return response;
+        },
+      }];
+
+      // Assuming the async plugin function is properly await-ed, an error
+      // will be thrown.
+      return expectError(
+          () => precacheController.install({plugins}),
+          'bad-precaching-response'
+      );
+    });
   });
 
   describe(`activate()`, function() {


### PR DESCRIPTION
R: @philipwalton

Fixes #2285 

When we made all of the standard  plugins `async`, we forgot add in an `await` inside of the `PrecacheController.install()` method.