### PR TITLE
Absolute paths in injectManifest's filePaths return value

### DIFF
--- a/packages/workbox-build/src/inject-manifest.js
+++ b/packages/workbox-build/src/inject-manifest.js
@@ -130,7 +130,8 @@ async function injectManifest(config) {
     count,
     size,
     warnings,
-    filePaths: Object.keys(filesToWrite),
+    // Use upath.resolve() to make all the paths absolute.
+    filePaths: Object.keys(filesToWrite).map((f) => upath.resolve(f)),
   };
 }
 

--- a/test/workbox-build/node/inject-manifest.js
+++ b/test/workbox-build/node/inject-manifest.js
@@ -199,6 +199,17 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       });
     });
 
+    it(`should use absolute paths in the filePaths return value`, async function() {
+      // Deliberately use a relative path for swDest.
+      const swDest = upath.relative('.', tempy.file({extension: 'js'}));
+      const options = Object.assign({}, BASE_OPTIONS, {swDest});
+
+      const {filePaths, warnings} = await injectManifest(options);
+      expect(warnings).to.be.empty;
+      // Use upath.resolve() to confirm that we get back an absolute path.
+      expect(filePaths).to.have.members([upath.resolve(swDest)]);
+    });
+
     it(`should use defaults when all the required parameters are present, when workboxSW.precache() is called twice`, async function() {
       const swDest = tempy.file({extension: 'js'});
       const options = Object.assign({}, BASE_OPTIONS, {


### PR DESCRIPTION
R: @philipwalton

Just a small thing that bugged me when I looked at the logged output from `injectManifest`.