### PR TITLE
Update NodeJS to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
     - ~/.selenium-assistant
 
 node_js:
-  - 8
+  - 10
 
 install:
   - npm ci

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workbox",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "bot": "pr-bot",


### PR DESCRIPTION
Update to a supported maintained NodeJS version
https://nodejs.org/en/about/releases/
v8 have end of life this year, 2019-12-31.