### PR TITLE
Include the hash in our "friendly" URL logging

### DIFF
--- a/packages/workbox-core/src/_private/getFriendlyURL.ts
+++ b/packages/workbox-core/src/_private/getFriendlyURL.ts
@@ -10,10 +10,9 @@ import '../_version.js';
 
 const getFriendlyURL = (url: URL | string) => {
   const urlObj = new URL(String(url), location.href);
-  if (urlObj.origin === location.origin) {
-    return urlObj.pathname + urlObj.hash;
-  }
-  return urlObj.href;
+  // See https://github.com/GoogleChrome/workbox/issues/2323
+  // We want to include everything, except for the origin if it's same-origin.
+  return urlObj.href.replace(new RegExp(`^${location.origin}`), '');
 };
 
 export {getFriendlyURL};

--- a/packages/workbox-core/src/_private/getFriendlyURL.ts
+++ b/packages/workbox-core/src/_private/getFriendlyURL.ts
@@ -11,7 +11,7 @@ import '../_version.js';
 const getFriendlyURL = (url: URL | string) => {
   const urlObj = new URL(String(url), location.href);
   if (urlObj.origin === location.origin) {
-    return urlObj.pathname;
+    return urlObj.pathname + urlObj.hash;
   }
   return urlObj.href;
 };

--- a/test/workbox-core/sw/_private/test-getFriendlyURL.mjs
+++ b/test/workbox-core/sw/_private/test-getFriendlyURL.mjs
@@ -27,6 +27,18 @@ describe(`getFriendlyURL()`, function() {
     expect(url).to.equal('/hi#test');
   });
 
+  it(`should include the URL's search in the returned string`, function() {
+    const fullURL = new URL('/hi?one=two', self.location).toString();
+    const url = getFriendlyURL(fullURL);
+    expect(url).to.equal('/hi?one=two');
+  });
+
+  it(`should include the URL's search and hash in the returned string`, function() {
+    const fullURL = new URL('/hi?one=two#test', self.location).toString();
+    const url = getFriendlyURL(fullURL);
+    expect(url).to.equal('/hi?one=two#test');
+  });
+
   it(`should return full URL for external origin 'https://external-example.com/example'`, function() {
     const url = getFriendlyURL('https://external-example.com/example');
     expect(url).to.equal('https://external-example.com/example');

--- a/test/workbox-core/sw/_private/test-getFriendlyURL.mjs
+++ b/test/workbox-core/sw/_private/test-getFriendlyURL.mjs
@@ -21,6 +21,12 @@ describe(`getFriendlyURL()`, function() {
     expect(url).to.equal('/hi');
   });
 
+  it(`should include the URL's hash in the returned string`, function() {
+    const fullURL = new URL('/hi#test', self.location).toString();
+    const url = getFriendlyURL(fullURL);
+    expect(url).to.equal('/hi#test');
+  });
+
   it(`should return full URL for external origin 'https://external-example.com/example'`, function() {
     const url = getFriendlyURL('https://external-example.com/example');
     expect(url).to.equal('https://external-example.com/example');


### PR DESCRIPTION
R: @philipwalton

Fixes #2323 by including the `hash` portion of a URL in our log messages.