### PR TITLE
Loosen the hash validation in our integration tests

### DIFF
--- a/infra/testing/validator/service-worker-runtime.js
+++ b/infra/testing/validator/service-worker-runtime.js
@@ -170,9 +170,8 @@ function validateMethodCalls({methodsToSpies, expectedMethodCalls, context}) {
         });
       } else {
         expect(args).to.deep.equal(expectedMethodCalls[method],
-          `while testing method calls for ${method}`);
+            `while testing method calls for ${method}`);
       }
-      
     } else {
       expect(expectedMethodCalls[method],
           `while testing method calls for ${method}`).to.be.undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,30 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "json5": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+          "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -918,6 +942,23 @@
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "@babel/types": {
@@ -1089,9 +1130,9 @@
       "dev": true
     },
     "@google-cloud/storage": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-4.3.0.tgz",
-      "integrity": "sha512-ph0jsUsZ9FPtN40V5eIkKPLUmxnTpxqBDkWxStW/kbQZgoNVGW9vJcbsYSyE4ath7jQIpM4OHu6aqmPFX1OnGw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-4.3.1.tgz",
+      "integrity": "sha512-/i7tAcUZDQNDs8/+oN+U2mOXdWdP2eld0pFKLkpthmWmaD89JQlrgHAFL7uvlgCSbaD7YxgbSyJebgd6YBgMgQ==",
       "dev": true,
       "requires": {
         "@google-cloud/common": "^2.1.1",
@@ -1116,6 +1157,65 @@
         "stream-events": "^1.0.1",
         "through2": "^3.0.0",
         "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "pumpify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+          "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+          "dev": true,
+          "requires": {
+            "duplexify": "^4.1.1",
+            "inherits": "^2.0.3",
+            "pump": "^3.0.0"
+          },
+          "dependencies": {
+            "duplexify": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+              "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+              "dev": true,
+              "requires": {
+                "end-of-stream": "^1.4.1",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1",
+                "stream-shift": "^1.0.0"
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -1552,35 +1652,6 @@
           "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
           "dev": true
         },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
         "fast-glob": {
           "version": "2.2.7",
           "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
@@ -1593,29 +1664,6 @@
             "is-glob": "^4.0.0",
             "merge2": "^1.2.3",
             "micromatch": "^3.1.10"
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
           }
         },
         "globby": {
@@ -1640,53 +1688,6 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1698,16 +1699,6 @@
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
           "dev": true
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
         }
       }
     },
@@ -2197,35 +2188,6 @@
           "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
           "dev": true
         },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
         "dot-prop": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -2272,29 +2234,6 @@
             }
           }
         },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
         "glob-parent": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
@@ -2326,36 +2265,10 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
         "is-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
           "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-          "dev": true
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "load-json-file": {
@@ -2369,27 +2282,6 @@
             "pify": "^4.0.1",
             "strip-bom": "^3.0.0",
             "type-fest": "^0.3.0"
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
           }
         },
         "p-map": {
@@ -2415,16 +2307,6 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
         },
         "type-fest": {
           "version": "0.3.1",
@@ -2950,6 +2832,23 @@
         "@octokit/types": "^2.0.0",
         "is-plain-object": "^3.0.0",
         "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
       }
     },
     "@octokit/plugin-enterprise-rest": {
@@ -2997,6 +2896,23 @@
         "node-fetch": "^2.3.0",
         "once": "^1.4.0",
         "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
       }
     },
     "@octokit/request-error": {
@@ -3079,6 +2995,12 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@tootallnate/once": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.0.0.tgz",
+      "integrity": "sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -3127,9 +3049,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
-      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==",
+      "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.1.tgz",
+      "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA==",
       "dev": true
     },
     "@types/resolve": {
@@ -3142,12 +3064,12 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.19.0.tgz",
-      "integrity": "sha512-u7IcQ9qwsB6U806LupZmINRnQjC+RJyv36sV/ugaFWMHTbFm/hlLTRx3gGYJgHisxcGSTnf+I/fPDieRMhPSQQ==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.19.2.tgz",
+      "integrity": "sha512-HX2qOq2GOV04HNrmKnTpSIpHjfl7iwdXe3u/Nvt+/cpmdvzYvY0NHSiTkYN257jHnq4OM/yo+OsFgati+7LqJA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.19.0",
+        "@typescript-eslint/experimental-utils": "2.19.2",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -3155,32 +3077,44 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.0.tgz",
-      "integrity": "sha512-zwpg6zEOPbhB3+GaQfufzlMUOO6GXCNZq6skk+b2ZkZAIoBhVoanWK255BS1g5x9bMwHpLhX0Rpn5Fc3NdCZdg==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.2.tgz",
+      "integrity": "sha512-B88QuwT1wMJR750YvTJBNjMZwmiPpbmKYLm1yI7PCc3x0NariqPwqaPsoJRwU9DmUi0cd9dkhz1IqEnwfD+P1A==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.19.0",
+        "@typescript-eslint/typescript-estree": "2.19.2",
         "eslint-scope": "^5.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.19.0.tgz",
-      "integrity": "sha512-s0jZoxAWjHnuidbbN7aA+BFVXn4TCcxEVGPV8lWMxZglSs3NRnFFAlL+aIENNmzB2/1jUJuySi6GiM6uACPmpg==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.19.2.tgz",
+      "integrity": "sha512-8uwnYGKqX9wWHGPGdLB9sk9+12sjcdqEEYKGgbS8A0IvYX59h01o8os5qXUHMq2na8vpDRaV0suTLM7S8wraTA==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.19.0",
-        "@typescript-eslint/typescript-estree": "2.19.0",
+        "@typescript-eslint/experimental-utils": "2.19.2",
+        "@typescript-eslint/typescript-estree": "2.19.2",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.19.0.tgz",
-      "integrity": "sha512-n6/Xa37k0jQdwpUszffi19AlNbVCR0sdvCs3DmSKMD7wBttKY31lhD2fug5kMD91B2qW4mQldaTEc1PEzvGu8w==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.19.2.tgz",
+      "integrity": "sha512-Xu/qa0MDk6upQWqE4Qy2X16Xg8Vi32tQS2PR0AvnT/ZYS4YGDvtn2MStOh5y8Zy2mg4NuL06KUHlvCh95j9C6Q==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -3192,6 +3126,21 @@
         "tsutils": "^3.17.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -3201,180 +3150,179 @@
       }
     },
     "@webassemblyjs/ast": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.6.tgz",
-      "integrity": "sha512-8nkZS48EVsMUU0v6F1LCIOw4RYWLm2plMtbhFTjNgeXmsTNLuU3xTRtnljt9BFQB+iPbLRobkNrCWftWnNC7wQ==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+      "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/helper-module-context": "1.7.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.6",
-        "@webassemblyjs/wast-parser": "1.7.6",
-        "mamacro": "^0.0.3"
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.6.tgz",
-      "integrity": "sha512-VBOZvaOyBSkPZdIt5VBMg3vPWxouuM13dPXGWI1cBh3oFLNcFJ8s9YA7S9l4mPI7+Q950QqOmqj06oa83hNWBA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+      "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.6.tgz",
-      "integrity": "sha512-SCzhcQWHXfrfMSKcj8zHg1/kL9kb3aa5TN4plc/EREOs5Xop0ci5bdVBApbk2yfVi8aL+Ly4Qpp3/TRAUInjrg==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+      "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.6.tgz",
-      "integrity": "sha512-1/gW5NaGsEOZ02fjnFiU8/OEEXU1uVbv2um0pQ9YVL3IHSkyk6xOwokzyqqO1qDZQUAllb+V8irtClPWntbVqw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+      "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.6.tgz",
-      "integrity": "sha512-+suMJOkSn9+vEvDvgyWyrJo5vJsWSDXZmJAjtoUq4zS4eqHyXImpktvHOZwXp1XQjO5H+YQwsBgqTQEc0J/5zg==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+      "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/wast-printer": "1.7.6"
+        "@webassemblyjs/wast-printer": "1.8.5"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.6.tgz",
-      "integrity": "sha512-HCS6KN3wgxUihGBW7WFzEC/o8Eyvk0d56uazusnxXthDPnkWiMv+kGi9xXswL2cvfYfeK5yiM17z2K5BVlwypw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+      "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.6.tgz",
-      "integrity": "sha512-e8/6GbY7OjLM+6OsN7f2krC2qYVNaSr0B0oe4lWdmq5sL++8dYDD1TFbD1TdAdWMRTYNr/Qq7ovXWzia2EbSjw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+      "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
       "dev": true,
       "requires": {
+        "@webassemblyjs/ast": "1.8.5",
         "mamacro": "^0.0.3"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.6.tgz",
-      "integrity": "sha512-PzYFCb7RjjSdAOljyvLWVqd6adAOabJW+8yRT+NWhXuf1nNZWH+igFZCUK9k7Cx7CsBbzIfXjJc7u56zZgFj9Q==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+      "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.6.tgz",
-      "integrity": "sha512-3GS628ppDPSuwcYlQ7cDCGr4W2n9c4hLzvnRKeuz+lGsJSmc/ADVoYpm1ts2vlB1tGHkjtQMni+yu8mHoMlKlA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+      "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.6",
-        "@webassemblyjs/helper-buffer": "1.7.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.6",
-        "@webassemblyjs/wasm-gen": "1.7.6"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5"
       }
     },
     "@webassemblyjs/ieee754": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.6.tgz",
