### PR TITLE
Don't overwrite __WB_DISABLE_DEV_LOGS

### DIFF
--- a/packages/workbox-core/src/_private/logger.ts
+++ b/packages/workbox-core/src/_private/logger.ts
@@ -21,7 +21,11 @@ declare global {
 type LoggerMethods = 'debug'|'log'|'warn'|'error'|'groupCollapsed'|'groupEnd';
     
 const logger = <Console> (process.env.NODE_ENV === 'production' ? null : (() => {
-  self.__WB_DISABLE_DEV_LOGS = false;
+  // Don't overwrite this value if it's already set.
+  // See https://github.com/GoogleChrome/workbox/pull/2284#issuecomment-560470923
+  if (!('__WB_DISABLE_DEV_LOGS' in self)) {
+    self.__WB_DISABLE_DEV_LOGS = false;
+  }
 
   let inGroup = false;
 

--- a/packages/workbox-core/src/_private/logger.ts
+++ b/packages/workbox-core/src/_private/logger.ts
@@ -23,7 +23,7 @@ type LoggerMethods = 'debug'|'log'|'warn'|'error'|'groupCollapsed'|'groupEnd';
 const logger = <Console> (process.env.NODE_ENV === 'production' ? null : (() => {
   // Don't overwrite this value if it's already set.
   // See https://github.com/GoogleChrome/workbox/pull/2284#issuecomment-560470923
-  if (!('__WB_DISABLE_DEV_LOGS' in self)) {
+  if (!('__WB_DISABLE_DEV_LOGS' in self!)) {
     self.__WB_DISABLE_DEV_LOGS = false;
   }
 


### PR DESCRIPTION
R: @philipwalton
CC: @westonruter

See https://github.com/GoogleChrome/workbox/pull/2284#issuecomment-560470923

Unfortunately, I can't think of a great way to test this, given that by the time our test suite executes, the `logger` IIFE will have already executed.