### PR TITLE
Update jsdoc comments to use package names

### DIFF
--- a/packages/workbox-background-sync/src/BackgroundSyncPlugin.ts
+++ b/packages/workbox-background-sync/src/BackgroundSyncPlugin.ts
@@ -14,16 +14,16 @@ import './_version.js';
  * A class implementing the `fetchDidFail` lifecycle callback. This makes it
  * easier to add failed requests to a background sync Queue.
  *
- * @memberof workbox.backgroundSync
+ * @memberof module:workbox-background-sync
  */
 class BackgroundSyncPlugin implements WorkboxPlugin {
   private _queue: Queue;
 
   /**
-   * @param {string} name See the [Queue]{@link workbox.backgroundSync.Queue}
+   * @param {string} name See the [Queue]{@link module:workbox-background-sync.Queue}
    *     documentation for parameter details.
    * @param {Object} [options] See the
-   *     [Queue]{@link workbox.backgroundSync.Queue} documentation for
+   *     [Queue]{@link module:workbox-background-sync.Queue} documentation for
    *     parameter details.
    */
   constructor(name: string, options: QueueOptions) {

--- a/packages/workbox-background-sync/src/Queue.ts
+++ b/packages/workbox-background-sync/src/Queue.ts
@@ -47,7 +47,7 @@ const queueNames = new Set();
  * later. All parts of the storing and replaying process are observable via
  * callbacks.
  *
- * @memberof workbox.backgroundSync
+ * @memberof module:workbox-background-sync
  */
 class Queue {
   private _name: string;

--- a/packages/workbox-background-sync/src/index.ts
+++ b/packages/workbox-background-sync/src/index.ts
@@ -12,7 +12,7 @@ import './_version.js';
 
 
 /**
- * @namespace workbox.backgroundSync
+ * @module workbox-background-sync
  */
 
 export {

--- a/packages/workbox-background-sync/src/lib/QueueStore.ts
+++ b/packages/workbox-background-sync/src/lib/QueueStore.ts
@@ -149,7 +149,7 @@ export class QueueStore {
   /**
    * Returns all entries in the store matching the `queueName`.
    *
-   * @param {Object} options See workbox.backgroundSync.Queue~getAll}
+   * @param {Object} options See {@link module:workbox-background-sync.Queue~getAll}
    * @return {Promise<Array<Object>>}
    * @private
    */

--- a/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts
+++ b/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts
@@ -52,7 +52,7 @@ function defaultPayloadGenerator(data: CacheDidUpdateCallbackParam): Object {
  * For efficiency's sake, the underlying response bodies are not compared;
  * only specific response headers are checked.
  *
- * @memberof workbox.broadcastUpdate
+ * @memberof module:workbox-broadcast-updatesync
  */
 class BroadcastCacheUpdate {
   private _headersToCheck: string[];

--- a/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts
+++ b/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts
@@ -52,7 +52,7 @@ function defaultPayloadGenerator(data: CacheDidUpdateCallbackParam): Object {
  * For efficiency's sake, the underlying response bodies are not compared;
  * only specific response headers are checked.
  *
- * @memberof module:workbox-broadcast-updatesync
+ * @memberof module:workbox-broadcast-update
  */
 class BroadcastCacheUpdate {
   private _headersToCheck: string[];

--- a/packages/workbox-broadcast-update/src/BroadcastUpdatePlugin.ts
+++ b/packages/workbox-broadcast-update/src/BroadcastUpdatePlugin.ts
@@ -17,7 +17,7 @@ import './_version.js';
  * This plugin will automatically broadcast a message whenever a cached response
  * is updated.
  *
- * @memberof module:workbox-broadcast-updatesync
+ * @memberof module:workbox-broadcast-update
  */
 class BroadcastUpdatePlugin implements WorkboxPlugin {
   private _broadcastUpdate: BroadcastCacheUpdate;

--- a/packages/workbox-broadcast-update/src/BroadcastUpdatePlugin.ts
+++ b/packages/workbox-broadcast-update/src/BroadcastUpdatePlugin.ts
@@ -17,14 +17,14 @@ import './_version.js';
  * This plugin will automatically broadcast a message whenever a cached response
  * is updated.
  *
- * @memberof workbox.broadcastUpdate
+ * @memberof module:workbox-broadcast-updatesync
  */
 class BroadcastUpdatePlugin implements WorkboxPlugin {
   private _broadcastUpdate: BroadcastCacheUpdate;
 
   /**
    * Construct a BroadcastCacheUpdate instance with the passed options and
-   * calls its [`notifyIfUpdated()`]{@link workbox.broadcastUpdate.BroadcastCacheUpdate~notifyIfUpdated}
+   * calls its [`notifyIfUpdated()`]{@link module:workbox-broadcast-update.BroadcastCacheUpdate~notifyIfUpdated}
    * method whenever the plugin's `cacheDidUpdate` callback is invoked.
    *
    * @param {Object} options

--- a/packages/workbox-broadcast-update/src/index.ts
+++ b/packages/workbox-broadcast-update/src/index.ts
@@ -13,7 +13,7 @@ import './_version.js';
 
 
 /**
- * @namespace workbox.broadcastUpdate
+ * @module workbox-broadcast-update
  */
 
 export {

--- a/packages/workbox-broadcast-update/src/responsesAreSame.ts
+++ b/packages/workbox-broadcast-update/src/responsesAreSame.ts
@@ -20,8 +20,7 @@ import './_version.js';
  * @param {Array<string>} headersToCheck
  * @return {boolean}
  *
- * @memberof module:workbox-broadcast-updatesync
- * @private
+ * @memberof module:workbox-broadcast-update
  */
 const responsesAreSame = (
   firstResponse: Response,

--- a/packages/workbox-broadcast-update/src/responsesAreSame.ts
+++ b/packages/workbox-broadcast-update/src/responsesAreSame.ts
@@ -20,7 +20,7 @@ import './_version.js';
  * @param {Array<string>} headersToCheck
  * @return {boolean}
  *
- * @memberof workbox.broadcastUpdate
+ * @memberof module:workbox-broadcast-updatesync
  * @private
  */
 const responsesAreSame = (

--- a/packages/workbox-build/src/lib/module-registry.js
+++ b/packages/workbox-build/src/lib/module-registry.js
@@ -12,10 +12,11 @@ const upath = require('upath');
 /**
  * Class for keeping track of which Workbox modules are used by the generated
  * service worker script.
+ * @private
  */
 class ModuleRegistry {
   /**
-   * Basic constructor.
+   * @private
    */
   constructor() {
     this.modulesUsed = new Map();
@@ -24,6 +25,7 @@ class ModuleRegistry {
   /**
    * @return {Array<string>} A list of all of the import statements that are
    * needed for the modules being used.
+   * @private
    */
   getImportStatements() {
     const workboxModuleImports = [];
@@ -48,6 +50,7 @@ class ModuleRegistry {
    * @param {string} pkg The workbox package that the module belongs to.
    * @param {string} moduleName The name of the module to import.
    * @return {string} The local variable name that corresponds to that module.
+   * @private
    */
   getLocalName(pkg, moduleName) {
     return `${pkg.replace(/-/g, '_')}_${moduleName}`;
@@ -57,6 +60,7 @@ class ModuleRegistry {
    * @param {string} pkg The workbox package that the module belongs to.
    * @param {string} moduleName The name of the module to import.
    * @return {string} The local variable name that corresponds to that module.
+   * @private
    */
   use(pkg, moduleName) {
     const localName = this.getLocalName(pkg, moduleName);

--- a/packages/workbox-cacheable-response/src/CacheableResponse.ts
+++ b/packages/workbox-cacheable-response/src/CacheableResponse.ts
@@ -24,7 +24,7 @@ export interface CacheableResponseOptions {
  * [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
  * to be considered cacheable.
  *
- * @memberof workbox.cacheableResponse
+ * @memberof module:workbox-cacheable-response
  */
 class CacheableResponse {
   private _statuses?: CacheableResponseOptions['statuses'];

--- a/packages/workbox-cacheable-response/src/CacheableResponsePlugin.ts
+++ b/packages/workbox-cacheable-response/src/CacheableResponsePlugin.ts
@@ -15,7 +15,7 @@ import './_version.js';
  * easier to add in cacheability checks to requests made via Workbox's built-in
  * strategies.
  *
- * @memberof workbox.cacheableResponse
+ * @memberof module:workbox-cacheable-response
  */
 class CacheableResponsePlugin implements WorkboxPlugin {
   private _cacheableResponse: CacheableResponse;

--- a/packages/workbox-cacheable-response/src/index.ts
+++ b/packages/workbox-cacheable-response/src/index.ts
@@ -12,7 +12,7 @@ import './_version.js';
 
 
 /**
- * @namespace workbox.cacheableResponse
+ * @module workbox-cacheable-response
  */
 
 export {

--- a/packages/workbox-cli/src/lib/errors.js
+++ b/packages/workbox-cli/src/lib/errors.js
@@ -27,5 +27,5 @@ module.exports = {
     configuration file.`,
   'sw-src-missing-injection-point': ol`That is not a valid source service worker
     file. Please try again with a file containing
-    'workbox.precaching.precacheAndRoute([])'.`,
+    'self.__WB_MANIFEST'.`,
 };

--- a/packages/workbox-cli/src/lib/questions/ask-sw-src.js
+++ b/packages/workbox-cli/src/lib/questions/ask-sw-src.js
@@ -22,7 +22,7 @@ function askQuestion() {
     name,
     message: ol`Where's your existing service worker file? To be used with
       injectManifest, it should include a call to
-      'workbox.precaching.precacheAndRoute([])'`,
+      'self.__WB_MANIFEST'`,
     type: 'input',
   }]);
 }

--- a/packages/workbox-core/src/_private/executeQuotaErrorCallbacks.ts
+++ b/packages/workbox-core/src/_private/executeQuotaErrorCallbacks.ts
@@ -15,7 +15,7 @@ import '../_version.js';
  * Runs all of the callback functions, one at a time sequentially, in the order
  * in which they were registered.
  *
- * @memberof workbox.core
+ * @memberof module:workbox-core
  * @private
  */
 async function executeQuotaErrorCallbacks() {

--- a/packages/workbox-core/src/cacheNames.ts
+++ b/packages/workbox-core/src/cacheNames.ts
@@ -23,9 +23,9 @@ import './_version.js';
  * @return {Object} An object with `precache`, `runtime`, `prefix`, and
  *     `googleAnalytics` properties.
  *
- * @alias workbox.core.cacheNames
+ * @memberof module:workbox-core
  */
-export const cacheNames = {
+const cacheNames = {
   get googleAnalytics() {
     return _cacheNames.getGoogleAnalyticsName();
   },
@@ -42,3 +42,5 @@ export const cacheNames = {
     return _cacheNames.getSuffix();
   },
 };
+
+export {cacheNames}

--- a/packages/workbox-core/src/clientsClaim.ts
+++ b/packages/workbox-core/src/clientsClaim.ts
@@ -16,8 +16,10 @@ declare var self: ServiceWorkerGlobalScope;
  * Claim any currently available clients once the service worker
  * becomes active. This is normally used in conjunction with `skipWaiting()`.
  *
- * @alias workbox.core.clientsClaim
+ * @memberof module:workbox-core
  */
-export const clientsClaim = () => {
+function clientsClaim() {
   self.addEventListener('activate', () => self.clients.claim());
 };
+
+export {clientsClaim}

--- a/packages/workbox-core/src/copyResponse.ts
+++ b/packages/workbox-core/src/copyResponse.ts
@@ -24,7 +24,7 @@ import './_version.js';
  *
  * @param {Response} response
  * @param {Function} modifier
- * @alias workbox.core.copyResponse
+ * @memberof module:workbox-core
  */
 async function copyResponse(
   response: Response,

--- a/packages/workbox-core/src/index.ts
+++ b/packages/workbox-core/src/index.ts
@@ -21,7 +21,7 @@ import './_version.js';
  * code as well as setting default values that need to be shared (like cache
  * names).
  *
- * @namespace workbox.core
+ * @module workbox-core
  */
 export {
   _private,

--- a/packages/workbox-core/src/registerQuotaErrorCallback.ts
+++ b/packages/workbox-core/src/registerQuotaErrorCallback.ts
@@ -17,7 +17,7 @@ import './_version.js';
  * there's a quota error.
  *
  * @param {Function} callback
- * @memberof workbox.core
+ * @memberof module:workbox-core
  */
 function registerQuotaErrorCallback(callback: Function) {
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/workbox-core/src/setCacheNameDetails.ts
+++ b/packages/workbox-core/src/setCacheNameDetails.ts
@@ -27,9 +27,9 @@ import './_version.js';
  * @param {Object} [details.googleAnalytics] The cache name to use for
  *     `workbox-google-analytics` caching.
  *
- * @alias workbox.core.setCacheNameDetails
+ * @memberof module:workbox-core
  */
-export const setCacheNameDetails = (details: PartialCacheNameDetails) => {
+function setCacheNameDetails(details: PartialCacheNameDetails) {
   if (process.env.NODE_ENV !== 'production') {
     Object.keys(details).forEach((key) => {
       assert!.isType(details[key], 'string', {
@@ -63,3 +63,5 @@ export const setCacheNameDetails = (details: PartialCacheNameDetails) => {
 
   cacheNames.updateDetails(details);
 };
+
+export {setCacheNameDetails}

--- a/packages/workbox-core/src/skipWaiting.ts
+++ b/packages/workbox-core/src/skipWaiting.ts
@@ -16,10 +16,12 @@ declare var self: ServiceWorkerGlobalScope;
  * Force a service worker to become active, instead of waiting. This is
  * normally used in conjunction with `clientsClaim()`.
  *
- * @alias workbox.core.skipWaiting
+ * @memberof module:workbox-core
  */
-export const skipWaiting = () => {
+function skipWaiting() {
   // We need to explicitly call `self.skipWaiting()` here because we're
   // shadowing `skipWaiting` with this local function.
   self.addEventListener('install', () => self.skipWaiting());
 };
+
+export {skipWaiting}

--- a/packages/workbox-expiration/src/CacheExpiration.ts
+++ b/packages/workbox-expiration/src/CacheExpiration.ts
@@ -26,7 +26,7 @@ interface CacheExpirationConfig {
  * limit on the number of responses stored in a
  * [`Cache`](https://developer.mozilla.org/en-US/docs/Web/API/Cache).
  *
- * @memberof workbox.expiration
+ * @memberof module:workbox-expiration
  */
 class CacheExpiration {
   private _isRunning: boolean = false;

--- a/packages/workbox-expiration/src/ExpirationPlugin.ts
+++ b/packages/workbox-expiration/src/ExpirationPlugin.ts
@@ -35,7 +35,7 @@ import './_version.js';
  * When using `maxEntries`, the entry least-recently requested will be removed
  * from the cache first.
  *
- * @memberof workbox.expiration
+ * @memberof module:workbox-expiration
  */
 class ExpirationPlugin implements WorkboxPlugin {
   private _config: object;
@@ -117,7 +117,7 @@ class ExpirationPlugin implements WorkboxPlugin {
 
   /**
    * A "lifecycle" callback that will be triggered automatically by the
-   * `workbox.strategies` handlers when a `Response` is about to be returned
+   * `workbox-strategies` handlers when a `Response` is about to be returned
    * from a [Cache](https://developer.mozilla.org/en-US/docs/Web/API/Cache) to
    * the handler. It allows the `Response` to be inspected for freshness and
    * prevents it from being used if the `Response`'s `Date` header value is
@@ -226,7 +226,7 @@ class ExpirationPlugin implements WorkboxPlugin {
 
   /**
    * A "lifecycle" callback that will be triggered automatically by the
-   * `workbox.strategies` handlers when an entry is added to a cache.
+   * `workbox-strategies` handlers when an entry is added to a cache.
    *
    * @param {Object} options
    * @param {string} options.cacheName Name of the cache that was updated.

--- a/packages/workbox-expiration/src/index.ts
+++ b/packages/workbox-expiration/src/index.ts
@@ -12,7 +12,7 @@ import './_version.js';
 
 
 /**
- * @namespace workbox.expiration
+ * @module workbox-expiration
  */
 
 export {

--- a/packages/workbox-google-analytics/src/index.ts
+++ b/packages/workbox-google-analytics/src/index.ts
@@ -11,7 +11,7 @@ import './_version.js';
 
 
 /**
- * @namespace workbox.googleAnalytics
+ * @module workbox-google-analytics
  */
 
 export {

--- a/packages/workbox-google-analytics/src/initialize.ts
+++ b/packages/workbox-google-analytics/src/initialize.ts
@@ -41,8 +41,8 @@ interface GoogleAnalyticsInitializeOptions {
  * `qt` param based on the current time, as well as applies any other
  * user-defined hit modifications.
  *
- * @param {Object} config See workbox.googleAnalytics.initialize.
- * @return {Function} The requestWillDequeu callback function.
+ * @param {Object} config See {@link module:workbox-google-analytics.initialize}.
+ * @return {Function} The requestWillDequeue callback function.
  *
  * @private
  */
@@ -204,7 +204,7 @@ const createGtmJsRoute = (cacheName: string) => {
  *     the hit. The function is invoked with the original hit's URLSearchParams
  *     object as its only argument.
  *
- * @memberof workbox.googleAnalytics
+ * @memberof module:workbox-google-analytics
  */
 const initialize = (options: GoogleAnalyticsInitializeOptions = {}) => {
   const cacheName = cacheNames.getGoogleAnalyticsName(options.cacheName);

--- a/packages/workbox-navigation-preload/src/disable.ts
+++ b/packages/workbox-navigation-preload/src/disable.ts
@@ -17,7 +17,7 @@ declare var self: ServiceWorkerGlobalScope;
 /**
  * If the browser supports Navigation Preload, then this will disable it.
  *
- * @memberof workbox.navigationPreload
+ * @memberof module:workbox-navigation-preload
  */
 function disable() {
   if (isSupported()) {

--- a/packages/workbox-navigation-preload/src/enable.ts
+++ b/packages/workbox-navigation-preload/src/enable.ts
@@ -22,7 +22,7 @@ declare var self: ServiceWorkerGlobalScope;
  * the value of the `Service-Worker-Navigation-Preload` header which will be
  * sent to the server when making the navigation request.
  *
- * @memberof workbox.navigationPreload
+ * @memberof module:workbox-navigation-preload
  */
 function enable(headerValue?: string) {
   if (isSupported()) {

--- a/packages/workbox-navigation-preload/src/index.ts
+++ b/packages/workbox-navigation-preload/src/index.ts
@@ -13,7 +13,7 @@ import './_version.js';
 
 
 /**
- * @namespace workbox.navigationPreload
+ * @module workbox-navigation-preload
  */
 
 export {

--- a/packages/workbox-navigation-preload/src/isSupported.ts
+++ b/packages/workbox-navigation-preload/src/isSupported.ts
@@ -16,7 +16,7 @@ declare var self: ServiceWorkerGlobalScope;
  * @return {boolean} Whether or not the current browser supports enabling
  * navigation preload.
  *
- * @memberof workbox.navigationPreload
+ * @memberof module:workbox-navigation-preload
  */
 function isSupported(): boolean {
   return Boolean(self.registration && self.registration.navigationPreload);

--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -123,7 +123,7 @@ class PrecacheController {
    * @param {Event} [options.event] The install event (if needed).
    * @param {Array<Object>} [options.plugins] Plugins to be used for fetching
    * and caching during install.
-   * @return {Promise<workbox.precaching.InstallResult>}
+   * @return {Promise<module:workbox-precaching.InstallResult>}
    */
   async install({event, plugins}: {
     event?: ExtendableEvent,
@@ -186,7 +186,7 @@ class PrecacheController {
    * Deletes assets that are no longer present in the current precache manifest.
    * Call this method from the service worker activate event.
    *
-   * @return {Promise<workbox.precaching.CleanupResult>}
+   * @return {Promise<module:workbox-precaching.CleanupResult>}
    */
   async activate() {
     const cache = await self.caches.open(this._cacheName);
@@ -250,7 +250,7 @@ class PrecacheController {
 
     // Allow developers to override the default logic about what is and isn't
     // valid by passing in a plugin implementing cacheWillUpdate(), e.g.
-    // a workbox.cacheableResponse.CacheableResponsePlugin instance.
+    // a `CacheableResponsePlugin` instance.
     let cacheWillUpdatePlugin;
     for (const plugin of (plugins || [])) {
       if ('cacheWillUpdate' in plugin) {
@@ -359,8 +359,9 @@ class PrecacheController {
   }
 
   /**
-   * Returns a function that can be used within a {@link workbox.routing.Route}
-   * that will find a response for the incoming request against the precache.
+   * Returns a function that can be used within a
+   * {@link module:workbox-routing.Route} that will find a response for the
+   * incoming request against the precache.
    *
    * If for an unexpected reason there is a cache miss for the request,
    * this will fall back to retrieving the `Response` via `fetch()` when
@@ -368,7 +369,7 @@ class PrecacheController {
    *
    * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
    * response from the network if there's a precache miss.
-   * @return {workbox.routing~handlerCallback}
+   * @return {module:workbox-routing~handlerCallback}
    */
   createHandler(fallbackToNetwork = true): RouteHandlerCallback {
     return async ({request}: RouteHandlerCallbackOptions) => {
@@ -410,7 +411,7 @@ class PrecacheController {
    * `Response`.
    * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
    * response from the network if there's a precache miss.
-   * @return {workbox.routing~handlerCallback}
+   * @return {module:workbox-routing~handlerCallback}
    */
   createHandlerBoundToURL(url: string, fallbackToNetwork = true): RouteHandlerCallback {
     const cacheKey = this.getCacheKeyForURL(url);

--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -334,12 +334,12 @@ class PrecacheController {
   /**
    * This acts as a drop-in replacement for [`cache.match()`](https://developer.mozilla.org/en-US/docs/Web/API/Cache/match)
    * with the following differences:
-   * 
+   *
    * - It knows what the name of the precache is, and only checks in that cache.
    * - It allows you to pass in an "original" URL without versioning parameters,
    * and it will automatically look up the correct cache key for the currently
    * active revision of that URL.
-   * 
+   *
    * E.g., `matchPrecache('index.html')` will find the correct precached
    * response for the currently active service worker, even if the actual cache
    * key is `'/index.html?__WB_REVISION__=1234abcd'`.
@@ -368,7 +368,7 @@ class PrecacheController {
    *
    * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
    * response from the network if there's a precache miss.
-   * @return {workbox.routing.Route~handlerCallback}
+   * @return {workbox.routing~handlerCallback}
    */
   createHandler(fallbackToNetwork = true): RouteHandlerCallback {
     return async ({request}: RouteHandlerCallbackOptions) => {
@@ -410,7 +410,7 @@ class PrecacheController {
    * `Response`.
    * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
    * response from the network if there's a precache miss.
-   * @return {workbox.routing.Route~handlerCallback}
+   * @return {workbox.routing~handlerCallback}
    */
   createHandlerBoundToURL(url: string, fallbackToNetwork = true): RouteHandlerCallback {
     const cacheKey = this.getCacheKeyForURL(url);

--- a/packages/workbox-precaching/src/_types.ts
+++ b/packages/workbox-precaching/src/_types.ts
@@ -8,6 +8,30 @@
 
 import './_version.js';
 
+export interface InstallResult {
+  updatedURLs: string[];
+  notUpdatedURLs: string[];
+}
+
+export interface CleanupResult {
+  deletedCacheRequests: string[],
+}
+
+export interface PrecacheEntry {
+  integrity?: string;
+  url: string;
+  revision?: string;
+}
+
+export type urlManipulation = ({url}: {url: URL}) => URL[];
+
+// * * * IMPORTANT! * * *
+// ------------------------------------------------------------------------- //
+// jdsoc type definitions cannot be declared above TypeScript definitions or
+// they'll be stripped from the built `.js` files, and they'll only be in the
+// `d.ts` files, which aren't read by the jsdoc generator. As a result we
+// have to put declare them below.
+
 /**
  * @typedef {Object} InstallResult
  * @property {Array<string>} updatedURLs List of URLs that were updated during
@@ -17,10 +41,6 @@ import './_version.js';
  *
  * @memberof workbox.precaching
  */
-export interface InstallResult {
-  updatedURLs: string[];
-  notUpdatedURLs: string[];
-}
 
 /**
  * @typedef {Object} CleanupResult
@@ -29,9 +49,6 @@ export interface InstallResult {
  *
  * @memberof workbox.precaching
  */
-export interface CleanupResult {
-  deletedCacheRequests: string[],
-}
 
 /**
  * @typedef {Object} PrecacheEntry
@@ -42,11 +59,6 @@ export interface CleanupResult {
  *
  * @memberof workbox.precaching
  */
-export interface PrecacheEntry {
-  integrity?: string;
-  url: string;
-  revision?: string;
-}
 
 /**
  * The "urlManipulation" callback can be used to determine if there are any
@@ -64,4 +76,3 @@ export interface PrecacheEntry {
  *
  * @memberof workbox.precaching
  */
-export type urlManipulation = ({url}: {url: URL}) => URL[];

--- a/packages/workbox-precaching/src/_types.ts
+++ b/packages/workbox-precaching/src/_types.ts
@@ -39,7 +39,7 @@ export type urlManipulation = ({url}: {url: URL}) => URL[];
  * @property {Array<string>} notUpdatedURLs List of URLs that were already up to
  * date.
  *
- * @memberof workbox.precaching
+ * @memberof module:workbox-precaching
  */
 
 /**
@@ -47,7 +47,7 @@ export type urlManipulation = ({url}: {url: URL}) => URL[];
  * @property {Array<string>} deletedCacheRequests List of URLs that were deleted
  * while cleaning up the cache.
  *
- * @memberof workbox.precaching
+ * @memberof module:workbox-precaching
  */
 
 /**
@@ -57,7 +57,7 @@ export type urlManipulation = ({url}: {url: URL}) => URL[];
  * @property {string} [integrity] Integrity metadata that will be used when
  * making the network request for the URL.
  *
- * @memberof workbox.precaching
+ * @memberof module:workbox-precaching
  */
 
 /**
@@ -74,5 +74,5 @@ export type urlManipulation = ({url}: {url: URL}) => URL[];
  * @return {Array<URL>} To add additional urls to test, return an Array of
  * URLs. Please note that these **should not be strings**, but URL objects.
  *
- * @memberof workbox.precaching
+ * @memberof module:workbox-precaching
  */

--- a/packages/workbox-precaching/src/addPlugins.ts
+++ b/packages/workbox-precaching/src/addPlugins.ts
@@ -16,9 +16,9 @@ import './_version.js';
  *
  * @param {Array<Object>} newPlugins
  *
- * @alias workbox.precaching.addPlugins
+ * @memberof module:workbox-precaching
  */
-const addPlugins = (newPlugins: WorkboxPlugin[]) => {
+function addPlugins(newPlugins: WorkboxPlugin[]) {
   precachePlugins.add(newPlugins);
 };
 

--- a/packages/workbox-precaching/src/addRoute.ts
+++ b/packages/workbox-precaching/src/addRoute.ts
@@ -30,15 +30,17 @@ let listenerAdded = false;
  * array of regex's to remove search params when looking for a cache match.
  * @param {boolean} [options.cleanURLs=true] The `cleanURLs` option will
  * check the cache for the URL with a `.html` added to the end of the end.
- * @param {workbox.precaching~urlManipulation} [options.urlManipulation]
+ * @param {module:workbox-precaching~urlManipulation} [options.urlManipulation]
  * This is a function that should take a URL and return an array of
  * alternative URLs that should be checked for precache matches.
  *
- * @alias workbox.precaching.addRoute
+ * @memberof module:workbox-precaching
  */
-export const addRoute = (options?: FetchListenerOptions) => {
+function addRoute(options?: FetchListenerOptions) {
   if (!listenerAdded) {
     addFetchListener(options);
     listenerAdded = true;
   }
 };
+
+export {addRoute}

--- a/packages/workbox-precaching/src/cleanupOutdatedCaches.ts
+++ b/packages/workbox-precaching/src/cleanupOutdatedCaches.ts
@@ -16,9 +16,9 @@ import './_version.js';
  * Adds an `activate` event listener which will clean up incompatible
  * precaches that were created by older versions of Workbox.
  *
- * @alias workbox.precaching.cleanupOutdatedCaches
+ * @memberof module:workbox-precaching
  */
-export const cleanupOutdatedCaches = () => {
+function cleanupOutdatedCaches() {
   // See https://github.com/Microsoft/TypeScript/issues/28357#issuecomment-436484705
   self.addEventListener('activate', ((event: ExtendableEvent) => {
     const cacheName = cacheNames.getPrecacheName();
@@ -33,3 +33,5 @@ export const cleanupOutdatedCaches = () => {
     }));
   }) as EventListener);
 };
+
+export {cleanupOutdatedCaches}

--- a/packages/workbox-precaching/src/createHandler.ts
+++ b/packages/workbox-precaching/src/createHandler.ts
@@ -14,18 +14,20 @@ import './_version.js';
  * Helper function that calls
  * {@link PrecacheController#createHandler} on the default
  * {@link PrecacheController} instance.
- * 
+ *
  * If you are creating your own {@link PrecacheController}, then call the
  * {@link PrecacheController#createHandler} on that instance,
  * instead of using this function.
  *
  * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
  * response from the network if there's a precache miss.
- * @return {workbox.routing.Route~handlerCallback}
+ * @return {workbox.routing~handlerCallback}
  *
- * @alias workbox.precaching.createHandler
+ * @memberof module:workbox-precaching
  */
-export const createHandler = (fallbackToNetwork = true) => {
+function createHandler(fallbackToNetwork = true) {
   const precacheController = getOrCreatePrecacheController();
   return precacheController.createHandler(fallbackToNetwork);
 };
+
+export {createHandler}

--- a/packages/workbox-precaching/src/createHandler.ts
+++ b/packages/workbox-precaching/src/createHandler.ts
@@ -21,7 +21,7 @@ import './_version.js';
  *
  * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
  * response from the network if there's a precache miss.
- * @return {workbox.routing~handlerCallback}
+ * @return {module:workbox-routing~handlerCallback}
  *
  * @memberof module:workbox-precaching
  */

--- a/packages/workbox-precaching/src/createHandlerBoundToURL.ts
+++ b/packages/workbox-precaching/src/createHandlerBoundToURL.ts
@@ -23,7 +23,7 @@ import './_version.js';
  * `Response`.
  * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
  * response from the network if there's a precache miss.
- * @return {workbox.routing~handlerCallback}
+ * @return {module:workbox-routing~handlerCallback}
  *
  * @memberof module:workbox-precaching
  */

--- a/packages/workbox-precaching/src/createHandlerBoundToURL.ts
+++ b/packages/workbox-precaching/src/createHandlerBoundToURL.ts
@@ -14,7 +14,7 @@ import './_version.js';
  * Helper function that calls
  * {@link PrecacheController#createHandlerBoundToURL} on the default
  * {@link PrecacheController} instance.
- * 
+ *
  * If you are creating your own {@link PrecacheController}, then call the
  * {@link PrecacheController#createHandlerBoundToURL} on that instance,
  * instead of using this function.
@@ -23,11 +23,13 @@ import './_version.js';
  * `Response`.
  * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
  * response from the network if there's a precache miss.
- * @return {workbox.routing.Route~handlerCallback}
+ * @return {workbox.routing~handlerCallback}
  *
- * @alias workbox.precaching.createHandlerBoundToURL
+ * @memberof module:workbox-precaching
  */
-export const createHandlerBoundToURL = (url: string) => {
+function createHandlerBoundToURL(url: string) {
   const precacheController = getOrCreatePrecacheController();
   return precacheController.createHandlerBoundToURL(url);
 };
+
+export {createHandlerBoundToURL}

--- a/packages/workbox-precaching/src/getCacheKeyForURL.ts
+++ b/packages/workbox-precaching/src/getCacheKeyForURL.ts
@@ -27,9 +27,11 @@ import './_version.js';
  * @param {string} url The URL whose cache key to look up.
  * @return {string} The cache key that corresponds to that URL.
  *
- * @alias workbox.precaching.getCacheKeyForURL
+ * @memberof module:workbox-precaching
  */
-export const getCacheKeyForURL = (url: string) => {
+function getCacheKeyForURL(url: string) {
   const precacheController = getOrCreatePrecacheController();
   return precacheController.getCacheKeyForURL(url);
 };
+
+export {getCacheKeyForURL}

--- a/packages/workbox-precaching/src/index.ts
+++ b/packages/workbox-precaching/src/index.ts
@@ -27,12 +27,12 @@ if (process.env.NODE_ENV !== 'production') {
 
 /**
  * Most consumers of this module will want to use the
- * [precacheAndRoute()]{@link workbox.precaching.precacheAndRoute}
+ * [precacheAndRoute()]{@link module:workbox-precaching.precacheAndRoute}
  * method to add assets to the Cache and respond to network requests with these
  * cached assets.
  *
  * If you require finer grained control, you can use the
- * [PrecacheController]{@link workbox.precaching.PrecacheController}
+ * [PrecacheController]{@link module:workbox-precaching.PrecacheController}
  * to determine when performed.
  *
  * @module workbox-precaching

--- a/packages/workbox-precaching/src/index.ts
+++ b/packages/workbox-precaching/src/index.ts
@@ -35,7 +35,7 @@ if (process.env.NODE_ENV !== 'production') {
  * [PrecacheController]{@link workbox.precaching.PrecacheController}
  * to determine when performed.
  *
- * @namespace workbox.precaching
+ * @module workbox-precaching
  */
 
 export {

--- a/packages/workbox-precaching/src/matchPrecache.ts
+++ b/packages/workbox-precaching/src/matchPrecache.ts
@@ -14,7 +14,7 @@ import './_version.js';
  * Helper function that calls
  * {@link PrecacheController#matchPrecache} on the default
  * {@link PrecacheController} instance.
- * 
+ *
  * If you are creating your own {@link PrecacheController}, then call
  * {@link PrecacheController#matchPrecache} on that instance,
  * instead of using this function.
@@ -23,9 +23,11 @@ import './_version.js';
  * to look up in the precache.
  * @return {Promise<Response|undefined>}
  *
- * @alias workbox.precaching.matchPrecache
+ * @memberof module:workbox-precaching
  */
-export const matchPrecache = (request: string|Request) => {
+function matchPrecache(request: string|Request) {
   const precacheController = getOrCreatePrecacheController();
   return precacheController.matchPrecache(request);
 };
+
+export {matchPrecache}

--- a/packages/workbox-precaching/src/precache.ts
+++ b/packages/workbox-precaching/src/precache.ts
@@ -58,9 +58,9 @@ const activateListener = (event: ExtendableEvent) => {
  *
  * @param {Array<Object|string>} [entries=[]] Array of entries to precache.
  *
- * @alias workbox.precaching.precache
+ * @memberof module:workbox-precaching
  */
-export const precache = (entries: Array<PrecacheEntry|string>) => {
+function precache(entries: Array<PrecacheEntry|string>) {
   const precacheController = getOrCreatePrecacheController();
   precacheController.addToCacheList(entries);
 
@@ -73,3 +73,5 @@ export const precache = (entries: Array<PrecacheEntry|string>) => {
     self.addEventListener('activate', activateListener as EventListener);
   }
 };
+
+export {precache}

--- a/packages/workbox-precaching/src/precacheAndRoute.ts
+++ b/packages/workbox-precaching/src/precacheAndRoute.ts
@@ -30,10 +30,11 @@ declare global {
  * @param {Object} [options] See
  * [addRoute() options]{@link module:workbox-precaching.addRoute}.
  *
- * @alias workbox.precaching.precacheAndRoute
+ * @memberof module:workbox-precaching
  */
-export const precacheAndRoute =
-    (entries: Array<PrecacheEntry|string>, options?: FetchListenerOptions) => {
+function precacheAndRoute(entries: Array<PrecacheEntry|string>, options?: FetchListenerOptions) {
   precache(entries);
   addRoute(options);
 };
+
+export {precacheAndRoute}

--- a/packages/workbox-range-requests/src/RangeRequestsPlugin.ts
+++ b/packages/workbox-range-requests/src/RangeRequestsPlugin.ts
@@ -18,7 +18,7 @@ import './_version.js';
  * It does this by intercepting the `cachedResponseWillBeUsed` plugin callback
  * and returning the appropriate subset of the cached response body.
  *
- * @memberof workbox.rangeRequests
+ * @memberof module:workbox-range-requests
  */
 class RangeRequestsPlugin implements WorkboxPlugin {
   /**

--- a/packages/workbox-range-requests/src/createPartialResponse.ts
+++ b/packages/workbox-range-requests/src/createPartialResponse.ts
@@ -29,7 +29,7 @@ import './_version.js';
  * `Range:` header, or a `416 Range Not Satisfiable` response if the
  * conditions of the `Range:` header can't be met.
  *
- * @memberof workbox.rangeRequests
+ * @memberof module:workbox-range-requests
  */
 async function createPartialResponse(
     request: Request, originalResponse: Response): Promise<Response> {

--- a/packages/workbox-range-requests/src/index.ts
+++ b/packages/workbox-range-requests/src/index.ts
@@ -12,7 +12,7 @@ import './_version.js';
 
 
 /**
- * @namespace workbox.rangeRequests
+ * @module workbox-range-requests
  */
 
 export {

--- a/packages/workbox-routing/src/NavigationRoute.ts
+++ b/packages/workbox-routing/src/NavigationRoute.ts
@@ -18,8 +18,8 @@ export interface NavigationRouteMatchOptions {
 }
 
 /**
- * NavigationRoute makes it easy to create a [Route]{@link
- * workbox.routing.Route} that matches for browser
+ * NavigationRoute makes it easy to create a
+ * [Route]{@link module:workbox-routing.Route} that matches for browser
  * [navigation requests]{@link https://developers.google.com/web/fundamentals/primers/service-workers/high-performance-loading#first_what_are_navigation_requests}.
  *
  * It will only match incoming Requests whose
@@ -30,7 +30,7 @@ export interface NavigationRouteMatchOptions {
  * by using one or both of the `blacklist` and `whitelist` parameters.
  *
  * @memberof module:workbox-routing
- * @extends workbox.routing.Route
+ * @extends module:workbox-routing.Route
  */
 class NavigationRoute extends Route {
   private _whitelist: RegExp[];

--- a/packages/workbox-routing/src/NavigationRoute.ts
+++ b/packages/workbox-routing/src/NavigationRoute.ts
@@ -29,7 +29,7 @@ export interface NavigationRouteMatchOptions {
  * You can optionally only apply this route to a subset of navigation requests
  * by using one or both of the `blacklist` and `whitelist` parameters.
  *
- * @memberof workbox.routing
+ * @memberof module:workbox-routing
  * @extends workbox.routing.Route
  */
 class NavigationRoute extends Route {
@@ -46,7 +46,7 @@ class NavigationRoute extends Route {
    * and [`search`]{@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/search}
    * portions of the requested URL.
    *
-   * @param {workbox.routing.Route~handlerCallback} handler A callback
+   * @param {module:workbox-routing~handlerCallback} handler A callback
    * function that returns a Promise resulting in a Response.
    * @param {Object} options
    * @param {Array<RegExp>} [options.blacklist] If any of these patterns match,

--- a/packages/workbox-routing/src/RegExpRoute.ts
+++ b/packages/workbox-routing/src/RegExpRoute.ts
@@ -25,7 +25,7 @@ import './_version.js';
  * [See the module docs for info.]{@link https://developers.google.com/web/tools/workbox/modules/workbox-routing}
  *
  * @memberof module:workbox-routing
- * @extends workbox.routing.Route
+ * @extends module:workbox-routing.Route
  */
 class RegExpRoute extends Route {
   /**

--- a/packages/workbox-routing/src/RegExpRoute.ts
+++ b/packages/workbox-routing/src/RegExpRoute.ts
@@ -16,7 +16,7 @@ import './_version.js';
 
 /**
  * RegExpRoute makes it easy to create a regular expression based
- * [Route]{@link workbox.routing.Route}.
+ * [Route]{@link module:workbox-routing.Route}.
  *
  * For same-origin requests the RegExp only needs to match part of the URL. For
  * requests against third-party servers, you must define a RegExp that matches
@@ -24,7 +24,7 @@ import './_version.js';
  *
  * [See the module docs for info.]{@link https://developers.google.com/web/tools/workbox/modules/workbox-routing}
  *
- * @memberof workbox.routing
+ * @memberof module:workbox-routing
  * @extends workbox.routing.Route
  */
 class RegExpRoute extends Route {
@@ -32,11 +32,11 @@ class RegExpRoute extends Route {
    * If the regulard expression contains
    * [capture groups]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#grouping-back-references},
    * th ecaptured values will be passed to the
-   * [handler's]{@link workbox.routing.Route~handlerCallback} `params`
+   * [handler's]{@link module:workbox-routing~handlerCallback} `params`
    * argument.
    *
    * @param {RegExp} regExp The regular expression to match against URLs.
-   * @param {workbox.routing.Route~handlerCallback} handler A callback
+   * @param {module:workbox-routing~handlerCallback} handler A callback
    * function that returns a Promise resulting in a Response.
    * @param {string} [method='GET'] The HTTP method to match the Route
    * against.

--- a/packages/workbox-routing/src/Route.ts
+++ b/packages/workbox-routing/src/Route.ts
@@ -20,7 +20,7 @@ import './_version.js';
  * is called when there is a match and should return a Promise that resolves
  * to a `Response`.
  *
- * @memberof workbox.routing
+ * @memberof module:workbox-routing
  */
 class Route {
   handler: HandlerObject;
@@ -30,10 +30,10 @@ class Route {
   /**
    * Constructor for Route class.
    *
-   * @param {workbox.routing.Route~matchCallback} match
+   * @param {module:workbox-routing.Route~matchCallback} match
    * A callback function that determines whether the route matches a given
    * `fetch` event by returning a non-falsy value.
-   * @param {workbox.routing.Route~handlerCallback} handler A callback
+   * @param {module:workbox-routing~handlerCallback} handler A callback
    * function that returns a Promise resolving to a Response.
    * @param {string} [method='GET'] The HTTP method to match the Route
    * against.

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -57,7 +57,7 @@ class Router {
   }
 
   /**
-   * @return {Map<string, Array<workbox.routing.Route>>} routes A `Map` of HTTP
+   * @return {Map<string, Array<module:workbox-routing.Route>>} routes A `Map` of HTTP
    * method name ('GET', etc.) to an array of all the corresponding `Route`
    * instances that are registered.
    */

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -29,7 +29,7 @@ interface CacheURLsMessageData {
 
 /**
  * The Router can be used to process a FetchEvent through one or more
- * [Routes]{@link workbox.routing.Route} responding  with a Request if
+ * [Routes]{@link module:workbox-routing.Route} responding  with a Request if
  * a matching route exists.
  *
  * If no route matches a given a request, the Router will use a "default"
@@ -42,7 +42,7 @@ interface CacheURLsMessageData {
  * If a request matches multiple routes, the **earliest** registered route will
  * be used to respond to the request.
  *
- * @memberof workbox.routing
+ * @memberof module:workbox-routing
  */
 class Router {
   private _routes: Map<HTTPMethod, Route[]>;
@@ -320,7 +320,7 @@ class Router {
    * Without a default handler, unmatched requests will go against the
    * network as if there were no service worker present.
    *
-   * @param {workbox.routing.Route~handlerCallback} handler A callback
+   * @param {module:workbox-routing~handlerCallback} handler A callback
    * function that returns a Promise resulting in a Response.
    */
   setDefaultHandler(handler: Handler) {
@@ -331,7 +331,7 @@ class Router {
    * If a Route throws an error while handling a request, this `handler`
    * will be called and given a chance to provide a response.
    *
-   * @param {workbox.routing.Route~handlerCallback} handler A callback
+   * @param {module:workbox-routing~handlerCallback} handler A callback
    * function that returns a Promise resulting in a Response.
    */
   setCatchHandler(handler: Handler) {
@@ -341,7 +341,7 @@ class Router {
   /**
    * Registers a route with the router.
    *
-   * @param {workbox.routing.Route} route The route to register.
+   * @param {module:workbox-routing.Route} route The route to register.
    */
   registerRoute(route: Route) {
     if (process.env.NODE_ENV !== 'production') {
@@ -393,7 +393,7 @@ class Router {
   /**
    * Unregisters a route with the router.
    *
-   * @param {workbox.routing.Route} route The route to unregister.
+   * @param {module:workbox-routing.Route} route The route to unregister.
    */
   unregisterRoute(route: Route) {
     if (!this._routes.has(route.method)) {

--- a/packages/workbox-routing/src/_types.ts
+++ b/packages/workbox-routing/src/_types.ts
@@ -16,55 +16,6 @@ import {
 } from 'workbox-core/types.js';
 import './_version.js';
 
-/**
- * The "match" callback is used to determine if a `Route` should apply for a
- * particular URL. When matching occurs in response to a fetch event from the
- * client, the `event` and `request` objects are supplied in addition to the
- * URL. However, since the match callback can be invoked outside of a fetch
- * event, matching logic should not assume the `event` or `request` objects
- * will always be available (unlike URL, which is always available).
- * If the match callback returns a truthy value, the matching route's
- * [handler callback]{@link workbox.routing.Route~handlerCallback} will be
- * invoked immediately. If the value returned is a non-empty array or object,
- * that value will be set on the handler's `context.params` argument.
- *
- * @callback Route~matchCallback
- * @param {Object} context
- * @param {URL} context.url The request's URL.
- * @param {Request} [context.request] The corresponding request,
- *     if available.
- * @param {FetchEvent} [context.event] The corresponding event that triggered
- *     the request, if available.
- * @return {*} To signify a match, return a truthy value.
- *
- * @memberof workbox.routing
- */
-
-/**
- * The "handler" callback is invoked whenever a `Router` matches a URL to a
- * `Route` via its [match]{@link workbox.routing.Route~handlerCallback}
- * callback. This callback should return a Promise that resolves with a
- * `Response`.
- *
- * If a non-empty array or object is returned by the
- * [match callback]{@link workbox.routing.Route~matchCallback} it
- * will be passed in as the handler's `context.params` argument.
- *
- * @callback Route~handlerCallback
- * @param {Object} context
- * @param {URL} context.url The URL that matched.
- * @param {Request} [context.request] The corresponding request,
- *     if available.
- * @param {FetchEvent} [context.event] The corresponding event that triggered
- *     the request, if available.
- * @param {Object} [context.params] Array or Object parameters returned by the
- *     Route's [match callback]{@link workbox.routing.Route~matchCallback}.
- *     This will be undefined if an empty array or object were returned.
- * @return {Promise<Response>} The response that will fulfill the request.
- *
- * @memberof workbox.routing
- */
-
  export {
   RouteHandler as Handler,
   RouteHandlerObject as HandlerObject,
@@ -73,3 +24,59 @@ import './_version.js';
   RouteMatchCallback as MatchCallback,
   RouteMatchCallbackOptions as MatchCallbackOptions,
 }
+
+// * * * IMPORTANT! * * *
+// ------------------------------------------------------------------------- //
+// jdsoc type definitions cannot be declared above TypeScript definitions or
+// they'll be stripped from the built `.js` files, and they'll only be in the
+// `d.ts` files, which aren't read by the jsdoc generator. As a result we
+// have to put declare them below.
+
+/**
+ * The "match" callback is used to determine if a `Route` should apply for a
+ * particular URL. When matching occurs in response to a fetch event from the
+ * client, the `event` and `request` objects are supplied in addition to the
+ * URL. However, since the match callback can be invoked outside of a fetch
+ * event, matching logic should not assume the `event` or `request` objects
+ * will always be available (unlike URL, which is always available).
+ * If the match callback returns a truthy value, the matching route's
+ * [handler callback]{@link module:workbox-routing~handlerCallback} will be
+ * invoked immediately. If the value returned is a non-empty array or object,
+ * that value will be set on the handler's `context.params` argument.
+ *
+ * @callback ~matchCallback
+ * @param {Object} context
+ * @param {URL} context.url The request's URL.
+ * @param {Request} [context.request] The corresponding request,
+ *     if available.
+ * @param {FetchEvent} [context.event] The corresponding event that triggered
+ *     the request, if available.
+ * @return {*} To signify a match, return a truthy value.
+ *
+ * @memberof module:workbox-routing
+ */
+
+/**
+ * The "handler" callback is invoked whenever a `Router` matches a URL to a
+ * `Route` via its [match]{@link module:workbox-routing~handlerCallback}
+ * callback. This callback should return a Promise that resolves with a
+ * `Response`.
+ *
+ * If a non-empty array or object is returned by the
+ * [match callback]{@link module:workbox-routing~matchCallback} it
+ * will be passed in as the handler's `context.params` argument.
+ *
+ * @callback ~handlerCallback
+ * @param {Object} context
+ * @param {URL} context.url The URL that matched.
+ * @param {Request} [context.request] The corresponding request,
+ *     if available.
+ * @param {FetchEvent} [context.event] The corresponding event that triggered
+ *     the request, if available.
+ * @param {Object} [context.params] Array or Object parameters returned by the
+ *     Route's [match callback]{@link module:workbox-routing~matchCallback}.
+ *     This will be undefined if an empty array or object were returned.
+ * @return {Promise<Response>} The response that will fulfill the request.
+ *
+ * @memberof module:workbox-routing
+ */

--- a/packages/workbox-routing/src/index.ts
+++ b/packages/workbox-routing/src/index.ts
@@ -6,8 +6,6 @@
   https://opensource.org/licenses/MIT.
 */
 
-import {assert} from 'workbox-core/_private/assert.js';
-
 import {NavigationRoute} from './NavigationRoute.js';
 import {RegExpRoute} from './RegExpRoute.js';
 import {registerRoute} from './registerRoute.js';
@@ -18,12 +16,9 @@ import {setDefaultHandler} from './setDefaultHandler.js';
 
 import './_version.js';
 
-if (process.env.NODE_ENV !== 'production') {
-  assert!.isSWEnv('workbox-routing');
-}
 
 /**
- * @namespace workbox.routing
+ * @module workbox-routing
  */
 
 export {

--- a/packages/workbox-routing/src/registerRoute.ts
+++ b/packages/workbox-routing/src/registerRoute.ts
@@ -21,30 +21,24 @@ import './_version.js';
  * strategy to a singleton Router instance.
  *
  * This method will generate a Route for you if needed and
- * call [Router.registerRoute()]{@link
- * workbox.routing.Router#registerRoute}.
+ * call [registerRoute()]{@link module:workbox-routing.Router#registerRoute}.
  *
- * @param {
- * RegExp|
- * string|
- * workbox.routing.Route~matchCallback|
- * workbox.routing.Route
- * } capture
+ * @param {RegExp|string|module:workbox-routing.Route~matchCallback|module:workbox-routing.Route} capture
  * If the capture param is a `Route`, all other arguments will be ignored.
- * @param {workbox.routing.Route~handlerCallback} [handler] A callback
+ * @param {module:workbox-routing~handlerCallback} [handler] A callback
  * function that returns a Promise resulting in a Response. This parameter
  * is required if `capture` is not a `Route` object.
  * @param {string} [method='GET'] The HTTP method to match the Route
  * against.
- * @return {workbox.routing.Route} The generated `Route`(Useful for
+ * @return {module:workbox-routing.Route} The generated `Route`(Useful for
  * unregistering).
  *
- * @alias workbox.routing.registerRoute
+ * @memberof module:workbox-routing
  */
-export const registerRoute = (
+function registerRoute(
     capture: RegExp | string | MatchCallback | Route,
     handler?: Handler,
-    method?: HTTPMethod): Route => {
+    method?: HTTPMethod): Route {
   let route;
 
   if (typeof capture === 'string') {
@@ -112,3 +106,5 @@ export const registerRoute = (
 
   return route;
 };
+
+export {registerRoute}

--- a/packages/workbox-routing/src/setCatchHandler.ts
+++ b/packages/workbox-routing/src/setCatchHandler.ts
@@ -10,17 +10,18 @@ import {getOrCreateDefaultRouter} from './utils/getOrCreateDefaultRouter.js';
 import {Handler} from './_types.js';
 import './_version.js';
 
-
 /**
  * If a Route throws an error while handling a request, this `handler`
  * will be called and given a chance to provide a response.
  *
- * @param {workbox.routing.Route~handlerCallback} handler A callback
+ * @param {module:workbox-routing~handlerCallback} handler A callback
  * function that returns a Promise resulting in a Response.
  *
- * @alias workbox.routing.setCatchHandler
+ * @memberof module:workbox-routing
  */
-export const setCatchHandler = (handler: Handler) => {
+function setCatchHandler(handler: Handler) {
   const defaultRouter = getOrCreateDefaultRouter();
   defaultRouter.setCatchHandler(handler);
 };
+
+export {setCatchHandler}

--- a/packages/workbox-routing/src/setDefaultHandler.ts
+++ b/packages/workbox-routing/src/setDefaultHandler.ts
@@ -18,12 +18,14 @@ import './_version.js';
  * Without a default handler, unmatched requests will go against the
  * network as if there were no service worker present.
  *
- * @param {workbox.routing.Route~handlerCallback} handler A callback
+ * @param {module:workbox-routing~handlerCallback} handler A callback
  * function that returns a Promise resulting in a Response.
  *
- * @alias workbox.routing.setDefaultHandler
+ * @memberof module:workbox-routing
  */
-export const setDefaultHandler = (handler: Handler) => {
+function setDefaultHandler(handler: Handler) {
   const defaultRouter = getOrCreateDefaultRouter();
   defaultRouter.setDefaultHandler(handler);
 };
+
+export {setDefaultHandler}

--- a/packages/workbox-strategies/src/CacheFirst.ts
+++ b/packages/workbox-strategies/src/CacheFirst.ts
@@ -36,7 +36,7 @@ interface CacheFirstOptions {
  * If the network request fails, and there is no cache match, this will throw
  * a `WorkboxError` exception.
  *
- * @memberof workbox.strategies
+ * @memberof module:workbox-strategies
  */
 class CacheFirst implements RouteHandlerObject {
   private _cacheName: string;
@@ -66,7 +66,7 @@ class CacheFirst implements RouteHandlerObject {
   /**
    * This method will perform a request strategy and follows an API that
    * will work with the
-   * [Workbox Router]{@link workbox.routing.Router}.
+   * [Workbox Router]{@link module:workbox-routing.Router}.
    *
    * @param {Object} options
    * @param {Request} options.request The request to run this strategy for.

--- a/packages/workbox-strategies/src/CacheFirst.ts
+++ b/packages/workbox-strategies/src/CacheFirst.ts
@@ -48,7 +48,7 @@ class CacheFirst implements RouteHandlerObject {
    * @param {Object} options
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
-   * [workbox-core]{@link workbox.core.cacheNames}.
+   * [workbox-core]{@link module:workbox-core.cacheNames}.
    * @param {Array<Object>} options.plugins [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
    * to use in conjunction with this caching strategy.
    * @param {Object} options.fetchOptions Values passed along to the

--- a/packages/workbox-strategies/src/CacheOnly.ts
+++ b/packages/workbox-strategies/src/CacheOnly.ts
@@ -32,7 +32,7 @@ interface CacheOnlyOptions {
  *
  * If there is no cache match, this will throw a `WorkboxError` exception.
  *
- * @memberof workbox.strategies
+ * @memberof module:workbox-strategies
  */
 class CacheOnly implements RouteHandlerObject {
   private _cacheName: string;
@@ -57,7 +57,7 @@ class CacheOnly implements RouteHandlerObject {
   /**
    * This method will perform a request strategy and follows an API that
    * will work with the
-   * [Workbox Router]{@link workbox.routing.Router}.
+   * [Workbox Router]{@link module:workbox-routing.Router}.
    *
    * @param {Object} options
    * @param {Request} options.request The request to run this strategy for.

--- a/packages/workbox-strategies/src/CacheOnly.ts
+++ b/packages/workbox-strategies/src/CacheOnly.ts
@@ -43,7 +43,7 @@ class CacheOnly implements RouteHandlerObject {
    * @param {Object} options
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
-   * [workbox-core]{@link workbox.core.cacheNames}.
+   * [workbox-core]{@link module:workbox-core.cacheNames}.
    * @param {Array<Object>} options.plugins [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
    * to use in conjunction with this caching strategy.
    * @param {Object} options.matchOptions [`CacheQueryOptions`](https://w3c.github.io/ServiceWorker/#dictdef-cachequeryoptions)

--- a/packages/workbox-strategies/src/NetworkFirst.ts
+++ b/packages/workbox-strategies/src/NetworkFirst.ts
@@ -40,7 +40,7 @@ interface NetworkFirstOptions {
  * If the network request fails, and there is no cache match, this will throw
  * a `WorkboxError` exception.
  *
- * @memberof workbox.strategies
+ * @memberof module:workbox-strategies
  */
 class NetworkFirst implements RouteHandlerObject {
   private _cacheName: string;
@@ -99,7 +99,7 @@ class NetworkFirst implements RouteHandlerObject {
   /**
    * This method will perform a request strategy and follows an API that
    * will work with the
-   * [Workbox Router]{@link workbox.routing.Router}.
+   * [Workbox Router]{@link module:workbox-routing.Router}.
    *
    * @param {Object} options
    * @param {Request} options.request The request to run this strategy for.

--- a/packages/workbox-strategies/src/NetworkFirst.ts
+++ b/packages/workbox-strategies/src/NetworkFirst.ts
@@ -53,7 +53,7 @@ class NetworkFirst implements RouteHandlerObject {
    * @param {Object} options
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
-   * [workbox-core]{@link workbox.core.cacheNames}.
+   * [workbox-core]{@link module:workbox-core.cacheNames}.
    * @param {Array<Object>} options.plugins [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
    * to use in conjunction with this caching strategy.
    * @param {Object} options.fetchOptions Values passed along to the

--- a/packages/workbox-strategies/src/NetworkOnly.ts
+++ b/packages/workbox-strategies/src/NetworkOnly.ts
@@ -40,7 +40,7 @@ class NetworkOnly implements RouteHandlerObject {
    * @param {Object} options
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
-   * [workbox-core]{@link workbox.core.cacheNames}.
+   * [workbox-core]{@link module:workbox-core.cacheNames}.
    * @param {Array<Object>} options.plugins [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
    * to use in conjunction with this caching strategy.
    * @param {Object} options.fetchOptions Values passed along to the

--- a/packages/workbox-strategies/src/NetworkOnly.ts
+++ b/packages/workbox-strategies/src/NetworkOnly.ts
@@ -30,7 +30,7 @@ interface NetworkFirstOptions {
  *
  * If the network request fails, this will throw a `WorkboxError` exception.
  *
- * @memberof workbox.strategies
+ * @memberof module:workbox-strategies
  */
 class NetworkOnly implements RouteHandlerObject {
   private _plugins: WorkboxPlugin[];
@@ -55,7 +55,7 @@ class NetworkOnly implements RouteHandlerObject {
   /**
    * This method will perform a request strategy and follows an API that
    * will work with the
-   * [Workbox Router]{@link workbox.routing.Router}.
+   * [Workbox Router]{@link module:workbox-routing.Router}.
    *
    * @param {Object} options
    * @param {Request} options.request The request to run this strategy for.

--- a/packages/workbox-strategies/src/StaleWhileRevalidate.ts
+++ b/packages/workbox-strategies/src/StaleWhileRevalidate.ts
@@ -56,7 +56,7 @@ class StaleWhileRevalidate implements RouteHandlerObject {
    * @param {Object} options
    * @param {string} options.cacheName Cache name to store and retrieve
    * requests. Defaults to cache names provided by
-   * [workbox-core]{@link workbox.core.cacheNames}.
+   * [workbox-core]{@link module:workbox-core.cacheNames}.
    * @param {Array<Object>} options.plugins [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
    * to use in conjunction with this caching strategy.
    * @param {Object} options.fetchOptions Values passed along to the

--- a/packages/workbox-strategies/src/StaleWhileRevalidate.ts
+++ b/packages/workbox-strategies/src/StaleWhileRevalidate.ts
@@ -44,7 +44,7 @@ interface StaleWhileRevalidateOptions {
  * If the network request fails, and there is no cache match, this will throw
  * a `WorkboxError` exception.
  *
- * @memberof workbox.strategies
+ * @memberof module:workbox-strategies
  */
 class StaleWhileRevalidate implements RouteHandlerObject {
   private _cacheName: string;
@@ -85,7 +85,7 @@ class StaleWhileRevalidate implements RouteHandlerObject {
   /**
    * This method will perform a request strategy and follows an API that
    * will work with the
-   * [Workbox Router]{@link workbox.routing.Router}.
+   * [Workbox Router]{@link module:workbox-routing.Router}.
    *
    * @param {Object} options
    * @param {Request} options.request The request to run this strategy for.

--- a/packages/workbox-strategies/src/index.ts
+++ b/packages/workbox-strategies/src/index.ts
@@ -6,8 +6,6 @@
   https://opensource.org/licenses/MIT.
 */
 
-import {logger} from 'workbox-core/_private/logger.js';
-import {RouteHandler} from 'workbox-core/types.js';
 import {CacheFirst} from './CacheFirst.js';
 import {CacheOnly} from './CacheOnly.js';
 import {NetworkFirst} from './NetworkFirst.js';
@@ -16,81 +14,11 @@ import {StaleWhileRevalidate} from './StaleWhileRevalidate.js';
 import './_version.js';
 
 
-interface StrategyClass {
-  new({}: object): RouteHandler
-}
-
-interface StrategyDeprecationMap {
-  [strategyName: string]: StrategyClass;
-}
-
-const mapping: StrategyDeprecationMap = {
-  cacheFirst: CacheFirst,
-  cacheOnly: CacheOnly,
-  networkFirst: NetworkFirst,
-  networkOnly: NetworkOnly,
-  staleWhileRevalidate: StaleWhileRevalidate,
-};
-
-const deprecate = (strategy: string) => {
-  const StrategyCtr = mapping[strategy];
-
-  return (options: object) => {
-    if (process.env.NODE_ENV !== 'production') {
-      const strategyCtrName = strategy[0].toUpperCase() + strategy.slice(1);
-      logger.warn(`The 'workbox.strategies.${strategy}()' function has been ` +
-          `deprecated and will be removed in a future version of Workbox.\n` +
-          `Please use 'new workbox.strategies.${strategyCtrName}()' instead.`);
-    }
-    return new StrategyCtr(options);
-  };
-};
-
-/**
- * @function workbox.strategies.cacheFirst
- * @param {Object} options See the {@link workbox.strategies.CacheFirst}
- * constructor for more info.
- * @deprecated since v4.0.0
- */
-const cacheFirst = deprecate('cacheFirst');
-
-/**
- * @function workbox.strategies.cacheOnly
- * @param {Object} options See the {@link workbox.strategies.CacheOnly}
- * constructor for more info.
- * @deprecated since v4.0.0
- */
-const cacheOnly = deprecate('cacheOnly');
-
-/**
- * @function workbox.strategies.networkFirst
- * @param {Object} options See the {@link workbox.strategies.NetworkFirst}
- * constructor for more info.
- * @deprecated since v4.0.0
- */
-const networkFirst = deprecate('networkFirst');
-
-/**
- * @function workbox.strategies.networkOnly
- * @param {Object} options See the {@link workbox.strategies.NetworkOnly}
- * constructor for more info.
- * @deprecated since v4.0.0
- */
-const networkOnly = deprecate('networkOnly');
-
-/**
- * @function workbox.strategies.staleWhileRevalidate
- * @param {Object} options See the
- * {@link workbox.strategies.StaleWhileRevalidate} constructor for more info.
- * @deprecated since v4.0.0
- */
-const staleWhileRevalidate = deprecate('staleWhileRevalidate');
-
 /**
  * There are common caching strategies that most service workers will need
  * and use. This module provides simple implementations of these strategies.
  *
- * @namespace workbox.strategies
+ * @module workbox-strategies
  */
 
 export {
@@ -99,12 +27,5 @@ export {
   NetworkFirst,
   NetworkOnly,
   StaleWhileRevalidate,
-
-  // Deprecated...
-  cacheFirst,
-  cacheOnly,
-  networkFirst,
-  networkOnly,
-  staleWhileRevalidate,
 };
 

--- a/packages/workbox-streams/src/_types.ts
+++ b/packages/workbox-streams/src/_types.ts
@@ -8,9 +8,17 @@
 
 import './_version.js';
 
-/**
- * @typedef {Response|ReadableStream|BodyInit} StreamSource
- * @memberof workbox.streams
- */
 
 export type StreamSource = Response | ReadableStream | BodyInit;
+
+// * * * IMPORTANT! * * *
+// ------------------------------------------------------------------------- //
+// jdsoc type definitions cannot be declared above TypeScript definitions or
+// they'll be stripped from the built `.js` files, and they'll only be in the
+// `d.ts` files, which aren't read by the jsdoc generator. As a result we
+// have to put declare them below.
+
+/**
+ * @typedef {Response|ReadableStream|BodyInit} StreamSource
+ * @memberof module:workbox-streams
+ */

--- a/packages/workbox-streams/src/concatenate.ts
+++ b/packages/workbox-streams/src/concatenate.ts
@@ -42,7 +42,7 @@ function _getReaderFromSource(source: StreamSource): ReadableStreamReader {
  * @param {Array<Promise<workbox.streams.StreamSource>>} sourcePromises
  * @return {Object<{done: Promise, stream: ReadableStream}>}
  *
- * @memberof workbox.streams
+ * @memberof module:workbox-streams
  */
 function concatenate(sourcePromises: Promise<StreamSource>[]): {
   done: Promise<void>,

--- a/packages/workbox-streams/src/concatenate.ts
+++ b/packages/workbox-streams/src/concatenate.ts
@@ -17,7 +17,7 @@ import './_version.js';
  * [BodyInit](https://fetch.spec.whatwg.org/#bodyinit) and returns the
  * ReadableStreamReader object associated with it.
  *
- * @param {workbox.streams.StreamSource} source
+ * @param {module:workbox-streams.StreamSource} source
  * @return {ReadableStreamReader}
  * @private
  */
@@ -39,7 +39,7 @@ function _getReaderFromSource(source: StreamSource): ReadableStreamReader {
  * data returned in sequence, along with a Promise which signals when the
  * stream is finished (useful for passing to a FetchEvent's waitUntil()).
  *
- * @param {Array<Promise<workbox.streams.StreamSource>>} sourcePromises
+ * @param {Array<Promise<module:workbox-streams.StreamSource>>} sourcePromises
  * @return {Object<{done: Promise, stream: ReadableStream}>}
  *
  * @memberof module:workbox-streams

--- a/packages/workbox-streams/src/concatenateToResponse.ts
+++ b/packages/workbox-streams/src/concatenateToResponse.ts
@@ -27,7 +27,7 @@ import './_version.js';
  * `'text/html'` will be used by default.
  * @return {Object<{done: Promise, response: Response}>}
  *
- * @memberof workbox.streams
+ * @memberof module:workbox-streams
  */
 function concatenateToResponse(
     sourcePromises: Promise<StreamSource>[],

--- a/packages/workbox-streams/src/concatenateToResponse.ts
+++ b/packages/workbox-streams/src/concatenateToResponse.ts
@@ -22,7 +22,7 @@ import './_version.js';
  * stream's data returned in sequence, along with a Promise which signals when
  * the stream is finished (useful for passing to a FetchEvent's waitUntil()).
  *
- * @param {Array<Promise<workbox.streams.StreamSource>>} sourcePromises
+ * @param {Array<Promise<module:workbox-streams.StreamSource>>} sourcePromises
  * @param {HeadersInit} [headersInit] If there's no `Content-Type` specified,
  * `'text/html'` will be used by default.
  * @return {Object<{done: Promise, response: Response}>}

--- a/packages/workbox-streams/src/index.ts
+++ b/packages/workbox-streams/src/index.ts
@@ -14,7 +14,7 @@ import './_version.js';
 
 
 /**
- * @namespace workbox.streams
+ * @module workbox-streams
  */
 
 export {

--- a/packages/workbox-streams/src/isSupported.ts
+++ b/packages/workbox-streams/src/isSupported.ts
@@ -19,7 +19,7 @@ import './_version.js';
  * @return {boolean} `true`, if the current browser meets the requirements for
  * streaming responses, and `false` otherwise.
  *
- * @memberof workbox.streams
+ * @memberof module:workbox-streams
  */
 function isSupported() {
   return canConstructReadableStream();

--- a/packages/workbox-streams/src/strategy.ts
+++ b/packages/workbox-streams/src/strategy.ts
@@ -27,14 +27,14 @@ interface StreamsHandlerCallback {
  * and create a final response that concatenates their values together.
  *
  * @param {Array<function({event, request, url, params})>} sourceFunctions
- * An array of functions similar to {@link workbox.routing.Route~handlerCallback}
+ * An array of functions similar to {@link workbox.routing~handlerCallback}
  * but that instead return a {@link workbox.streams.StreamSource} (or a
  * Promise which resolves to one).
  * @param {HeadersInit} [headersInit] If there's no `Content-Type` specified,
  * `'text/html'` will be used by default.
- * @return {workbox.routing.Route~handlerCallback}
+ * @return {workbox.routing~handlerCallback}
  *
- * @memberof workbox.streams
+ * @memberof module:workbox-streams
  */
 function strategy(
   sourceFunctions: StreamsHandlerCallback[],

--- a/packages/workbox-streams/src/strategy.ts
+++ b/packages/workbox-streams/src/strategy.ts
@@ -27,13 +27,12 @@ interface StreamsHandlerCallback {
  * and create a final response that concatenates their values together.
  *
  * @param {Array<function({event, request, url, params})>} sourceFunctions
- * An array of functions similar to {@link workbox.routing~handlerCallback}
- * but that instead return a {@link workbox.streams.StreamSource} (or a
+ * An array of functions similar to {@link module:workbox-routing~handlerCallback}
+ * but that instead return a {@link module:workbox-streams.StreamSource} (or a
  * Promise which resolves to one).
  * @param {HeadersInit} [headersInit] If there's no `Content-Type` specified,
  * `'text/html'` will be used by default.
- * @return {workbox.routing~handlerCallback}
- *
+ * @return {module:workbox-routing~handlerCallback}
  * @memberof module:workbox-streams
  */
 function strategy(

--- a/packages/workbox-streams/src/utils/createHeaders.ts
+++ b/packages/workbox-streams/src/utils/createHeaders.ts
@@ -14,6 +14,7 @@ import '../_version.js';
  * [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/ReadableStream)
  * is available.
  *
+ * @private
  * @param {HeadersInit} [headersInit] If there's no `Content-Type` specified,
  * `'text/html'` will be used by default.
  * @return {boolean} `true`, if the current browser meets the requirements for

--- a/packages/workbox-streams/src/utils/createHeaders.ts
+++ b/packages/workbox-streams/src/utils/createHeaders.ts
@@ -19,7 +19,7 @@ import '../_version.js';
  * @return {boolean} `true`, if the current browser meets the requirements for
  * streaming responses, and `false` otherwise.
  *
- * @memberof workbox.streams
+ * @memberof module:workbox-streams
  */
 function createHeaders(headersInit = {}) {
   // See https://github.com/GoogleChrome/workbox/issues/1461

--- a/packages/workbox-sw/controllers/WorkboxSW.mjs
+++ b/packages/workbox-sw/controllers/WorkboxSW.mjs
@@ -11,21 +11,77 @@ import '../_version.mjs';
 const CDN_PATH = `WORKBOX_CDN_ROOT_URL`;
 
 const MODULE_KEY_TO_NAME_MAPPING = {
-  // TODO(philipwalton): add jsdoc tags to associate these with their module.
-  // @name backgroundSync
-  // @memberof workbox
-  // @see module:workbox-background-sync
+  /**
+   * @name backgroundSync
+   * @memberof workbox
+   * @see module:workbox-background-sync
+   */
   backgroundSync: 'background-sync',
+  /**
+   * @name broadcastUpdate
+   * @memberof workbox
+   * @see module:workbox-broadcast-update
+   */
   broadcastUpdate: 'broadcast-update',
+  /**
+   * @name cacheableResponse
+   * @memberof workbox
+   * @see module:workbox-cacheable-response
+   */
   cacheableResponse: 'cacheable-response',
+  /**
+   * @name core
+   * @memberof workbox
+   * @see module:workbox-core
+   */
   core: 'core',
+  /**
+   * @name expiration
+   * @memberof workbox
+   * @see module:workbox-expiration
+   */
   expiration: 'expiration',
+  /**
+   * @name googleAnalytics
+   * @memberof workbox
+   * @see module:workbox-google-analytics
+   */
   googleAnalytics: 'offline-ga',
+  /**
+   * @name navigationPreload
+   * @memberof workbox
+   * @see module:workbox-navigation-preload
+   */
   navigationPreload: 'navigation-preload',
+  /**
+   * @name precaching
+   * @memberof workbox
+   * @see module:workbox-precaching
+   */
   precaching: 'precaching',
+  /**
+   * @name rangeRequests
+   * @memberof workbox
+   * @see module:workbox-range-requests
+   */
   rangeRequests: 'range-requests',
+  /**
+   * @name routing
+   * @memberof workbox
+   * @see module:workbox-routing
+   */
   routing: 'routing',
+  /**
+   * @name strategies
+   * @memberof workbox
+   * @see module:workbox-strategies
+   */
   strategies: 'strategies',
+  /**
+   * @name streams
+   * @memberof workbox
+   * @see module:workbox-streams
+   */
   streams: 'streams',
 };
 

--- a/packages/workbox-webpack-plugin/src/generate-sw.js
+++ b/packages/workbox-webpack-plugin/src/generate-sw.js
@@ -31,7 +31,7 @@ const _generatedAssetNames = new Set();
  * [`plugins` array](https://webpack.js.org/concepts/plugins/#usage) of a
  * webpack config.
  *
- * @module workbox-webpack-plugin
+ * @memberof module:workbox-webpack-plugin
  */
 class GenerateSW {
   /**

--- a/packages/workbox-webpack-plugin/src/index.js
+++ b/packages/workbox-webpack-plugin/src/index.js
@@ -9,6 +9,10 @@
 const GenerateSW = require('./generate-sw');
 const InjectManifest = require('./inject-manifest');
 
+/**
+ * @module workbox-webpack-plugin
+ */
+
 module.exports = {
   GenerateSW,
   InjectManifest,

--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -34,7 +34,7 @@ const _generatedAssetNames = new Set();
  * [`plugins` array](https://webpack.js.org/concepts/plugins/#usage) of a
  * webpack config.
  *
- * @module workbox-webpack-plugin
+ * @memberof module:workbox-webpack-plugin
  */
 class InjectManifest {
   /**

--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -17,6 +17,7 @@ import {WorkboxEvent, WorkboxLifecycleEventMap} from './utils/WorkboxEvent.js';
 
 import './_version.js';
 
+
 // The time a SW must be in the waiting phase before we can conclude
 // `skipWaiting()` wasn't called. This 200 amount wasn't scientifically
 // chosen, but it seems to avoid false positives in my testing.
@@ -39,7 +40,6 @@ const REGISTRATION_TIMEOUT_DURATION = 60000;
  * @fires [externalinstalled]{@link module:workbox-window.Workbox#externalinstalled}
  * @fires [externalwaiting]{@link module:workbox-window.Workbox#externalwaiting}
  * @fires [externalactivated]{@link module:workbox-window.Workbox#externalactivated}
- *
  * @memberof module:workbox-window
  */
 class Workbox extends WorkboxEventTarget {
@@ -524,6 +524,8 @@ class Workbox extends WorkboxEventTarget {
   }
 }
 
+export {Workbox};
+
 // The jsdoc comments below outline the events this instance may dispatch:
 // -----------------------------------------------------------------------
 
@@ -681,5 +683,3 @@ class Workbox extends WorkboxEventTarget {
  * @property {string} type `externalactivated`.
  * @property {Workbox} target The `Workbox` instance.
  */
-
-export {Workbox};

--- a/packages/workbox-window/src/messageSW.ts
+++ b/packages/workbox-window/src/messageSW.ts
@@ -21,10 +21,9 @@ import './_version.js';
  * @param {ServiceWorker} sw The service worker to send the message to.
  * @param {Object} data An object to send to the service worker.
  * @return {Promise<Object|undefined>}
- *
  * @memberof module:workbox-window
  */
-export function messageSW(sw: ServiceWorker, data: {}): Promise<any> {
+function messageSW(sw: ServiceWorker, data: {}): Promise<any> {
   return new Promise((resolve) => {
     let messageChannel = new MessageChannel();
     messageChannel.port1.onmessage = (event: MessageEvent) => {
@@ -33,3 +32,5 @@ export function messageSW(sw: ServiceWorker, data: {}): Promise<any> {
     sw.postMessage(data, [messageChannel.port2]);
   });
 };
+
+export {messageSW}

--- a/test/all/node/test-exports.mjs
+++ b/test/all/node/test-exports.mjs
@@ -14,16 +14,6 @@ const glob = require('glob');
 const {getPackages} = require('../../../gulp-tasks/utils/get-packages');
 
 
-const deprecatedPackageExports = {
-  'workbox-strategies': [
-    'cacheFirst',
-    'cacheOnly',
-    'networkFirst',
-    'networkOnly',
-    'staleWhileRevalidate',
-  ],
-};
-
 describe(`[all] Window and SW packages`, function() {
   // Reading files can be slow.
   this.timeout(5 * 1000);
@@ -68,11 +58,8 @@ describe(`[all] Window and SW packages`, function() {
         cwd: packagePath,
       }).map((file) => path.basename(file, `.${ext}`));
 
-      const deprecatedExports = deprecatedPackageExports[pkg.name] || [];
-
       // Assert there's a 1-to-1 mapping between exports and top-level files.
-      expect(namedExports.sort())
-          .to.deep.equal(topLevelFiles.concat(deprecatedExports).sort());
+      expect(namedExports.sort()).to.deep.equal(topLevelFiles.sort());
     }
   });
 
@@ -118,11 +105,8 @@ describe(`[all] Window and SW packages`, function() {
       const topLevelFiles = glob.sync(`*.${ext}`, {cwd: privateDirectoryPath})
           .map((file) => path.basename(file, `.${ext}`));
 
-      const deprecatedExports = deprecatedPackageExports[pkg.name] || [];
-
       // Assert there's a 1-to-1 mapping between exports and top-level files.
-      expect(namedExports.sort())
-          .to.deep.equal(topLevelFiles.concat(deprecatedExports).sort());
+      expect(namedExports.sort()).to.deep.equal(topLevelFiles.sort());
     }
   });
 });

--- a/test/workbox-cacheable-response/static/cacheable-response-plugin/sw.js
+++ b/test/workbox-cacheable-response/static/cacheable-response-plugin/sw.js
@@ -14,7 +14,7 @@ importScripts('/infra/testing/comlink/sw-interface.js');
 
 workbox.routing.registerRoute(
     /.*.txt/,
-    workbox.strategies.cacheFirst({
+    new workbox.strategies.CacheFirst({
       cacheName: 'cacheable-response-cache',
       plugins: [
         new workbox.cacheableResponse.CacheableResponsePlugin({

--- a/test/workbox-range-requests/static/sw.js
+++ b/test/workbox-range-requests/static/sw.js
@@ -14,7 +14,7 @@ importScripts('/__WORKBOX/buildFile/workbox-strategies');
 const cacheName = 'range-requests-integration-test';
 workbox.routing.registerRoute(
     new RegExp('this-file-doesnt-exist\\.txt$'),
-    workbox.strategies.cacheOnly({
+    new workbox.strategies.CacheOnly({
       cacheName,
       plugins: [
         new workbox.rangeRequests.RangeRequestsPlugin(),

--- a/test/workbox-strategies/static/cache-first/sw.js
+++ b/test/workbox-strategies/static/cache-first/sw.js
@@ -11,7 +11,7 @@ importScripts('/infra/testing/comlink/sw-interface.js');
 
 workbox.routing.registerRoute(
     new RegExp('/test/workbox-strategies/static/cache-first/example.txt'),
-    workbox.strategies.cacheFirst()
+    new workbox.strategies.CacheFirst()
 );
 
 self.addEventListener('install', (event) => event.waitUntil(self.skipWaiting()));

--- a/test/workbox-strategies/static/cache-only/sw.js
+++ b/test/workbox-strategies/static/cache-only/sw.js
@@ -11,7 +11,7 @@ importScripts('/infra/testing/comlink/sw-interface.js');
 
 workbox.routing.registerRoute(
     new RegExp('/CacheOnly/.*/'),
-    workbox.strategies.cacheOnly()
+    new workbox.strategies.CacheOnly()
 );
 
 self.addEventListener('install', (event) => event.waitUntil(

--- a/test/workbox-strategies/static/network-first/sw.js
+++ b/test/workbox-strategies/static/network-first/sw.js
@@ -11,7 +11,7 @@ importScripts('/infra/testing/comlink/sw-interface.js');
 
 workbox.routing.registerRoute(
     new RegExp('/__WORKBOX/uniqueValue'),
-    workbox.strategies.networkFirst({
+    new workbox.strategies.NetworkFirst({
       cacheName: 'network-first',
     })
 );

--- a/test/workbox-strategies/static/network-only/sw.js
+++ b/test/workbox-strategies/static/network-only/sw.js
@@ -11,7 +11,7 @@ importScripts('/infra/testing/comlink/sw-interface.js');
 
 workbox.routing.registerRoute(
     new RegExp('/__WORKBOX/uniqueValue'),
-    workbox.strategies.networkOnly({
+    new workbox.strategies.NetworkOnly({
       cacheName: 'network-only',
     }),
 );

--- a/test/workbox-strategies/static/stale-while-revalidate/sw.js
+++ b/test/workbox-strategies/static/stale-while-revalidate/sw.js
@@ -11,7 +11,7 @@ importScripts('/infra/testing/comlink/sw-interface.js');
 
 workbox.routing.registerRoute(
     new RegExp('/__WORKBOX/uniqueValue'),
-    workbox.strategies.staleWhileRevalidate({
+    new workbox.strategies.StaleWhileRevalidate({
       cacheName: 'stale-while-revalidate',
     })
 );


### PR DESCRIPTION
R: @jeffposnick

I started exploring what it would take to update all our jsdoc comments to reference package names instead of the global namespace, and with a bit of find-and-replace it ended up not being so bad.

And it was good I did because along the way I realized that all our jsdoc comments in the `_types.ts` files were being dropped (since they were ending up in `.d.ts` files instead of `.js` files), so had we just published as is, a lot of links would have broken.

I also removed the deprecation warnings for the strategy functions (since we said we'd remove those in v5).

To see what the docs look like, you can run: `gulp docs --pretty`. I'm still trying to work out if it's possible to customize how the modules are displayed (e.g. I don't like the `module:` prefix in links and params references, nor do I like the `module-` prefix in the filenames, so hopefully we can get rid of them, but I don't think it's a huge deal if we can't.