-      "integrity": "sha512-V4cIp0ruyw+hawUHwQLn6o2mFEw4t50tk530oKsYXQhEzKR+xNGDxs/SFFuyTO7X3NzEu4usA3w5jzhl2RYyzQ==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+      "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.6.tgz",
-      "integrity": "sha512-ojdlG8WpM394lBow4ncTGJoIVZ4aAtNOWHhfAM7m7zprmkVcKK+2kK5YJ9Bmj6/ketTtOn7wGSHCtMt+LzqgYQ==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+      "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
       "dev": true,
       "requires": {
-        "@xtuc/long": "4.2.1"
+        "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.6.tgz",
-      "integrity": "sha512-oId+tLxQ+AeDC34ELRYNSqJRaScB0TClUU6KQfpB8rNT6oelYlz8axsPhf6yPTg7PBJ/Z5WcXmUYiHEWgbbHJw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+      "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.6.tgz",
-      "integrity": "sha512-pTNjLO3o41v/Vz9VFLl+I3YLImpCSpodFW77pNoH4agn5I6GgSxXHXtvWDTvYJFty0jSeXZWLEmbaSIRUDlekg==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+      "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.6",
-        "@webassemblyjs/helper-buffer": "1.7.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.6",
-        "@webassemblyjs/helper-wasm-section": "1.7.6",
-        "@webassemblyjs/wasm-gen": "1.7.6",
-        "@webassemblyjs/wasm-opt": "1.7.6",
-        "@webassemblyjs/wasm-parser": "1.7.6",
-        "@webassemblyjs/wast-printer": "1.7.6"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/helper-wasm-section": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-opt": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "@webassemblyjs/wast-printer": "1.8.5"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.6.tgz",
-      "integrity": "sha512-mQvFJVumtmRKEUXMohwn8nSrtjJJl6oXwF3FotC5t6e2hlKMh8sIaW03Sck2MDzw9xPogZD7tdP5kjPlbH9EcQ==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+      "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.6",
-        "@webassemblyjs/ieee754": "1.7.6",
-        "@webassemblyjs/leb128": "1.7.6",
-        "@webassemblyjs/utf8": "1.7.6"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.6.tgz",
-      "integrity": "sha512-go44K90fSIsDwRgtHhX14VtbdDPdK2sZQtZqUcMRvTojdozj5tLI0VVJAzLCfz51NOkFXezPeVTAYFqrZ6rI8Q==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+      "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.6",
-        "@webassemblyjs/helper-buffer": "1.7.6",
-        "@webassemblyjs/wasm-gen": "1.7.6",
-        "@webassemblyjs/wasm-parser": "1.7.6"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.6.tgz",
-      "integrity": "sha512-t1T6TfwNY85pDA/HWPA8kB9xA4sp9ajlRg5W7EKikqrynTyFo+/qDzIpvdkOkOGjlS6d4n4SX59SPuIayR22Yg==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+      "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.6",
-        "@webassemblyjs/helper-api-error": "1.7.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.6",
-        "@webassemblyjs/ieee754": "1.7.6",
-        "@webassemblyjs/leb128": "1.7.6",
-        "@webassemblyjs/utf8": "1.7.6"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
       }
     },
     "@webassemblyjs/wast-parser": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.6.tgz",
-      "integrity": "sha512-1MaWTErN0ziOsNUlLdvwS+NS1QWuI/kgJaAGAMHX8+fMJFgOJDmN/xsG4h/A1Gtf/tz5VyXQciaqHZqp2q0vfg==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+      "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.6",
-        "@webassemblyjs/floating-point-hex-parser": "1.7.6",
-        "@webassemblyjs/helper-api-error": "1.7.6",
-        "@webassemblyjs/helper-code-frame": "1.7.6",
-        "@webassemblyjs/helper-fsm": "1.7.6",
-        "@xtuc/long": "4.2.1",
-        "mamacro": "^0.0.3"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/floating-point-hex-parser": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-code-frame": "1.8.5",
+        "@webassemblyjs/helper-fsm": "1.8.5",
+        "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.6.tgz",
-      "integrity": "sha512-vHdHSK1tOetvDcl1IV1OdDeGNe/NDDQ+KzuZHMtqTVP1xO/tZ/IKNpj5BaGk1OYFdsDWQqb31PIwdEyPntOWRQ==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+      "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.6",
-        "@webassemblyjs/wast-parser": "1.7.6",
-        "@xtuc/long": "4.2.1"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5",
+        "@xtuc/long": "4.2.2"
       }
     },
     "@xtuc/ieee754": {
@@ -3384,9 +3332,9 @@
       "dev": true
     },
     "@xtuc/long": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
-      "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
     "@zkochan/cmd-shim": {
@@ -3446,23 +3394,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
       "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
-    },
-    "acorn-dynamic-import": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
-      "dev": true,
-      "requires": {
-        "acorn": "^5.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-          "dev": true
-        }
-      }
     },
     "acorn-jsx": {
       "version": "5.1.0",
@@ -3586,105 +3517,6 @@
         "normalize-path": "^2.1.1"
       },
       "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
         "normalize-path": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -3692,16 +3524,6 @@
           "dev": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
           }
         }
       }
@@ -3743,6 +3565,19 @@
         "readable-stream": "^3.4.0",
         "tar-stream": "^2.1.0",
         "zip-stream": "^2.1.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "archiver-utils": {
@@ -3761,23 +3596,6 @@
         "lodash.union": "^4.6.0",
         "normalize-path": "^3.0.0",
         "readable-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "archy": {
@@ -3794,23 +3612,6 @@
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "argparse": {
@@ -4220,12 +4021,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
         }
       }
     },
@@ -4291,6 +4086,19 @@
       "dev": true,
       "requires": {
         "readable-stream": "^3.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "bluebird": {
@@ -4321,23 +4129,6 @@
         "qs": "6.7.0",
         "raw-body": "2.4.0",
         "type-is": "~1.6.17"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
       }
     },
     "boolbase": {
@@ -4357,12 +4148,32 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "brorand": {
@@ -4466,13 +4277,14 @@
       "dev": true
     },
     "buffer": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
-      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-crc32": {
@@ -4579,14 +4391,6 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "caching-transform": {
@@ -4599,6 +4403,23 @@
         "make-dir": "^3.0.0",
         "package-hash": "^4.0.0",
         "write-file-atomic": "^3.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "call-me-maybe": {
@@ -4667,9 +4488,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001025",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz",
-      "integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==",
+      "version": "1.0.30001027",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
+      "integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==",
       "dev": true
     },
     "caseless": {
@@ -4783,87 +4604,12 @@
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        }
       }
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
     "chrome-trace-event": {
@@ -4911,12 +4657,6 @@
           "requires": {
             "is-descriptor": "^0.1.0"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
         }
       }
     },
@@ -5000,23 +4740,6 @@
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
-      },
-      "dependencies": {
-        "is-plain-object": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "clone-stats": {
@@ -5034,23 +4757,6 @@
         "inherits": "^2.0.1",
         "process-nextick-args": "^2.0.0",
         "readable-stream": "^2.3.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "code-point-at": {
@@ -5144,9 +4850,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
     "comment-parser": {
@@ -5210,23 +4916,6 @@
         "crc32-stream": "^3.0.1",
         "normalize-path": "^3.0.0",
         "readable-stream": "^2.3.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "compressible": {
@@ -5245,14 +4934,14 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
+        "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
       }
     },
@@ -5278,6 +4967,23 @@
         "unique-string": "^2.0.0",
         "write-file-atomic": "^3.0.0",
         "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "console-browserify": {
@@ -5431,6 +5137,15 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
         }
       }
     },
@@ -5463,6 +5178,15 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
         }
       }
     },
@@ -5489,6 +5213,17 @@
         "split2": "^2.0.0",
         "through2": "^3.0.0",
         "trim-off-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
       }
     },
     "conventional-recommended-bump": {
@@ -5507,6 +5242,18 @@
         "q": "^1.5.1"
       },
       "dependencies": {
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -5606,6 +5353,17 @@
             "read-pkg": "^3.0.0"
           }
         },
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -5663,23 +5421,6 @@
       "requires": {
         "each-props": "^1.3.0",
         "is-plain-object": "^2.0.1"
-      },
-      "dependencies": {
-        "is-plain-object": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "copy-webpack-plugin": {
@@ -5780,6 +5521,18 @@
       "dev": true,
       "requires": {
         "buffer": "^5.1.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
       }
     },
     "crc32-stream": {
@@ -5790,6 +5543,19 @@
       "requires": {
         "crc": "^3.4.4",
         "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "create-ecdh": {
@@ -5955,12 +5721,12 @@
       "dev": true
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.0.0"
       }
     },
     "debuglog": {
@@ -6130,12 +5896,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
         }
       }
     },
@@ -6199,9 +5959,9 @@
           "dev": true
         },
         "rimraf": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-          "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -6250,6 +6010,23 @@
         "vue-template-compiler": "^2.6.11",
         "walkdir": "^0.4.1",
         "yargs": "^15.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "depd": {
@@ -6441,23 +6218,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "each-props": {
@@ -6468,23 +6228,6 @@
       "requires": {
         "is-plain-object": "^2.0.1",
         "object.defaults": "^1.1.0"
-      },
-      "dependencies": {
-        "is-plain-object": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "ecc-jsbn": {
@@ -6518,12 +6261,6 @@
         "sigmund": "^1.0.1"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        },
         "lru-cache": {
           "version": "4.1.5",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -6555,9 +6292,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.345",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz",
-      "integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==",
+      "version": "1.3.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.349.tgz",
+      "integrity": "sha512-uEb2zs6EJ6OZIqaMsCSliYVgzE/f7/s1fLWqtvRtHg/v5KBF2xds974fUnyatfxIDgkqzQVwFtam5KExqywx0Q==",
       "dev": true
     },
     "elliptic": {
@@ -6630,21 +6367,6 @@
           "requires": {
             "errno": "^0.1.3",
             "readable-stream": "^2.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
           }
         }
       }
@@ -6866,6 +6588,25 @@
             "supports-color": "^5.3.0"
           }
         },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
         "glob-parent": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
@@ -6899,6 +6640,12 @@
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         },
         "regexpp": {
           "version": "2.0.1",
@@ -6956,6 +6703,21 @@
         "spdx-expression-parse": "^3.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -6965,9 +6727,9 @@
       }
     },
     "eslint-scope": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -7007,9 +6769,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -7114,15 +6876,6 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -7140,12 +6893,6 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -7194,23 +6941,6 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
       }
     },
     "ext": {
@@ -7254,21 +6984,6 @@
           "requires": {
             "is-plain-object": "^2.0.4"
           }
-        },
-        "is-plain-object": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
         }
       }
     },
