### PR TITLE
Update publish-lerna to include all packages

### DIFF
--- a/gulp-tasks/publish-lerna.js
+++ b/gulp-tasks/publish-lerna.js
@@ -16,8 +16,10 @@ gulp.task('publish-lerna', () => {
     'run', 'local-lerna',
     '--',
     'publish',
+    // Make sure to publish all packages, regardless of what's changed
+    '--force-publish',
 
     // The following flags can be used if publishing non-stable versions
-    '--npm-tag', 'next',
+    // '--dist-tag=next',
   ]);
 });


### PR DESCRIPTION
R: @jeffposnick 

This PR adds the `--force-publish` to our lerna publish task, which is needed to make sure all packages are bumped, regardless of whether they had changes or not. This was not necessary before because we were manually adding commits to all packages with new version details (thus there were always changes), but we're not doing that anymore.

The PR also removes the `--dist-tag=next` line, since we no longer plan on publishing v5 prereleases.