### PR TITLE
Fix the update-cdn-details task

### DIFF
--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -32,17 +32,18 @@ gulp.task('build:update-cdn-details', async function() {
       __dirname, '..', 'cdn-details.json'
   ));
 
-  const lernaPkg = await fs.readJSON(path.join(
-      __dirname, '..', 'lerna.json'
-  ));
-
-  cdnDetails.latestVersion = lernaPkg.version;
-
   const workboxBuildPath = path.join(
-      __dirname, '..', 'packages', 'workbox-build', 'src', 'cdn-details.json'
-  );
+      __dirname, '..', 'packages', 'workbox-build');
 
-  await fs.writeJson(workboxBuildPath, cdnDetails, {
+  const workboxBuildCdnDetailsPath = path.join(
+      workboxBuildPath, 'src', 'cdn-details.json');
+
+  const workboxBuildPkg = await fs.readJSON(path.join(
+      workboxBuildPath, 'package.json'));
+
+  cdnDetails.latestVersion = workboxBuildPkg.version;
+
+  await fs.writeJson(workboxBuildCdnDetailsPath, cdnDetails, {
     spaces: 2,
   });
 });


### PR DESCRIPTION
R: @jeffposnick 

This PR updates the `gulp build:update-cdn-details` task to use the version from `workbox-build` rather than from `lerna.json` in the root directory. This issue appears to be that the `lerna version` lifecycle will update each package's version and run it's `version` npm script, and then it will update `lerna.json` last.

Since we need the version it's updating to in this task, it's better to get the version from `workbox-build`'s `package.json` file.