@@ -7385,6 +7100,24 @@
         "micromatch": "^4.0.2"
       },
       "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
         "glob-parent": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
@@ -7392,6 +7125,31 @@
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
           }
         }
       }
@@ -7474,12 +7232,26 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "to-regex-range": "^5.0.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "finalhandler": {
@@ -7495,23 +7267,6 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
       }
     },
     "find-cache-dir": {
@@ -7523,24 +7278,6 @@
         "commondir": "^1.0.1",
         "make-dir": "^2.0.0",
         "pkg-dir": "^3.0.0"
-      },
-      "dependencies": {
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-          "dev": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "find-parent-dir": {
@@ -7568,117 +7305,6 @@
         "is-glob": "^4.0.0",
         "micromatch": "^3.0.4",
         "resolve-dir": "^1.0.1"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        }
       }
     },
     "fined": {
@@ -7692,23 +7318,6 @@
         "object.defaults": "^1.1.0",
         "object.pick": "^1.2.0",
         "parse-filepath": "^1.0.1"
-      },
-      "dependencies": {
-        "is-plain-object": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "flagged-respawn": {
@@ -7770,23 +7379,6 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "follow-redirects": {
@@ -7797,23 +7389,6 @@
       "requires": {
         "debug": "^2.2.0",
         "stream-consume": "^0.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
       }
     },
     "for-in": {
@@ -7930,23 +7505,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "fromentries": {
@@ -7989,33 +7547,6 @@
       "requires": {
         "graceful-fs": "^4.1.11",
         "through2": "^2.0.3"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "fs-write-stream-atomic": {
@@ -8028,23 +7559,6 @@
         "iferr": "^0.1.5",
         "imurmurhash": "^0.1.4",
         "readable-stream": "1 || 2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "fs.realpath": {
@@ -8711,6 +8225,42 @@
         "google-auth-library": "^5.0.0",
         "pumpify": "^2.0.0",
         "stream-events": "^1.0.4"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+          "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "pumpify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+          "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+          "dev": true,
+          "requires": {
+            "duplexify": "^4.1.1",
+            "inherits": "^2.0.3",
+            "pump": "^3.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "genfun": {
@@ -8799,21 +8349,6 @@
             "trim-newlines": "^1.0.0"
           }
         },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
         "redent": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -8831,16 +8366,6 @@
           "dev": true,
           "requires": {
             "get-stdin": "^4.0.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
           }
         },
         "trim-newlines": {
@@ -8999,36 +8524,11 @@
             "read-pkg": "^3.0.0"
           }
         },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
         }
       }
     },
@@ -9223,15 +8723,6 @@
             "semver": "~5.0.1"
           }
         },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "https-proxy-agent": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
@@ -9247,12 +8738,6 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "semver": {
@@ -9314,44 +8799,6 @@
         "remove-trailing-separator": "^1.0.1",
         "to-absolute-glob": "^2.0.0",
         "unique-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "pumpify": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-          "dev": true,
-          "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "glob-to-regexp": {
@@ -9555,18 +9002,6 @@
             "wrap-ansi": "^2.0.0"
           }
         },
-        "concat-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          }
-        },
         "get-caller-file": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -9606,27 +9041,6 @@
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
           }
         },
         "require-main-filename": {
@@ -9719,33 +9133,6 @@
         "replace-ext": "^1.0.0",
         "through2": "^2.0.0",
         "vinyl-sourcemaps-apply": "^0.2.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gulplog": {
@@ -9865,14 +9252,6 @@
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
         "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "has-values": {
@@ -9885,26 +9264,6 @@
         "kind-of": "^4.0.0"
       },
       "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -9933,33 +9292,6 @@
       "dev": true,
       "requires": {
         "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "hash.js": {
@@ -10033,6 +9365,14 @@
         "param-case": "2.1.x",
         "relateurl": "0.2.x",
         "uglify-js": "3.4.x"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "dev": true
+        }
       }
     },
     "html-webpack-plugin": {
@@ -10095,6 +9435,17 @@
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
           "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
           "dev": true
+        },
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         }
       }
     },
@@ -10126,11 +9477,12 @@
       }
     },
     "http-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-GX0FA6+IcDf4Oxc/FBWgYj4zKgo/DnZrksaG9jyuQLExs6xlX+uI5lcA8ymM3JaZTRrF/4s2UX19wJolyo7OBA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
       "dev": true,
       "requires": {
+        "@tootallnate/once": "1",
         "agent-base": "6",
         "debug": "4"
       },
@@ -10143,6 +9495,21 @@
           "requires": {
             "debug": "4"
           }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -10171,6 +9538,23 @@
       "requires": {
         "agent-base": "5",
         "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "humanize-ms": {
@@ -10561,10 +9945,24 @@
       "dev": true
     },
     "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "is-obj": {
       "version": "2.0.0",
@@ -10597,12 +9995,12 @@
       "dev": true
     },
     "is-plain-object": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-      "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^4.0.0"
+        "isobject": "^3.0.1"
       }
     },
     "is-promise": {
@@ -10712,6 +10110,12 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -10725,9 +10129,9 @@
       "dev": true
     },
     "isobject": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "isstream": {
@@ -10800,6 +10204,15 @@
             "which": "^2.0.1"
           }
         },
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
         "path-key": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -10807,13 +10220,19 @@
           "dev": true
         },
         "rimraf": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-          "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         },
         "shebang-command": {
           "version": "2.0.0",
@@ -10858,6 +10277,21 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
         "supports-color": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
@@ -10880,6 +10314,21 @@
         "source-map": "^0.6.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11072,9 +10521,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -11117,23 +10566,6 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "set-immediate-shim": "~1.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "just-debounce": {
@@ -11201,23 +10633,6 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "lcid": {
@@ -11318,23 +10733,6 @@
         "object.map": "^1.0.0",
         "rechoir": "^0.6.2",
         "resolve": "^1.1.7"
-      },
-      "dependencies": {
-        "is-plain-object": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "linkify-it": {
@@ -11391,17 +10789,6 @@
         "big.js": "^5.2.2",
         "emojis-list": "^2.0.0",
         "json5": "^1.0.1"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
       }
     },
     "locate-path": {
@@ -11604,18 +10991,19 @@
       }
     },
     "make-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-      "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
       "requires": {
-        "semver": "^6.0.0"
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -11676,12 +11064,6 @@
             "agent-base": "^4.3.0",
             "debug": "^3.1.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -11775,58 +11157,6 @@
         "stack-trace": "0.0.10"
       },
       "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
         "findup-sync": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
@@ -11846,63 +11176,6 @@
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.0"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
           }
         }
       }
@@ -11952,23 +11225,6 @@
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "meow": {
@@ -12141,13 +11397,24 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.0.5"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "miller-rabin": {
@@ -12267,68 +11534,6 @@
         "pumpify": "^1.3.3",
         "stream-each": "^1.1.0",
         "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          }
-        },
-        "pumpify": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-          "dev": true,
-          "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
-          },
-          "dependencies": {
-            "pump": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-              "dev": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "mixin-deep": {
@@ -12349,21 +11554,6 @@
           "requires": {
             "is-plain-object": "^2.0.4"
           }
-        },
-        "is-plain-object": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
         }
       }
     },
@@ -12453,6 +11643,15 @@
           "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
           "dev": true
         },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
         "chokidar": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
@@ -12494,6 +11693,15 @@
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
         },
         "fsevents": {
           "version": "2.1.2",
@@ -12538,6 +11746,12 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
         "ms": {
@@ -12588,6 +11802,15 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
           }
         },
         "wrap-ansi": {
@@ -12658,9 +11881,9 @@
       }
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "multimatch": {
@@ -12907,37 +12130,11 @@
         "vm-browserify": "^1.0.1"
       },
       "dependencies": {
-        "buffer": {
-          "version": "4.9.2",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
-          }
-        },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
         }
       }
     },
@@ -12973,9 +12170,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.48.tgz",
-      "integrity": "sha512-Hr8BbmUl1ujAST0K0snItzEA5zkJTQup8VNTKNfT6Zw8vTJkIiagUPNfxHmgDOyfFYNfKAul40sD0UEYTvwebw==",
+      "version": "1.1.49",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.49.tgz",
+      "integrity": "sha512-xH8t0LS0disN0mtRCh+eByxFPie+msJUBL/lJDBuap53QGiYPa9joh83K4pCZgWJ+2L4b9h88vCVdXQ60NO2bg==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -13337,6 +12534,15 @@
             "p-locate": "^4.1.0"
           }
         },
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
         "p-locate": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -13368,13 +12574,19 @@
           "dev": true
         },
         "rimraf": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-          "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -13440,14 +12652,6 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "object.assign": {
@@ -13472,14 +12676,6 @@
         "array-slice": "^1.0.0",
         "for-own": "^1.0.0",
         "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -13509,14 +12705,6 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "object.reduce": {
@@ -13601,23 +12789,6 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "os-browserify": {
@@ -13772,23 +12943,6 @@
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "param-case": {
@@ -14378,26 +13532,24 @@
       }
     },
     "pumpify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
-      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "^4.1.1",
+        "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
-        "pump": "^3.0.0"
+        "pump": "^2.0.0"
       },
       "dependencies": {
-        "duplexify": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
-          "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.4.1",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1",
-            "stream-shift": "^1.0.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -14579,14 +13731,18 @@
       }
     },
     "readable-stream": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-      "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdir-scoped-modules": {
@@ -14610,132 +13766,6 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        }
       }
     },
     "rechoir": {
@@ -14882,33 +13912,6 @@
         "remove-bom-buffer": "^3.0.0",
         "safe-buffer": "^5.1.0",
         "through2": "^2.0.3"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "remove-trailing-separator": {
@@ -14986,9 +13989,9 @@
       }
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -14998,7 +14001,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -15008,7 +14011,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
@@ -15141,6 +14144,32 @@
       "requires": {
         "debug": "^4.1.1",
         "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
       }
     },
     "reusify": {
@@ -15290,6 +14319,15 @@
             "p-locate": "^4.1.0"
           }
         },
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
         "p-locate": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -15331,6 +14369,12 @@
           "requires": {
             "estree-walker": "^0.6.1"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -15437,6 +14481,12 @@
             "agent-base": "^4.3.0",
             "debug": "^3.1.0"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -15519,9 +14569,9 @@
       }
     },
     "semver": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.2.tgz",
