### PR TITLE
String support in handle()

### DIFF
--- a/packages/workbox-core/src/types.ts
+++ b/packages/workbox-core/src/types.ts
@@ -37,7 +37,7 @@ export interface RouteMatchCallback {
  * Options passed to a `RouteHandlerCallback` function.
  */
 export interface RouteHandlerCallbackOptions {
-  request: Request;
+  request: Request | string;
   url?: URL;
   event?: ExtendableEvent;
   params?: string[] | {[paramName: string]: string};

--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -382,7 +382,7 @@ class PrecacheController {
         // https://github.com/GoogleChrome/workbox/issues/1441
         throw new WorkboxError('missing-precache-entry', {
           cacheName: this._cacheName,
-          url: request.url,
+          url: request instanceof Request ? request.url : request,
         });
       } catch (error) {
         if (fallbackToNetwork) {

--- a/packages/workbox-strategies/src/CacheFirst.ts
+++ b/packages/workbox-strategies/src/CacheFirst.ts
@@ -69,12 +69,16 @@ class CacheFirst implements RouteHandlerObject {
    * [Workbox Router]{@link workbox.routing.Router}.
    *
    * @param {Object} options
-   * @param {Request} options.request The request to run this strategy for.
+   * @param {Request|string} options.request A request to run this strategy for.
    * @param {Event} [options.event] The event that triggered the request.
    * @return {Promise<Response>}
    */
   async handle({event, request}: RouteHandlerCallbackOptions): Promise<Response> {
     const logs = [];
+
+    if (typeof request === 'string') {
+      request = new Request(request);
+    }
 
     if (process.env.NODE_ENV !== 'production') {
       assert!.isInstance(request, Request, {

--- a/packages/workbox-strategies/src/CacheOnly.ts
+++ b/packages/workbox-strategies/src/CacheOnly.ts
@@ -60,11 +60,15 @@ class CacheOnly implements RouteHandlerObject {
    * [Workbox Router]{@link workbox.routing.Router}.
    *
    * @param {Object} options
-   * @param {Request} options.request The request to run this strategy for.
+   * @param {Request|string} options.request A request to run this strategy for.
    * @param {Event} [options.event] The event that triggered the request.
    * @return {Promise<Response>}
    */
   async handle({event, request}: RouteHandlerCallbackOptions): Promise<Response> {
+    if (typeof request === 'string') {
+      request = new Request(request);
+    }
+
     if (process.env.NODE_ENV !== 'production') {
       assert!.isInstance(request, Request, {
         moduleName: 'workbox-strategies',

--- a/packages/workbox-strategies/src/NetworkFirst.ts
+++ b/packages/workbox-strategies/src/NetworkFirst.ts
@@ -102,12 +102,16 @@ class NetworkFirst implements RouteHandlerObject {
    * [Workbox Router]{@link workbox.routing.Router}.
    *
    * @param {Object} options
-   * @param {Request} options.request The request to run this strategy for.
+   * @param {Request|string} options.request A request to run this strategy for.
    * @param {Event} [options.event] The event that triggered the request.
    * @return {Promise<Response>}
    */
   async handle({event, request}: RouteHandlerCallbackOptions): Promise<Response> {
-   const logs: any[] = [];
+    const logs: any[] = [];
+   
+    if (typeof request === 'string') {
+      request = new Request(request);
+    }
 
     if (process.env.NODE_ENV !== 'production') {
       assert!.isInstance(request, Request, {

--- a/packages/workbox-strategies/src/NetworkOnly.ts
+++ b/packages/workbox-strategies/src/NetworkOnly.ts
@@ -58,11 +58,15 @@ class NetworkOnly implements RouteHandlerObject {
    * [Workbox Router]{@link workbox.routing.Router}.
    *
    * @param {Object} options
-   * @param {Request} options.request The request to run this strategy for.
+   * @param {Request|string} options.request The request to run this strategy for.
    * @param {Event} [options.event] The event that triggered the request.
    * @return {Promise<Response>}
    */
   async handle({event, request}: RouteHandlerCallbackOptions): Promise<Response> {
+    if (typeof request === 'string') {
+      request = new Request(request);
+    }
+
     if (process.env.NODE_ENV !== 'production') {
       assert!.isInstance(request, Request, {
         moduleName: 'workbox-strategies',

--- a/packages/workbox-strategies/src/StaleWhileRevalidate.ts
+++ b/packages/workbox-strategies/src/StaleWhileRevalidate.ts
@@ -88,12 +88,16 @@ class StaleWhileRevalidate implements RouteHandlerObject {
    * [Workbox Router]{@link workbox.routing.Router}.
    *
    * @param {Object} options
-   * @param {Request} options.request The request to run this strategy for.
+   * @param {Request|string} options.request A request to run this strategy for.
    * @param {Event} [options.event] The event that triggered the request.
    * @return {Promise<Response>}
    */
   async handle({event, request}: RouteHandlerCallbackOptions): Promise<Response> {
-   const logs = [];
+    const logs = [];
+
+    if (typeof request === 'string') {
+      request = new Request(request);
+    }
 
     if (process.env.NODE_ENV !== 'production') {
       assert!.isInstance(request, Request, {

--- a/test/workbox-strategies/sw/test-CacheOnly.mjs
+++ b/test/workbox-strategies/sw/test-CacheOnly.mjs
@@ -64,6 +64,23 @@ describe(`CacheOnly`, function() {
       await compareResponses(injectedResponse, handleResponse, true);
     });
 
+    it(`should support using a string as the request`, async function() {
+      const stringRequest = 'http://example.io/test/';
+      const request = new Request(stringRequest);
+      const event = new FetchEvent('fetch', {request});
+
+      const injectedResponse = generateUniqueResponse();
+      const cache = await caches.open(cacheNames.getRuntimeName());
+      await cache.put(request, injectedResponse.clone());
+
+      const cacheOnly = new CacheOnly();
+      const handleResponse = await cacheOnly.handle({
+        request: stringRequest,
+        event,
+      });
+      await compareResponses(injectedResponse, handleResponse, true);
+    });
+
     it(`should return no cached response from custom cache name`, async function() {
       const request = new Request('http://example.io/test/');
       const event = new FetchEvent('fetch', {request});

--- a/test/workbox-strategies/sw/test-NetworkFirst.mjs
+++ b/test/workbox-strategies/sw/test-NetworkFirst.mjs
@@ -60,6 +60,30 @@ describe(`NetworkFirst`, function() {
       await compareResponses(cachedResponse, handleResponse, true);
     });
 
+    it(`should support using a string as the request`, async function() {
+      const stringRequest = 'http://example.io/test/';
+      const request = new Request(stringRequest);
+      const event = new FetchEvent('fetch', {request});
+      spyOnEvent(event);
+
+      const fetchResponse = generateOpaqueResponse();
+      sandbox.stub(self, 'fetch').resolves(fetchResponse);
+
+      const networkFirst = new NetworkFirst();
+      const handleResponse = await networkFirst.handle({
+        request: stringRequest,
+        event,
+      });
+
+      // Wait until cache.put is finished.
+      await eventDoneWaiting(event);
+
+      const cache = await caches.open(cacheNames.getRuntimeName());
+      const cachedResponse = await cache.match(request);
+
+      await compareResponses(cachedResponse, handleResponse, true);
+    });
+
     it(`should return the cached response if exists and not update the cache when the network request fails`, async function() {
       sandbox.stub(self, 'fetch').rejects(new Error('Injected error.'));
 

--- a/test/workbox-strategies/sw/test-NetworkOnly.mjs
+++ b/test/workbox-strategies/sw/test-NetworkOnly.mjs
@@ -52,6 +52,27 @@ describe(`NetworkOnly`, function() {
       expect(keys).to.be.empty;
     });
 
+    it(`should support using a string as the request`, async function() {
+      sandbox.stub(self, 'fetch').resolves(generateUniqueResponse());
+
+      const stringRequest = 'http://example.io/test/';
+      const request = new Request(stringRequest);
+      const event = new FetchEvent('fetch', {request});
+
+      const networkOnly = new NetworkOnly();
+
+      const handleResponse = await networkOnly.handle({
+        request: stringRequest,
+        event,
+      });
+      expect(handleResponse).to.be.instanceOf(Response);
+
+      const cache = await caches.open(cacheNames.getRuntimeName());
+      const keys = await cache.keys();
+      expect(keys).to.be.empty;
+    });
+
+
     it(`should reject when the network request fails`, async function() {
       const request = new Request('http://example.io/test/');
       const event = new FetchEvent('fetch', {request});

--- a/test/workbox-strategies/sw/test-StaleWhileRevalidate.mjs
+++ b/test/workbox-strategies/sw/test-StaleWhileRevalidate.mjs
@@ -57,6 +57,28 @@ describe(`StaleWhileRevalidate`, function() {
       await compareResponses(cachedResponse, handleResponse, true);
     });
 
+    it(`should support using a string as the request`, async function() {
+      sandbox.stub(self, 'fetch').resolves(generateUniqueResponse());
+
+      const stringRequest = 'http://example.io/test/';
+      const request = new Request(stringRequest);
+      const event = new FetchEvent('fetch', {request});
+      spyOnEvent(event);
+
+      const staleWhileRevalidate = new StaleWhileRevalidate();
+      const handleResponse = await staleWhileRevalidate.handle({
+        request: stringRequest,
+        event,
+      });
+
+      await eventDoneWaiting(event);
+
+      const cache = await caches.open(cacheNames.getRuntimeName());
+      const cachedResponse = await cache.match(request);
+
+      await compareResponses(cachedResponse, handleResponse, true);
+    });
+
     it(`should return the cached response and not update the cache when the network request fails`, async function() {
       const request = new Request('http://example.io/test/');
       const event = new FetchEvent('fetch', {request});


### PR DESCRIPTION
R: @philipwalton

As mentioned when we were going through the v5 changes, it makes sense to support passing in a string request to `handle()` in the various strategies, to match the interface supported by `makeRequest()`.