### PR TITLE
Set revision: null instead of deleting revision

### DIFF
--- a/packages/workbox-build/src/lib/no-revision-for-urls-matching-transform.js
+++ b/packages/workbox-build/src/lib/no-revision-for-urls-matching-transform.js
@@ -20,7 +20,7 @@ module.exports = (regexp) => {
       }
 
       if (entry.url.match(regexp)) {
-        delete entry.revision;
+        entry.revision = null;
       }
 
       return entry;

--- a/packages/workbox-build/src/lib/transform-manifest.js
+++ b/packages/workbox-build/src/lib/transform-manifest.js
@@ -39,7 +39,7 @@ const noRevisionForURLsMatchingTransform =
  *   return {manifest, warnings: []};
  * };
  *
- * @example <caption>A transformation that removes the revision field when the
+ * @example <caption>A transformation that nulls the revision field when the
  * URL contains an 8-character hash surrounded by '.', indicating that it
  * already contains revision information:</caption>
  *
@@ -47,7 +47,7 @@ const noRevisionForURLsMatchingTransform =
  *   const manifest = manifestEntries.map(entry => {
  *     const hashRegExp = /\.\w{8}\./;
  *     if (entry.url.match(hashRegExp)) {
- *       delete entry.revision;
+ *       entry.revision = null;
  *     }
  *     return entry;
  *   });

--- a/test/workbox-build/node/lib/no-revision-for-urls-matching-transform.js
+++ b/test/workbox-build/node/lib/no-revision-for-urls-matching-transform.js
@@ -60,10 +60,11 @@ describe(`[workbox-build] lib/no-revision-for-urls-matching-transform.js`, funct
     }
   });
 
-  it(`should remove revision info from a single matching entry`, function() {
+  it(`should set revision info to null in a single matching entry`, function() {
     const transform = noRevisionForURLsMatching(/first-match/);
     expect(transform(MANIFEST)).to.eql({manifest: [{
       url: '/first-match/12345/hello',
+      revision: null,
     }, {
       url: '/second-match/12345/hello',
       revision: '1234abcd',
@@ -72,14 +73,17 @@ describe(`[workbox-build] lib/no-revision-for-urls-matching-transform.js`, funct
     }]});
   });
 
-  it(`should remove revision info from multiple matching entries`, function() {
+  it(`should set revision info to null in multiple matching entries`, function() {
     const transform = noRevisionForURLsMatching(/12345/);
     expect(transform(MANIFEST)).to.eql({manifest: [{
       url: '/first-match/12345/hello',
+      revision: null,
     }, {
       url: '/second-match/12345/hello',
+      revision: null,
     }, {
       url: '/third-match/12345/hello',
+      revision: null,
     }]});
   });
 

--- a/test/workbox-build/node/lib/transform-manifest.js
+++ b/test/workbox-build/node/lib/transform-manifest.js
@@ -56,6 +56,7 @@ describe(`[workbox-build] lib/transform-manifest.js`, function() {
     expect(count).to.eql(3);
     expect(manifestEntries).to.deep.equal([{
       url: ENTRY1.file,
+      revision: null,
     }, {
       url: ENTRY2.file,
       revision: ENTRY2.hash,

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -1273,6 +1273,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             importScripts: [],
             precacheAndRoute: [[[{
               url: 'main.f70b1e.js',
+              revision: null,
             }], {}]],
           }});
 

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -1169,6 +1169,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[{
                 url: 'main.8be1a4.js',
+                revision: null,
               }], {}]],
             },
           });


### PR DESCRIPTION
R: @philipwalton

This is needed to avoid a warning message due to a missing `revision` field, introduced in one of the earlier RCs.

See https://github.com/GoogleChrome/workbox/issues/2259#issuecomment-573281342