-      "integrity": "sha512-BJs9T/H8sEVHbeigqzIEo57Iu/3DG6c4QoqTfbQB3BPA4zgzAomh/Fk9E7QtjWQ8mx2dgA9YCfSF4y9k9bHNpQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+      "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
       "dev": true
     },
     "semver-compare": {
@@ -15560,23 +14610,6 @@
         "statuses": "~1.5.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
-            }
-          }
-        },
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -15612,15 +14645,6 @@
         "parseurl": "~1.3.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -15637,12 +14661,6 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "setprototypeof": {
@@ -15706,21 +14724,6 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
-        },
-        "is-plain-object": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
         }
       }
     },
@@ -15885,15 +14888,6 @@
         "use": "^3.1.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -15911,12 +14905,6 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -15968,12 +14956,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
         }
       }
     },
@@ -16112,14 +15094,29 @@
         "which": "^2.0.1"
       },
       "dependencies": {
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
         "rimraf": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-          "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         },
         "which": {
           "version": "2.0.2",
@@ -16195,33 +15192,6 @@
       "dev": true,
       "requires": {
         "through2": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "sprintf-js": {
@@ -16297,23 +15267,6 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "stream-consume": {
@@ -16358,23 +15311,6 @@
         "readable-stream": "^2.3.6",
         "to-arraybuffer": "^1.0.0",
         "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "stream-shift": {
@@ -16585,19 +15521,68 @@
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "teeny-request": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.1.tgz",
-      "integrity": "sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.2.tgz",
+      "integrity": "sha512-B6fxA0fSnY/bul06NggdN1nywtr5U5Uvt96pHfTi8pi4MNe6++VUWcAAFBrcMeha94s+gULwA5WvagoSZ+AcYg==",
       "dev": true,
       "requires": {
         "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.2.0",
         "stream-events": "^1.0.5",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+          "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "temp-dir": {
@@ -16688,12 +15673,31 @@
         "source-map-support": "~0.5.12"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        },
+        }
+      }
+    },
+    "terser-webpack-plugin": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+      "dev": true,
+      "requires": {
+        "cacache": "^12.0.2",
+        "find-cache-dir": "^2.1.0",
+        "is-wsl": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^2.1.2",
+        "source-map": "^0.6.1",
+        "terser": "^4.1.2",
+        "webpack-sources": "^1.4.0",
+        "worker-farm": "^1.7.0"
+      },
+      "dependencies": {
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -16750,12 +15754,13 @@
       "dev": true
     },
     "through2": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-      "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "2 || 3"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
       }
     },
     "through2-filter": {
@@ -16766,33 +15771,6 @@
       "requires": {
         "through2": "~2.0.0",
         "xtend": "~4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "time-stamp": {
@@ -16874,12 +15852,13 @@
       }
     },
     "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^7.0.0"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "to-through": {
@@ -16889,33 +15868,6 @@
       "dev": true,
       "requires": {
         "through2": "^2.0.3"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "toidentifier": {
@@ -16931,21 +15883,13 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "tr46": {
@@ -17089,262 +16033,6 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "uglifyjs-webpack-plugin": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
-      "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
-      "dev": true,
-      "requires": {
-        "cacache": "^10.0.4",
-        "find-cache-dir": "^1.0.0",
-        "schema-utils": "^0.4.5",
-        "serialize-javascript": "^1.4.0",
-        "source-map": "^0.6.1",
-        "uglify-es": "^3.3.4",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
-      },
-      "dependencies": {
-        "cacache": {
-          "version": "10.0.4",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
-          "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.1",
-            "mississippi": "^2.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "ssri": "^5.2.4",
-            "unique-filename": "^1.1.0",
-            "y18n": "^4.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-          "dev": true
-        },
-        "concat-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          }
-        },
-        "find-cache-dir": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-          "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-          "dev": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^1.0.0",
-            "pkg-dir": "^2.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "make-dir": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "mississippi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
-          "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
-          "dev": true,
-          "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^2.0.1",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.1.0"
-          }
-        },
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "pumpify": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-          "dev": true,
-          "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "schema-utils": {
-          "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        },
-        "serialize-javascript": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-          "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "ssri": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-          "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        },
-        "uglify-es": {
-          "version": "3.3.9",
-          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-          "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-          "dev": true,
-          "requires": {
-            "commander": "~2.13.0",
-            "source-map": "~0.6.1"
-          }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
       }
@@ -17530,12 +16218,6 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-          "dev": true
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
       }
@@ -17757,54 +16439,6 @@
         "value-or-function": "^3.0.0",
         "vinyl": "^2.0.0",
         "vinyl-sourcemap": "^1.1.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "pumpify": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-          "dev": true,
-          "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "vinyl-sourcemap": {
@@ -17891,171 +16525,41 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.19.1.tgz",
-      "integrity": "sha512-j7Q/5QqZRqIFXJvC0E59ipLV5Hf6lAnS3ezC3I4HMUybwEDikQBVad5d+IpPtmaQPQArvgUZLXIN6lWijHBn4g==",
+      "version": "4.41.6",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.6.tgz",
+      "integrity": "sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.6",
-        "@webassemblyjs/helper-module-context": "1.7.6",
-        "@webassemblyjs/wasm-edit": "1.7.6",
-        "@webassemblyjs/wasm-parser": "1.7.6",
-        "acorn": "^5.6.2",
-        "acorn-dynamic-import": "^3.0.0",
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0",
-        "chrome-trace-event": "^1.0.0",
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/wasm-edit": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "acorn": "^6.2.1",
+        "ajv": "^6.10.2",
+        "ajv-keywords": "^3.4.1",
+        "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^4.0.0",
+        "eslint-scope": "^4.0.3",
         "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.3.0",
-        "loader-utils": "^1.1.0",
-        "memory-fs": "~0.4.1",
-        "micromatch": "^3.1.8",
-        "mkdirp": "~0.5.0",
-        "neo-async": "^2.5.0",
-        "node-libs-browser": "^2.0.0",
-        "schema-utils": "^0.4.4",
-        "tapable": "^1.1.0",
-        "uglifyjs-webpack-plugin": "^1.2.4",
-        "watchpack": "^1.5.0",
-        "webpack-sources": "^1.2.0"
+        "loader-runner": "^2.4.0",
+        "loader-utils": "^1.2.3",
+        "memory-fs": "^0.4.1",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.1",
+        "neo-async": "^2.6.1",
+        "node-libs-browser": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.1.3",
+        "terser-webpack-plugin": "^1.4.3",
+        "watchpack": "^1.6.0",
+        "webpack-sources": "^1.4.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
           "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "eslint-scope": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "schema-utils": {
-          "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
         }
       }
     },
@@ -18279,22 +16783,6 @@
         "write-file-atomic": "^2.4.2"
       },
       "dependencies": {
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-          "dev": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
         "write-file-atomic": {
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
@@ -18591,6 +17079,19 @@
         "archiver-utils": "^2.1.0",
         "compress-commons": "^2.1.1",
         "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "typescript": "^3.7.5",
     "upath": "^1.2.0",
     "url-search-params": "^1.1.0",
-    "webpack": "4.19.1",
+    "webpack": "^4.41.6",
     "worker-plugin": "^3.2.0"
   }
 }

--- a/test/workbox-build/node/generate-sw.js
+++ b/test/workbox-build/node/generate-sw.js
@@ -143,22 +143,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
       }});
     });
@@ -183,22 +183,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
       }});
     });
@@ -223,22 +223,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [[...importScripts]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
       }});
     });
@@ -272,22 +272,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         setCacheNameDetails: [[{prefix: cacheId}]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {directoryIndex, ignoreURLParametersMatching}]],
       }, addEventListenerValidation: (addEventListenerStub) => {
         // When skipWaiting is true, the 'message' addEventListener shouldn't be called.
@@ -319,22 +319,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }, '/one', {
           revision: null,
           url: '/two',
@@ -364,22 +364,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
       }, addEventListenerValidation: (addEventListenerStub) => {
         expect(addEventListenerStub.calledOnce).to.be.true;
@@ -416,22 +416,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
         registerRoute: [[{name: 'NavigationRoute'}]],
         NavigationRoute: [['/urlWithCacheKey', {
@@ -464,22 +464,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'link/index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'link/page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'link/page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'link/styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'link/styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'link/webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
       }});
     });
@@ -508,16 +508,16 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'link/index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'link/page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'link/page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'link/webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
       }});
     });
@@ -541,22 +541,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
         initialize: [[{}]],
       }});
@@ -585,22 +585,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
         initialize: [[{
           parameterOverrides: {
@@ -742,22 +742,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
         registerRoute: [[STRING_URL_PATTERN, {name: STRING_HANDLER}, DEFAULT_METHOD]],
       }});
@@ -783,22 +783,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
         // See https://github.com/chaijs/chai/issues/697
         registerRoute: [['params => true', {name: STRING_HANDLER}, DEFAULT_METHOD]],
@@ -857,22 +857,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
         registerRoute: [
           [REGEXP_URL_PATTERN, {name: STRING_HANDLER}, DEFAULT_METHOD],
@@ -932,22 +932,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
         registerRoute: [
           [REGEXP_URL_PATTERN, {name: handler}, DEFAULT_METHOD],
@@ -998,22 +998,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
       }});
     });
@@ -1068,22 +1068,22 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         importScripts: [],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-1.html',
-          revision: '544658ab25ee8762dc241e8b1c5ed96d',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'page-2.html',
-          revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+          revision: '32_CHARACTER_HASH',
         }, {
           url: 'webpackEntry.js',
-          revision: '5b652181a25e96f255d0490203d3c47e',
+          revision: '32_CHARACTER_HASH',
         }], {}]],
         enable: [[]],
         registerRoute: [[urlPattern, {name: handler}, 'GET']],

--- a/test/workbox-build/node/generate-sw.js
+++ b/test/workbox-build/node/generate-sw.js
@@ -140,7 +140,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         __WB_DISABLE_DEV_LOGS: undefined,
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -180,7 +180,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         __WB_DISABLE_DEV_LOGS: true,
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -220,7 +220,10 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [[...importScripts]],
+        importScripts: [
+          ['./workbox-8_CHARACTER_HASH'],
+          [...importScripts],
+        ],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -266,7 +269,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         clientsClaim: [[]],
         skipWaiting: [[]],
         setCacheNameDetails: [[{prefix: cacheId}]],
@@ -316,7 +319,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -361,7 +364,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -413,7 +416,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         createHandlerBoundToURL: [[navigateFallback]],
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -461,7 +464,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'link/index.html',
           revision: '32_CHARACTER_HASH',
@@ -505,7 +508,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'link/index.html',
           revision: '32_CHARACTER_HASH',
@@ -538,7 +541,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -582,7 +585,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -717,7 +720,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       expect(size).to.eql(0);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [STRING_HANDLER]: [[]],
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         registerRoute: [[STRING_URL_PATTERN, {name: STRING_HANDLER}, DEFAULT_METHOD]],
       }});
     });
@@ -739,7 +742,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       expect(size).to.eql(2604);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [STRING_HANDLER]: [[]],
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -780,7 +783,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       expect(size).to.eql(2604);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [STRING_HANDLER]: [[]],
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -854,7 +857,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         }]],
         ExpirationPlugin: [[firstRuntimeCachingOptions.expiration]],
         CacheableResponsePlugin: [[secondRuntimeCachingOptions.cacheableResponse]],
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -929,7 +932,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       expect(size).to.eql(2604);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [handler]: [[runtimeCachingOptions]],
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -995,7 +998,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       expect(count).to.eql(6);
       expect(size).to.eql(2604);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',
@@ -1065,7 +1068,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       expect(size).to.eql(2604);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [handler]: [[]],
-        importScripts: [],
+        importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
           url: 'index.html',
           revision: '32_CHARACTER_HASH',

--- a/test/workbox-build/node/inject-manifest.js
+++ b/test/workbox-build/node/inject-manifest.js
@@ -178,22 +178,22 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
         expectedMethodCalls: {
           precacheAndRoute: [[[{
             url: 'index.html',
-            revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'page-1.html',
-            revision: '544658ab25ee8762dc241e8b1c5ed96d',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'page-2.html',
-            revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'styles/stylesheet-1.css',
-            revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'styles/stylesheet-2.css',
-            revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'webpackEntry.js',
-            revision: '5b652181a25e96f255d0490203d3c47e',
+            revision: '32_CHARACTER_HASH',
           }]]],
         },
       });
@@ -230,22 +230,22 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
           importScripts: [['./sample-import.js']],
           precacheAndRoute: [[[{
             url: 'index.html',
-            revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'page-1.html',
-            revision: '544658ab25ee8762dc241e8b1c5ed96d',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'page-2.html',
-            revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'styles/stylesheet-1.css',
-            revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'styles/stylesheet-2.css',
-            revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'webpackEntry.js',
-            revision: '5b652181a25e96f255d0490203d3c47e',
+            revision: '32_CHARACTER_HASH',
           }]], [[
             '/extra-assets/example.1234.css',
             '/extra-assets/example-2.1234.js',
@@ -274,22 +274,22 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
         expectedMethodCalls: {
           precacheAndRoute: [[[{
             url: 'index.html',
-            revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'page-1.html',
-            revision: '544658ab25ee8762dc241e8b1c5ed96d',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'page-2.html',
-            revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'styles/stylesheet-1.css',
-            revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'styles/stylesheet-2.css',
-            revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'webpackEntry.js',
-            revision: '5b652181a25e96f255d0490203d3c47e',
+            revision: '32_CHARACTER_HASH',
           }]]],
         },
       });
@@ -314,22 +314,22 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
         expectedMethodCalls: {
           precacheAndRoute: [[[{
             url: 'index.html',
-            revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'page-1.html',
-            revision: '544658ab25ee8762dc241e8b1c5ed96d',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'page-2.html',
-            revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'styles/stylesheet-1.css',
-            revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'styles/stylesheet-2.css',
-            revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'webpackEntry.js',
-            revision: '5b652181a25e96f255d0490203d3c47e',
+            revision: '32_CHARACTER_HASH',
           }], {
             cleanURLs: true,
           }]],
@@ -360,22 +360,22 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
         expectedMethodCalls: {
           precacheAndRoute: [[[{
             url: 'index.html',
-            revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'page-1.html',
-            revision: '544658ab25ee8762dc241e8b1c5ed96d',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'page-2.html',
-            revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'styles/stylesheet-1.css',
-            revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'styles/stylesheet-2.css',
-            revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+            revision: '32_CHARACTER_HASH',
           }, {
             url: 'webpackEntry.js',
-            revision: '5b652181a25e96f255d0490203d3c47e',
+            revision: '32_CHARACTER_HASH',
           }]]],
         },
       });

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -86,14 +86,14 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
-              importScripts: [],
+              importScripts: [['./workbox-8_CHARACTER_HASH']],
               precacheAndRoute: [[[
                 {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry1-43ba396bf52f8419e349.js',
+                  url: 'entry1-20_CHARACTER_HASH.js',
                 }, {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry2-aa21f43434f29ed0c946.js',
+                  url: 'entry2-20_CHARACTER_HASH.js',
                 },
               ], {}]],
             },
@@ -116,7 +116,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           imported: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         },
         output: {
-          filename: '[name]-[chunkhash].js',
+          filename: '[name]-[chunkhash:20].js',
           path: outputDir,
         },
         plugins: [
@@ -146,12 +146,13 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             swFile, expectedMethodCalls: {
               // imported-[chunkhash].js.map should *not* be included.
               importScripts: [
-                ['imported-1f6b183815996bd3f526.js'],
+                ['./workbox-8_CHARACTER_HASH'],
+                ['imported-20_CHARACTER_HASH.js'],
               ],
               // imported-[chunkhash].js should *not* be included.
               precacheAndRoute: [[[{
                 revision: '32_CHARACTER_HASH',
-                url: 'main-01a6ea3dea62d17888bb.js',
+                url: 'main-20_CHARACTER_HASH.js',
               }], {}]],
             },
           });
@@ -200,14 +201,14 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
-              importScripts: [],
+              importScripts: [['./workbox-8_CHARACTER_HASH']],
               precacheAndRoute: [[[
                 {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry1-43ba396bf52f8419e349.js',
+                  url: 'entry1-20_CHARACTER_HASH.js',
                 }, {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry2-aa21f43434f29ed0c946.js',
+                  url: 'entry2-20_CHARACTER_HASH.js',
                 }, {
                   revision: null,
                   url: 'one',
@@ -259,14 +260,14 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[
               {
                 revision: '32_CHARACTER_HASH',
-                url: 'entry1-46499ea335097c2d5d28.js',
+                url: 'entry1-20_CHARACTER_HASH.js',
               }, {
                 revision: '32_CHARACTER_HASH',
-                url: 'entry2-3b4a9899eba6f4fd5880.js',
+                url: 'entry2-20_CHARACTER_HASH.js',
               },
             ], {}]],
           }});
@@ -312,7 +313,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(4);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[
               {
                 revision: '32_CHARACTER_HASH',
@@ -361,14 +362,14 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[
               {
                 revision: '32_CHARACTER_HASH',
-                url: 'entry1-46499ea335097c2d5d28.js',
+                url: 'entry1-20_CHARACTER_HASH.js',
               }, {
                 revision: '32_CHARACTER_HASH',
-                url: 'entry2-3b4a9899eba6f4fd5880.js',
+                url: 'entry2-20_CHARACTER_HASH.js',
               },
             ], {}]],
           }});
@@ -411,11 +412,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[
               {
                 revision: '32_CHARACTER_HASH',
-                url: 'entry1-46499ea335097c2d5d28.js',
+                url: 'entry1-20_CHARACTER_HASH.js',
               },
             ], {}]],
           }});
@@ -457,14 +458,14 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[
               {
                 revision: '32_CHARACTER_HASH',
-                url: 'entry1-43ba396bf52f8419e349.js',
+                url: 'entry1-20_CHARACTER_HASH.js',
               }, {
                 revision: '32_CHARACTER_HASH',
-                url: 'entry2-aa21f43434f29ed0c946.js',
+                url: 'entry2-20_CHARACTER_HASH.js',
               }, {
                 revision: '32_CHARACTER_HASH',
                 url: 'index.html',
@@ -510,7 +511,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
-              importScripts: [],
+              importScripts: [['./workbox-8_CHARACTER_HASH']],
               precacheAndRoute: [[[
                 {
                   revision: '32_CHARACTER_HASH',
@@ -589,7 +590,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(9);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[{
               revision: '32_CHARACTER_HASH',
               url: 'manifest.json',
@@ -636,7 +637,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(6);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[{
               revision: '32_CHARACTER_HASH',
               url: 'webpackEntry.js',
@@ -683,7 +684,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(11);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[{
               revision: '32_CHARACTER_HASH',
               url: 'index.html',
@@ -734,7 +735,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(11);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[{
               revision: '32_CHARACTER_HASH',
               url: 'page-1.html',
@@ -780,7 +781,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[{
               revision: '32_CHARACTER_HASH',
               url: 'webpackEntry.js',
@@ -830,11 +831,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
-              importScripts: [],
+              importScripts: [['./workbox-8_CHARACTER_HASH']],
               precacheAndRoute: [[[
                 {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry1-534729ef1c2ff611b64f.js',
+                  url: 'entry1-20_CHARACTER_HASH.js',
                 },
               ], {}]],
             },
@@ -888,11 +889,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(12);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[
               {
                 revision: '32_CHARACTER_HASH',
-                url: 'entry1-534729ef1c2ff611b64f.js',
+                url: 'entry1-20_CHARACTER_HASH.js',
               },
               {
                 revision: '32_CHARACTER_HASH',
@@ -966,11 +967,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[
               {
                 revision: '32_CHARACTER_HASH',
-                url: '/testing/entry1-4357f117964871c288d9.js',
+                url: '/testing/entry1-20_CHARACTER_HASH.js',
               },
             ], {}]],
           }});
@@ -1111,7 +1112,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           await validateServiceWorkerRuntime({
             swFile: sw1File,
             expectedMethodCalls: {
-              importScripts: [],
+              importScripts: [['./workbox-8_CHARACTER_HASH']],
               precacheAndRoute: [[[{
                 revision: '32_CHARACTER_HASH',
                 url: 'index.js',
@@ -1122,7 +1123,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           await validateServiceWorkerRuntime({
             swFile: sw2File,
             expectedMethodCalls: {
-              importScripts: [],
+              importScripts: [['./workbox-8_CHARACTER_HASH']],
               precacheAndRoute: [[[{
                 revision: '32_CHARACTER_HASH',
                 url: 'index.js',
@@ -1252,12 +1253,12 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         mode: 'production',
         entry: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
-          filename: '[name].[hash:6].js',
+          filename: '[name].[hash:20].js',
           path: outputDir,
         },
         plugins: [
           new GenerateSW({
-            dontCacheBustURLsMatching: /\.[0-9a-f]{6}\./,
+            dontCacheBustURLsMatching: /\.[0-9a-f]{20}\./,
           }),
         ],
       };
@@ -1272,9 +1273,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[{
-              url: 'main.f70b1e.js',
+              url: 'main.20_CHARACTER_HASH.js',
               revision: null,
             }], {}]],
           }});
@@ -1292,7 +1293,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         mode: 'production',
         entry: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
-          filename: '[name].[hash:6].js',
+          filename: '[name].[hash:20].js',
           path: outputDir,
           publicPath: '/public/',
         },
@@ -1315,10 +1316,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[{
               revision: '32_CHARACTER_HASH',
-              url: 'https://example.org/main.a3c534.js',
+              url: 'https://example.org/main.20_CHARACTER_HASH.js',
             }], {}]],
           }});
 
@@ -1336,7 +1337,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         mode: 'production',
         entry: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
-          filename: '[name].[hash:6].js',
+          filename: '[name].[hash:20].js',
           path: outputDir,
         },
         plugins: [
@@ -1344,7 +1345,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             manifestTransforms: [(manifest, compilation) => {
               expect(manifest).to.have.lengthOf(1);
               expect(manifest[0].size).to.eql(930);
-              expect(manifest[0].url).to.eql('main.f70b1e.js');
+              expect(manifest[0].url.startsWith('main.')).to.be.true;
               expect(manifest[0].revision).to.have.lengthOf(32);
               expect(compilation).to.exist;
 
@@ -1376,10 +1377,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [],
+            importScripts: [['./workbox-8_CHARACTER_HASH']],
             precacheAndRoute: [[[{
               revision: null,
-              url: 'main.f70b1e.js-suffix',
+              url: 'main.20_CHARACTER_HASH.js-suffix',
             }], {}]],
           }});
 

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -89,10 +89,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
               importScripts: [],
               precacheAndRoute: [[[
                 {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry1-43ba396bf52f8419e349.js',
                 }, {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry2-aa21f43434f29ed0c946.js',
                 },
               ], {}]],
@@ -150,7 +150,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
               ],
               // imported-[chunkhash].js should *not* be included.
               precacheAndRoute: [[[{
-                revision: '39e9dd73c0daacacec3ea359cd47394a',
+                revision: '32_CHARACTER_HASH',
                 url: 'main-01a6ea3dea62d17888bb.js',
               }], {}]],
             },
@@ -178,9 +178,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         plugins: [
           new GenerateSW({
             additionalManifestEntries: [
-              '/one',
-              {url: '/two', revision: null},
-              {url: '/three', revision: '333'},
+              {url: 'one', revision: null},
+              {url: 'two', revision: null},
+              {url: 'three', revision: '333'},
             ],
           }),
         ],
@@ -193,8 +193,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           const statsJson = stats.toJson();
           expect(webpackError).not.to.exist;
           expect(statsJson.errors).to.be.empty;
-          // The string additionalManifestEntries entry should lead to one warning.
-          expect(statsJson.warnings).to.have.length(1);
+          expect(statsJson.warnings).to.have.length(0);
 
           const files = await globby(outputDir);
           expect(files).to.have.length(4);
@@ -204,17 +203,20 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
               importScripts: [],
               precacheAndRoute: [[[
                 {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry1-43ba396bf52f8419e349.js',
                 }, {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry2-aa21f43434f29ed0c946.js',
-                }, '/one', {
-                  revision: '333',
-                  url: '/three',
                 }, {
                   revision: null,
-                  url: '/two',
+                  url: 'one',
+                }, {
+                  revision: '333',
+                  url: 'three',
+                }, {
+                  revision: null,
+                  url: 'two',
                 },
               ], {}]],
             },
@@ -260,10 +262,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             importScripts: [],
             precacheAndRoute: [[[
               {
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'entry1-46499ea335097c2d5d28.js',
               }, {
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'entry2-3b4a9899eba6f4fd5880.js',
               },
             ], {}]],
@@ -313,10 +315,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             importScripts: [],
             precacheAndRoute: [[[
               {
-                revision: '112b1ad19c141f739a7ef2b803e83a6d',
+                revision: '32_CHARACTER_HASH',
                 url: 'main.js',
               }, {
-                revision: '279ad728ece4fb6ea9c9e884bb3179a3',
+                revision: '32_CHARACTER_HASH',
                 url: 'vendors~main.js',
               },
             ], {}]],
@@ -362,10 +364,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             importScripts: [],
             precacheAndRoute: [[[
               {
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'entry1-46499ea335097c2d5d28.js',
               }, {
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'entry2-3b4a9899eba6f4fd5880.js',
               },
             ], {}]],
@@ -412,7 +414,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             importScripts: [],
             precacheAndRoute: [[[
               {
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'entry1-46499ea335097c2d5d28.js',
               },
             ], {}]],
@@ -458,13 +460,13 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             importScripts: [],
             precacheAndRoute: [[[
               {
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'entry1-43ba396bf52f8419e349.js',
               }, {
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'entry2-aa21f43434f29ed0c946.js',
               }, {
-                revision: 'ebc41a064b42558847b35b3ec152df5d',
+                revision: '32_CHARACTER_HASH',
                 url: 'index.html',
               },
             ], {}]],
@@ -511,39 +513,39 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
               importScripts: [],
               precacheAndRoute: [[[
                 {
-                  revision: '452b0a9f3978190f4c77997ab23473db',
+                  revision: '32_CHARACTER_HASH',
                   url: 'images/example-jpeg.jpg',
                 },
                 {
-                  revision: '93ffb20d77327583892ca47f597b77aa',
+                  revision: '32_CHARACTER_HASH',
                   url: 'images/web-fundamentals-icon192x192.png',
                 },
                 {
-                  revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+                  revision: '32_CHARACTER_HASH',
                   url: 'index.html',
                 },
                 {
-                  revision: '544658ab25ee8762dc241e8b1c5ed96d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'page-1.html',
                 },
                 {
-                  revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+                  revision: '32_CHARACTER_HASH',
                   url: 'page-2.html',
                 },
                 {
-                  revision: '54befe539fc77e7b88106abd6ae0fc9c',
+                  revision: '32_CHARACTER_HASH',
                   url: 'splitChunksEntry.js',
                 },
                 {
-                  revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+                  revision: '32_CHARACTER_HASH',
                   url: 'styles/stylesheet-1.css',
                 },
                 {
-                  revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+                  revision: '32_CHARACTER_HASH',
                   url: 'styles/stylesheet-2.css',
                 },
                 {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'webpackEntry.js',
                 },
               ], {}]],
@@ -589,13 +591,13 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [],
             precacheAndRoute: [[[{
-              revision: '4b1eb3dc48c4e16d49db5b42298fe654',
+              revision: '32_CHARACTER_HASH',
               url: 'manifest.json',
             }, {
-              revision: 'aef75af28f6de0771a8d6bae84d9e71d',
+              revision: '32_CHARACTER_HASH',
               url: 'not-ignored.js',
             }, {
-              revision: '35ecfdff688561581ddd68a107ef1c46',
+              revision: '32_CHARACTER_HASH',
               url: 'webpackEntry.js',
             }], {}]],
           }});
@@ -636,10 +638,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [],
             precacheAndRoute: [[[{
-              revision: '35ecfdff688561581ddd68a107ef1c46',
+              revision: '32_CHARACTER_HASH',
               url: 'webpackEntry.js',
             }, {
-              revision: '258242b5a4bd3172868f906ad1b16a6e',
+              revision: '32_CHARACTER_HASH',
               url: 'webpackEntry.js.map',
             }], {}]],
           }});
@@ -683,13 +685,13 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [],
             precacheAndRoute: [[[{
-              revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+              revision: '32_CHARACTER_HASH',
               url: 'index.html',
             }, {
-              revision: '544658ab25ee8762dc241e8b1c5ed96d',
+              revision: '32_CHARACTER_HASH',
               url: 'page-1.html',
             }, {
-              revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+              revision: '32_CHARACTER_HASH',
               url: 'page-2.html',
             }], {}]],
           }});
@@ -734,10 +736,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [],
             precacheAndRoute: [[[{
-              revision: '544658ab25ee8762dc241e8b1c5ed96d',
+              revision: '32_CHARACTER_HASH',
               url: 'page-1.html',
             }, {
-              revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+              revision: '32_CHARACTER_HASH',
               url: 'page-2.html',
             }], {}]],
           }});
@@ -780,7 +782,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [],
             precacheAndRoute: [[[{
-              revision: '0fae6a991467bd40263a3ba8cd82835d',
+              revision: '32_CHARACTER_HASH',
               url: 'webpackEntry.js',
             }], {}]],
           }});
@@ -831,7 +833,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
               importScripts: [],
               precacheAndRoute: [[[
                 {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry1-534729ef1c2ff611b64f.js',
                 },
               ], {}]],
@@ -889,39 +891,39 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             importScripts: [],
             precacheAndRoute: [[[
               {
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'entry1-534729ef1c2ff611b64f.js',
               },
               {
-                revision: '93ffb20d77327583892ca47f597b77aa',
+                revision: '32_CHARACTER_HASH',
                 url: 'images/web-fundamentals-icon192x192.png',
               },
               {
-                revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+                revision: '32_CHARACTER_HASH',
                 url: 'index.html',
               },
               {
-                revision: '544658ab25ee8762dc241e8b1c5ed96d',
+                revision: '32_CHARACTER_HASH',
                 url: 'page-1.html',
               },
               {
-                revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+                revision: '32_CHARACTER_HASH',
                 url: 'page-2.html',
               },
               {
-                revision: '54befe539fc77e7b88106abd6ae0fc9c',
+                revision: '32_CHARACTER_HASH',
                 url: 'splitChunksEntry.js',
               },
               {
-                revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+                revision: '32_CHARACTER_HASH',
                 url: 'styles/stylesheet-1.css',
               },
               {
-                revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+                revision: '32_CHARACTER_HASH',
                 url: 'styles/stylesheet-2.css',
               },
               {
-                revision: 'd5242cbe60934575bd2d4f4161aeada1',
+                revision: '32_CHARACTER_HASH',
                 url: 'webpackEntry.js',
               },
             ], {}]],
@@ -967,7 +969,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             importScripts: [],
             precacheAndRoute: [[[
               {
-                revision: 'c00d58015497c84d6fa4eaa9ee31678d',
+                revision: '32_CHARACTER_HASH',
                 url: '/testing/entry1-4357f117964871c288d9.js',
               },
             ], {}]],
@@ -1111,7 +1113,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             expectedMethodCalls: {
               importScripts: [],
               precacheAndRoute: [[[{
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'index.js',
               }], {}]],
             },
@@ -1122,7 +1124,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             expectedMethodCalls: {
               importScripts: [],
               precacheAndRoute: [[[{
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'index.js',
               }], {}]],
             },
@@ -1315,7 +1317,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [],
             precacheAndRoute: [[[{
-              revision: 'eeb107dbf9e69f1a6184e616f38bab47',
+              revision: '32_CHARACTER_HASH',
               url: 'https://example.org/main.a3c534.js',
             }], {}]],
           }});
@@ -1340,16 +1342,15 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         plugins: [
           new GenerateSW({
             manifestTransforms: [(manifest, compilation) => {
-              expect(manifest).to.eql([{
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
-                size: 930,
-                url: 'main.f70b1e.js',
-              }]);
+              expect(manifest).to.have.lengthOf(1);
+              expect(manifest[0].size).to.eql(930);
+              expect(manifest[0].url).to.eql('main.f70b1e.js');
+              expect(manifest[0].revision).to.have.lengthOf(32);
               expect(compilation).to.exist;
 
               manifest = manifest.map((entry) => {
                 entry.url += '-suffix';
-                delete entry.revision;
+                entry.revision = null;
                 return entry;
               });
 
@@ -1368,7 +1369,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           expect(webpackError).not.to.exist;
           const statsJson = stats.toJson();
-          expect(statsJson.errors).to.be.empty;
+          expect(statsJson.errors, JSON.stringify(statsJson.errors)).to.be.empty;
           expect(statsJson.warnings).to.have.members([warningMessage]);
 
           const files = await globby(outputDir);
@@ -1377,6 +1378,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [],
             precacheAndRoute: [[[{
+              revision: null,
               url: 'main.f70b1e.js-suffix',
             }], {}]],
           }});

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -97,10 +97,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
               precacheAndRoute: [[[
                 {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry1-43ba396bf52f8419e349.js',
+                  url: 'entry1-20_CHARACTER_HASH.js',
                 }, {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry2-aa21f43434f29ed0c946.js',
+                  url: 'entry2-20_CHARACTER_HASH.js',
                 },
               ], {}]],
             },
@@ -151,10 +151,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
               precacheAndRoute: [[[
                 {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry1-46499ea335097c2d5d28.js',
+                  url: 'entry1-20_CHARACTER_HASH.js',
                 }, {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry2-3b4a9899eba6f4fd5880.js',
+                  url: 'entry2-20_CHARACTER_HASH.js',
                 },
               ], {}]],
             },
@@ -263,10 +263,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
               precacheAndRoute: [[[
                 {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry1-46499ea335097c2d5d28.js',
+                  url: 'entry1-20_CHARACTER_HASH.js',
                 }, {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry2-3b4a9899eba6f4fd5880.js',
+                  url: 'entry2-20_CHARACTER_HASH.js',
                 },
               ], {}]],
             },
@@ -318,7 +318,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
               precacheAndRoute: [[[
                 {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry1-46499ea335097c2d5d28.js',
+                  url: 'entry1-20_CHARACTER_HASH.js',
                 },
               ], {}]],
             },
@@ -370,10 +370,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
               precacheAndRoute: [[[
                 {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry1-43ba396bf52f8419e349.js',
+                  url: 'entry1-20_CHARACTER_HASH.js',
                 }, {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry2-aa21f43434f29ed0c946.js',
+                  url: 'entry2-20_CHARACTER_HASH.js',
                 }, {
                   revision: '32_CHARACTER_HASH',
                   url: 'index.html',
@@ -505,6 +505,11 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           const expectedSourcemap = await fse.readJSON(
               upath.join(__dirname, '..', 'static', 'expected-service-worker.js.map'));
           const actualSourcemap = await fse.readJSON(upath.join(outputDir, 'service-worker.js.map'));
+
+          // The mappings will vary depending on the webpack version.
+          delete expectedSourcemap.mappings;
+          delete actualSourcemap.mappings;
+
           expect(actualSourcemap).to.eql(expectedSourcemap);
 
           await validateServiceWorkerRuntime({
@@ -559,6 +564,11 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
               upath.join(__dirname, '..', 'static', 'expected-service-worker.js.map'));
           const actualSourcemap = await fse.readJSON(
               upath.join(outputDir, 'subdir', 'service-worker.js.map'));
+          
+          // The mappings will vary depending on the webpack version.
+          delete expectedSourcemap.mappings;
+          delete actualSourcemap.mappings;
+
           expect(actualSourcemap).to.eql(expectedSourcemap);
 
           await validateServiceWorkerRuntime({
@@ -931,7 +941,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
               precacheAndRoute: [[[
                 {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry1-534729ef1c2ff611b64f.js',
+                  url: 'entry1-20_CHARACTER_HASH.js',
                 },
               ], {}]],
             },
@@ -993,7 +1003,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
               precacheAndRoute: [[[
                 {
                   revision: '32_CHARACTER_HASH',
-                  url: 'entry1-534729ef1c2ff611b64f.js',
+                  url: 'entry1-20_CHARACTER_HASH.js',
                 },
                 {
                   revision: '32_CHARACTER_HASH',
@@ -1077,7 +1087,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
               precacheAndRoute: [[[
                 {
                   revision: '32_CHARACTER_HASH',
-                  url: '/testing/entry1-4357f117964871c288d9.js',
+                  url: '/testing/entry1-20_CHARACTER_HASH.js',
                 },
               ], {}]],
             },
@@ -1142,14 +1152,14 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         mode: 'production',
         entry: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
-          filename: '[name].[hash:6].js',
+          filename: '[name].[hash:20].js',
           path: outputDir,
         },
         plugins: [
           new InjectManifest({
             swSrc: SW_SRC,
             swDest: 'service-worker.js',
-            dontCacheBustURLsMatching: /\.[0-9a-f]{6}\./,
+            dontCacheBustURLsMatching: /\.[0-9a-f]{20}\./,
           }),
         ],
       };
@@ -1168,7 +1178,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                url: 'main.8be1a4.js',
+                url: 'main.20_CHARACTER_HASH.js',
                 revision: null,
               }], {}]],
             },
@@ -1187,7 +1197,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         mode: 'production',
         entry: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
-          filename: '[name].[hash:6].js',
+          filename: '[name].[hash:20].js',
           path: outputDir,
           publicPath: '/public/',
         },
@@ -1217,7 +1227,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[{
                 revision: '32_CHARACTER_HASH',
-                url: 'https://example.org/main.ee21b0.js',
+                url: 'https://example.org/main.20_CHARACTER_HASH.js',
               }], {}]],
             },
           });
@@ -1236,7 +1246,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         mode: 'production',
         entry: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
-          filename: '[name].[hash:6].js',
+          filename: '[name].[hash:20].js',
           path: outputDir,
         },
         plugins: [
@@ -1246,7 +1256,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             manifestTransforms: [(manifest, compilation) => {
               expect(manifest).to.have.lengthOf(1);
               expect(manifest[0].size).to.eql(930);
-              expect(manifest[0].url).to.eql('main.8be1a4.js');
+              expect(manifest[0].url.startsWith('main.')).to.be.true;
               expect(manifest[0].revision).to.have.lengthOf(32);
               expect(compilation).to.exist;
 
@@ -1283,7 +1293,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[{
                 revision: null,
-                url: 'main.8be1a4.js-suffix',
+                url: 'main.20_CHARACTER_HASH.js-suffix',
               }], {}]],
             },
           });
@@ -1389,7 +1399,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         mode: 'production',
         entry: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
-          filename: '[name].[hash:6].js',
+          filename: '[name].[hash:20].js',
           path: outputDir,
         },
         plugins: [
@@ -1423,7 +1433,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[{
                 revision: '32_CHARACTER_HASH',
-                url: 'main.94b7e7.js',
+                url: 'main.20_CHARACTER_HASH.js',
               }], {}]],
             },
           });
@@ -1434,7 +1444,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[{
                 revision: '32_CHARACTER_HASH',
-                url: 'main.94b7e7.js',
+                url: 'main.20_CHARACTER_HASH.js',
               }], {}]],
             },
           });
@@ -1454,7 +1464,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         mode: 'development',
         entry: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
         output: {
-          filename: '[name].[hash:6].js',
+          filename: '[name].[hash:20].js',
           path: outputDir,
         },
         plugins: [
@@ -1482,7 +1492,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[{
                 revision: '32_CHARACTER_HASH',
-                url: 'main.43096b.js',
+                url: 'main.20_CHARACTER_HASH.js',
               }], {}]],
             },
           });

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -96,10 +96,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry1-43ba396bf52f8419e349.js',
                 }, {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry2-aa21f43434f29ed0c946.js',
                 },
               ], {}]],
@@ -150,10 +150,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry1-46499ea335097c2d5d28.js',
                 }, {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry2-3b4a9899eba6f4fd5880.js',
                 },
               ], {}]],
@@ -208,10 +208,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '112b1ad19c141f739a7ef2b803e83a6d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'main.js',
                 }, {
-                  revision: '279ad728ece4fb6ea9c9e884bb3179a3',
+                  revision: '32_CHARACTER_HASH',
                   url: 'vendors~main.js',
                 },
               ], {}]],
@@ -262,10 +262,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry1-46499ea335097c2d5d28.js',
                 }, {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry2-3b4a9899eba6f4fd5880.js',
                 },
               ], {}]],
@@ -317,7 +317,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry1-46499ea335097c2d5d28.js',
                 },
               ], {}]],
@@ -369,13 +369,13 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry1-43ba396bf52f8419e349.js',
                 }, {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry2-aa21f43434f29ed0c946.js',
                 }, {
-                  revision: 'ebc41a064b42558847b35b3ec152df5d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'index.html',
                 },
               ], {}]],
@@ -427,39 +427,39 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '452b0a9f3978190f4c77997ab23473db',
+                  revision: '32_CHARACTER_HASH',
                   url: 'images/example-jpeg.jpg',
                 },
                 {
-                  revision: '93ffb20d77327583892ca47f597b77aa',
+                  revision: '32_CHARACTER_HASH',
                   url: 'images/web-fundamentals-icon192x192.png',
                 },
                 {
-                  revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+                  revision: '32_CHARACTER_HASH',
                   url: 'index.html',
                 },
                 {
-                  revision: '544658ab25ee8762dc241e8b1c5ed96d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'page-1.html',
                 },
                 {
-                  revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+                  revision: '32_CHARACTER_HASH',
                   url: 'page-2.html',
                 },
                 {
-                  revision: '54befe539fc77e7b88106abd6ae0fc9c',
+                  revision: '32_CHARACTER_HASH',
                   url: 'splitChunksEntry.js',
                 },
                 {
-                  revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+                  revision: '32_CHARACTER_HASH',
                   url: 'styles/stylesheet-1.css',
                 },
                 {
-                  revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+                  revision: '32_CHARACTER_HASH',
                   url: 'styles/stylesheet-2.css',
                 },
                 {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'webpackEntry.js',
                 },
               ], {}]],
@@ -512,7 +512,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '35ecfdff688561581ddd68a107ef1c46',
+                revision: '32_CHARACTER_HASH',
                 url: 'webpackEntry.js',
               }], {}]],
             },
@@ -566,7 +566,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: 'cbdf84623d52128c960fd35af74cdfbc',
+                revision: '32_CHARACTER_HASH',
                 url: 'webpackEntry.js',
               }], {}]],
             },
@@ -613,7 +613,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: 'f59ecc599c17c2bbc03a212969e13ee7',
+                revision: '32_CHARACTER_HASH',
                 url: 'webpackEntry.js',
               }], {}]],
             },
@@ -663,13 +663,13 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '4b1eb3dc48c4e16d49db5b42298fe654',
+                revision: '32_CHARACTER_HASH',
                 url: 'manifest.json',
               }, {
-                revision: 'aef75af28f6de0771a8d6bae84d9e71d',
+                revision: '32_CHARACTER_HASH',
                 url: 'not-ignored.js',
               }, {
-                revision: '35ecfdff688561581ddd68a107ef1c46',
+                revision: '32_CHARACTER_HASH',
                 url: 'webpackEntry.js',
               }], {}]],
             },
@@ -715,13 +715,13 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: 'ef4249bca2fd87d9078f1be3fce8d2d5',
+                revision: '32_CHARACTER_HASH',
                 url: 'service-worker.js.map',
               }, {
-                revision: '35ecfdff688561581ddd68a107ef1c46',
+                revision: '32_CHARACTER_HASH',
                 url: 'webpackEntry.js',
               }, {
-                revision: '258242b5a4bd3172868f906ad1b16a6e',
+                revision: '32_CHARACTER_HASH',
                 url: 'webpackEntry.js.map',
               }], {}]],
             },
@@ -770,13 +770,13 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+                revision: '32_CHARACTER_HASH',
                 url: 'index.html',
               }, {
-                revision: '544658ab25ee8762dc241e8b1c5ed96d',
+                revision: '32_CHARACTER_HASH',
                 url: 'page-1.html',
               }, {
-                revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+                revision: '32_CHARACTER_HASH',
                 url: 'page-2.html',
               }], {}]],
             },
@@ -826,10 +826,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '544658ab25ee8762dc241e8b1c5ed96d',
+                revision: '32_CHARACTER_HASH',
                 url: 'page-1.html',
               }, {
-                revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+                revision: '32_CHARACTER_HASH',
                 url: 'page-2.html',
               }], {}]],
             },
@@ -875,7 +875,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'webpackEntry.js',
               }], {}]],
             },
@@ -930,7 +930,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry1-534729ef1c2ff611b64f.js',
                 },
               ], {}]],
@@ -992,39 +992,39 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '0fae6a991467bd40263a3ba8cd82835d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'entry1-534729ef1c2ff611b64f.js',
                 },
                 {
-                  revision: '93ffb20d77327583892ca47f597b77aa',
+                  revision: '32_CHARACTER_HASH',
                   url: 'images/web-fundamentals-icon192x192.png',
                 },
                 {
-                  revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+                  revision: '32_CHARACTER_HASH',
                   url: 'index.html',
                 },
                 {
-                  revision: '544658ab25ee8762dc241e8b1c5ed96d',
+                  revision: '32_CHARACTER_HASH',
                   url: 'page-1.html',
                 },
                 {
-                  revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+                  revision: '32_CHARACTER_HASH',
                   url: 'page-2.html',
                 },
                 {
-                  revision: '54befe539fc77e7b88106abd6ae0fc9c',
+                  revision: '32_CHARACTER_HASH',
                   url: 'splitChunksEntry.js',
                 },
                 {
-                  revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+                  revision: '32_CHARACTER_HASH',
                   url: 'styles/stylesheet-1.css',
                 },
                 {
-                  revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+                  revision: '32_CHARACTER_HASH',
                   url: 'styles/stylesheet-2.css',
                 },
                 {
-                  revision: 'd5242cbe60934575bd2d4f4161aeada1',
+                  revision: '32_CHARACTER_HASH',
                   url: 'webpackEntry.js',
                 },
               ], {}]],
@@ -1076,7 +1076,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: 'c00d58015497c84d6fa4eaa9ee31678d',
+                  revision: '32_CHARACTER_HASH',
                   url: '/testing/entry1-4357f117964871c288d9.js',
                 },
               ], {}]],
@@ -1216,7 +1216,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: 'eeb107dbf9e69f1a6184e616f38bab47',
+                revision: '32_CHARACTER_HASH',
                 url: 'https://example.org/main.ee21b0.js',
               }], {}]],
             },
@@ -1244,16 +1244,15 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             swSrc: SW_SRC,
             swDest: 'service-worker.js',
             manifestTransforms: [(manifest, compilation) => {
-              expect(manifest).to.eql([{
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
-                size: 930,
-                url: 'main.8be1a4.js',
-              }]);
+              expect(manifest).to.have.lengthOf(1);
+              expect(manifest[0].size).to.eql(930);
+              expect(manifest[0].url).to.eql('main.8be1a4.js');
+              expect(manifest[0].revision).to.have.lengthOf(32);
               expect(compilation).to.exist;
 
               manifest = manifest.map((entry) => {
                 entry.url += '-suffix';
-                delete entry.revision;
+                entry.revision = null;
                 return entry;
               });
 
@@ -1283,6 +1282,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
+                revision: null,
                 url: 'main.8be1a4.js-suffix',
               }], {}]],
             },
@@ -1422,7 +1422,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'main.94b7e7.js',
               }], {}]],
             },
@@ -1433,7 +1433,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '0fae6a991467bd40263a3ba8cd82835d',
+                revision: '32_CHARACTER_HASH',
                 url: 'main.94b7e7.js',
               }], {}]],
             },
@@ -1481,7 +1481,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: 'a2baa2e58fe291932f000f0217579e97',
+                revision: '32_CHARACTER_HASH',
                 url: 'main.43096b.js',
               }], {}]],
             },

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -564,7 +564,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
               upath.join(__dirname, '..', 'static', 'expected-service-worker.js.map'));
           const actualSourcemap = await fse.readJSON(
               upath.join(outputDir, 'subdir', 'service-worker.js.map'));
-          
+
           // The mappings will vary depending on the webpack version.
           delete expectedSourcemap.mappings;
           delete actualSourcemap.mappings;


### PR DESCRIPTION
R: @philipwalton

Fixes #2362 

This moves from hardcoded hashes in our validation to special string constants, like `20_CHARACTER_HASH`.

It allows use to move from a pinned version of `webpack` that our tests needed to be run against to using whatever the latest version is. It should also help with re-enabling our Windows tests, which tended to generate different hashes.