### PR TITLE
Enable Windows tests on GH Actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,11 @@ jobs:
       with:
         node-version: 13.x
 
-    - run: npm ci
+    - name: Setup
+      run: |
+        npm ci
+        gulp build
+
     - run: npx gulp test-node
 
   Full_Suite_Mac:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,25 +3,25 @@ name: Test Suite
 on: [pull_request]
 
 jobs:
-  # Node_Tests_Windows:
-  #   runs-on: windows-latest
+  Node_Tests_Windows:
+    runs-on: windows-latest
     
-  #   steps:
-  #   - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v2
       
-  #   - uses: actions/cache@v1
-  #     with:
-  #       path: ~/.npm
-  #       key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-  #       restore-keys: |
-  #         ${{ runner.os }}-node-
+    - uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
           
-  #   - uses: actions/setup-node@v1
-  #     with:
-  #       node-version: 13.x
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 13.x
 
-  #   - run: npm ci
-  #   - run: npx gulp test
+    - run: npm ci
+    - run: npx gulp test
 
   Full_Suite_Mac:
     runs-on: macos-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ jobs:
         node-version: 13.x
 
     - run: npm ci
-    - run: npx gulp test
+    - run: npx gulp test-node
 
   Full_Suite_Mac:
     runs-on: macos-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -4714,6 +4714,15 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-match-pattern": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/chai-match-pattern/-/chai-match-pattern-1.1.0.tgz",
+      "integrity": "sha1-TM96GQDKA/mUylpwTJKiZG0CQdM=",
+      "dev": true,
+      "requires": {
+        "lodash-match-pattern": "^2.0.1"
+      }
+    },
     "chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -4777,6 +4786,16 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
+    },
+    "checkit": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/checkit/-/checkit-0.7.0.tgz",
+      "integrity": "sha1-FJeavJMBg0a/z9y6vBmrVMC/10o=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "lodash": "^4.0.0"
+      }
     },
     "chokidar": {
       "version": "2.1.8",
@@ -11320,6 +11339,40 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
+    },
+    "lodash-checkit": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lodash-checkit/-/lodash-checkit-2.3.2.tgz",
+      "integrity": "sha512-6ye0MEIYJHl7XMRCIE1sggtTHmTd4xHqZPiGjZVm9DQOFU8k3pMGzOAzC6L7boFFJJI4sRodHR+nU6Z4f+0aeQ==",
+      "dev": true,
+      "requires": {
+        "checkit": "^0.7.0",
+        "lodash": "^4.17.15"
+      }
+    },
+    "lodash-match-pattern": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/lodash-match-pattern/-/lodash-match-pattern-2.1.1.tgz",
+      "integrity": "sha512-uSECNe5YP6etrEhrnAeL6K2Bmy+sJOvNZeEXW5xROULu0WLf9ns1eVTdr8NFsh+5npNJ+ZqO2BocDQM6i5Q6mA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "he": "^1.2.0",
+        "lodash-checkit": "^2.3.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "bytes": "^3.1.0",
     "camelcase": "^5.3.1",
     "chai": "^4.2.0",
+    "chai-match-pattern": "^1.1.0",
     "chalk": "^3.0.0",
     "clear-require": "^3.0.0",
     "comlinkjs": "^3.2.0",

--- a/test/workbox-build/node/generate-sw.js
+++ b/test/workbox-build/node/generate-sw.js
@@ -141,25 +141,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         __WB_DISABLE_DEV_LOGS: undefined,
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
       }});
     });
@@ -182,25 +182,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         __WB_DISABLE_DEV_LOGS: true,
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
       }});
     });
@@ -224,27 +224,27 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         importScripts: [
-          ['./workbox-8_CHARACTER_HASH'],
+          [/^\.\/workbox-[0-9a-f]{8}$/],
           [...importScripts],
         ],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
       }});
     });
@@ -273,28 +273,28 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         clientsClaim: [[]],
         skipWaiting: [[]],
         setCacheNameDetails: [[{prefix: cacheId}]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {directoryIndex, ignoreURLParametersMatching}]],
       }, addEventListenerValidation: (addEventListenerStub) => {
         // When skipWaiting is true, the 'message' addEventListener shouldn't be called.
@@ -324,25 +324,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, '/one', {
           revision: null,
           url: '/two',
@@ -370,25 +370,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
       }, addEventListenerValidation: (addEventListenerStub) => {
         expect(addEventListenerStub.calledOnce).to.be.true;
@@ -423,25 +423,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         createHandlerBoundToURL: [[navigateFallback]],
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
         registerRoute: [[{name: 'NavigationRoute'}]],
         NavigationRoute: [['/urlWithCacheKey', {
@@ -472,25 +472,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'link/index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'link/page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'link/page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'link/styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'link/styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'link/webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
       }});
     });
@@ -511,24 +511,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(4);
-      expect(size).to.eql(2535);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2535, 2611]);
 
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'link/index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'link/page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'link/page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'link/webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
       }});
     });
@@ -544,30 +545,31 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
         initialize: [[{}]],
       }});
@@ -594,25 +596,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
         initialize: [[{
           parameterOverrides: {
@@ -731,7 +733,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       expect(size).to.eql(0);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [STRING_HANDLER]: [[]],
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         registerRoute: [[STRING_URL_PATTERN, {name: STRING_HANDLER}, DEFAULT_METHOD]],
       }});
     });
@@ -754,25 +756,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       expect(size).to.be.oneOf([2604, 2686]);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [STRING_HANDLER]: [[]],
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
         registerRoute: [[STRING_URL_PATTERN, {name: STRING_HANDLER}, DEFAULT_METHOD]],
       }});
@@ -796,25 +798,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       expect(size).to.be.oneOf([2604, 2686]);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [STRING_HANDLER]: [[]],
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
         // See https://github.com/chaijs/chai/issues/697
         registerRoute: [['params => true', {name: STRING_HANDLER}, DEFAULT_METHOD]],
@@ -871,25 +873,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         }]],
         ExpirationPlugin: [[firstRuntimeCachingOptions.expiration]],
         CacheableResponsePlugin: [[secondRuntimeCachingOptions.cacheableResponse]],
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
         registerRoute: [
           [REGEXP_URL_PATTERN, {name: STRING_HANDLER}, DEFAULT_METHOD],
@@ -947,25 +949,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       expect(size).to.be.oneOf([2604, 2686]);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [handler]: [[runtimeCachingOptions]],
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
         registerRoute: [
           [REGEXP_URL_PATTERN, {name: handler}, DEFAULT_METHOD],
@@ -1014,25 +1016,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
       }});
     });
@@ -1085,25 +1087,25 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       expect(size).to.be.oneOf([2604, 2686]);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [handler]: [[]],
-        importScripts: [['./workbox-8_CHARACTER_HASH']],
+        importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-1.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'page-2.html',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-1.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'styles/stylesheet-2.css',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }, {
           url: 'webpackEntry.js',
-          revision: '32_CHARACTER_HASH',
+          revision: /^[0-9a-f]{32}$/,
         }], {}]],
         enable: [[]],
         registerRoute: [[urlPattern, {name: handler}, 'GET']],

--- a/test/workbox-build/node/generate-sw.js
+++ b/test/workbox-build/node/generate-sw.js
@@ -134,7 +134,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       confirmDirectoryContains(outputDir, filePaths);
 
@@ -174,7 +175,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       confirmDirectoryContains(outputDir, filePaths);
 
@@ -215,7 +217,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       confirmDirectoryContains(outputDir, filePaths);
 
@@ -264,7 +267,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       confirmDirectoryContains(outputDir, filePaths);
 
@@ -314,7 +318,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // The string additionalManifestEntries entry should lead to one warning.
       expect(warnings).to.have.length(1);
       expect(count).to.eql(9);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       confirmDirectoryContains(outputDir, filePaths);
 
@@ -359,7 +364,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       confirmDirectoryContains(outputDir, filePaths);
 
@@ -410,7 +416,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       confirmDirectoryContains(outputDir, filePaths);
 
@@ -459,7 +466,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       confirmDirectoryContains(outputDir, filePaths);
 
@@ -580,7 +588,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       confirmDirectoryContains(outputDir, filePaths);
 
@@ -623,7 +632,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       confirmDirectoryContains(outputDir, filePaths);
     });
@@ -639,7 +649,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       confirmDirectoryContains(outputDir, filePaths);
       // We can't validate the generated sw.js file, unfortunately.
@@ -739,7 +750,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [STRING_HANDLER]: [[]],
         importScripts: [['./workbox-8_CHARACTER_HASH']],
@@ -780,7 +792,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [STRING_HANDLER]: [[]],
         importScripts: [['./workbox-8_CHARACTER_HASH']],
@@ -845,7 +858,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
 
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [STRING_HANDLER]: [[{
@@ -929,7 +943,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [handler]: [[runtimeCachingOptions]],
         importScripts: [['./workbox-8_CHARACTER_HASH']],
@@ -996,7 +1011,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         importScripts: [['./workbox-8_CHARACTER_HASH']],
         precacheAndRoute: [[[{
@@ -1065,7 +1081,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, size, warnings} = await generateSW(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         [handler]: [[]],
         importScripts: [['./workbox-8_CHARACTER_HASH']],

--- a/test/workbox-build/node/get-manifest.js
+++ b/test/workbox-build/node/get-manifest.js
@@ -110,7 +110,8 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
         revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
     });
 
     it(`should use defaults when all the required parameters, and 'globPatterns' are present`, async function() {
@@ -134,7 +135,8 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
         revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(4);
-      expect(size).to.eql(2535);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2535, 2611]);
     });
 
     it(`should use defaults when all the required parameters, and 'globIgnores' are present`, async function() {
@@ -152,7 +154,8 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
         revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(2);
-      expect(size).to.eql(69);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([69, 75]);
     });
 
     it(`should use defaults when all the required parameters, 'globIgnores', and 'globPatterns' are present`, async function() {
@@ -171,7 +174,8 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
         revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(2);
-      expect(size).to.eql(217);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([217, 220]);
     });
 
     it(`should use defaults when all the required parameters, and 'maximumFileSizeToCacheInBytes' are present`, async function() {
@@ -195,7 +199,8 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
         url: 'styles/stylesheet-2.css',
       }]);
       expect(count).to.eql(4);
-      expect(size).to.eql(101);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([101, 109]);
     });
 
     it(`should use defaults when all the required parameters, and 'templatedURLs' are present`, async function() {
@@ -237,7 +242,8 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
         revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(8);
-      expect(size).to.eql(4973);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([4973, 5131]);
     });
 
     it(`should use defaults when all the required parameters, and 'manifestTransforms' are present`, async function() {
@@ -271,7 +277,8 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
         revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(2);
-      expect(size).to.eql(50);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([50, 54]);
     });
 
     it(`should use defaults when all the required parameters are present, with 'globFollow' and symlinks`, async function() {
@@ -300,7 +307,8 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
         revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(4);
-      expect(size).to.eql(2535);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2535, 2611]);
     });
   });
 

--- a/test/workbox-build/node/get-manifest.js
+++ b/test/workbox-build/node/get-manifest.js
@@ -6,10 +6,14 @@
   https://opensource.org/licenses/MIT.
 */
 
-const expect = require('chai').expect;
+const chai = require('chai');
+const chaiMatchPattern = require('chai-match-pattern');
 const fse = require('fs-extra');
 const upath = require('upath');
 const tempy = require('tempy');
+
+chai.use(chaiMatchPattern);
+const {expect} = chai;
 
 const getManifest = require('../../../packages/workbox-build/src/get-manifest');
 
@@ -86,24 +90,24 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
 
       const {count, size, manifestEntries, warnings} = await getManifest(options);
       expect(warnings).to.be.empty;
-      expect(manifestEntries).to.deep.equal([{
+      expect(manifestEntries).to.matchPattern([{
         url: 'index.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'page-1.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'page-2.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'styles/stylesheet-1.css',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'styles/stylesheet-2.css',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'webpackEntry.js',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(6);
       expect(size).to.eql(2604);
@@ -116,18 +120,18 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
 
       const {count, size, manifestEntries, warnings} = await getManifest(options);
       expect(warnings).to.be.empty;
-      expect(manifestEntries).to.deep.equal([{
+      expect(manifestEntries).to.matchPattern([{
         url: 'index.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'page-1.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'page-2.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'webpackEntry.js',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(4);
       expect(size).to.eql(2535);
@@ -140,12 +144,12 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
 
       const {count, size, manifestEntries, warnings} = await getManifest(options);
       expect(warnings).to.be.empty;
-      expect(manifestEntries).to.deep.equal([{
+      expect(manifestEntries).to.matchPattern([{
         url: 'styles/stylesheet-1.css',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'styles/stylesheet-2.css',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(2);
       expect(size).to.eql(69);
@@ -159,12 +163,12 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
 
       const {count, size, manifestEntries, warnings} = await getManifest(options);
       expect(warnings).to.be.empty;
-      expect(manifestEntries).to.deep.equal([{
+      expect(manifestEntries).to.matchPattern([{
         url: 'styles/stylesheet-1.css',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'webpackEntry.js',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(2);
       expect(size).to.eql(217);
@@ -177,17 +181,17 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
 
       const {count, size, manifestEntries, warnings} = await getManifest(options);
       expect(warnings).to.have.lengthOf(2);
-      expect(manifestEntries).to.deep.equal([{
-        revision: '32_CHARACTER_HASH',
+      expect(manifestEntries).to.matchPattern([{
+        revision: /^[0-9a-f]{32}$/,
         url: 'page-1.html',
       }, {
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
         url: 'page-2.html',
       }, {
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
         url: 'styles/stylesheet-1.css',
       }, {
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
         url: 'styles/stylesheet-2.css',
       }]);
       expect(count).to.eql(4);
@@ -207,30 +211,30 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
 
       const {count, size, manifestEntries, warnings} = await getManifest(options);
       expect(warnings).to.be.empty;
-      expect(manifestEntries).to.deep.equal([{
+      expect(manifestEntries).to.matchPattern([{
         url: 'index.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'page-1.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'page-2.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'styles/stylesheet-1.css',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'styles/stylesheet-2.css',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'webpackEntry.js',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'url1',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'url2',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(8);
       expect(size).to.eql(4973);
@@ -259,12 +263,12 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
 
       const {count, size, manifestEntries, warnings} = await getManifest(options);
       expect(warnings).to.be.empty;
-      expect(manifestEntries).to.deep.equal([{
+      expect(manifestEntries).to.matchPattern([{
         url: '/prefix/page-1.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: '/prefix/styles/stylesheet-1.css',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(2);
       expect(size).to.eql(50);
@@ -282,18 +286,18 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
 
       const {count, size, manifestEntries, warnings} = await getManifest(options);
       expect(warnings).to.be.empty;
-      expect(manifestEntries).to.deep.equal([{
+      expect(manifestEntries).to.matchPattern([{
         url: 'link/index.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'link/page-1.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'link/page-2.html',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }, {
         url: 'link/webpackEntry.js',
-        revision: '32_CHARACTER_HASH',
+        revision: /^[0-9a-f]{32}$/,
       }]);
       expect(count).to.eql(4);
       expect(size).to.eql(2535);

--- a/test/workbox-build/node/get-manifest.js
+++ b/test/workbox-build/node/get-manifest.js
@@ -88,22 +88,22 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
       expect(warnings).to.be.empty;
       expect(manifestEntries).to.deep.equal([{
         url: 'index.html',
-        revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'page-1.html',
-        revision: '544658ab25ee8762dc241e8b1c5ed96d',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'page-2.html',
-        revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'styles/stylesheet-1.css',
-        revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'styles/stylesheet-2.css',
-        revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'webpackEntry.js',
-        revision: '5b652181a25e96f255d0490203d3c47e',
+        revision: '32_CHARACTER_HASH',
       }]);
       expect(count).to.eql(6);
       expect(size).to.eql(2604);
@@ -118,16 +118,16 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
       expect(warnings).to.be.empty;
       expect(manifestEntries).to.deep.equal([{
         url: 'index.html',
-        revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'page-1.html',
-        revision: '544658ab25ee8762dc241e8b1c5ed96d',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'page-2.html',
-        revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'webpackEntry.js',
-        revision: '5b652181a25e96f255d0490203d3c47e',
+        revision: '32_CHARACTER_HASH',
       }]);
       expect(count).to.eql(4);
       expect(size).to.eql(2535);
@@ -142,10 +142,10 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
       expect(warnings).to.be.empty;
       expect(manifestEntries).to.deep.equal([{
         url: 'styles/stylesheet-1.css',
-        revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'styles/stylesheet-2.css',
-        revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+        revision: '32_CHARACTER_HASH',
       }]);
       expect(count).to.eql(2);
       expect(size).to.eql(69);
@@ -161,10 +161,10 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
       expect(warnings).to.be.empty;
       expect(manifestEntries).to.deep.equal([{
         url: 'styles/stylesheet-1.css',
-        revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'webpackEntry.js',
-        revision: '5b652181a25e96f255d0490203d3c47e',
+        revision: '32_CHARACTER_HASH',
       }]);
       expect(count).to.eql(2);
       expect(size).to.eql(217);
@@ -178,16 +178,16 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
       const {count, size, manifestEntries, warnings} = await getManifest(options);
       expect(warnings).to.have.lengthOf(2);
       expect(manifestEntries).to.deep.equal([{
-        revision: '544658ab25ee8762dc241e8b1c5ed96d',
+        revision: '32_CHARACTER_HASH',
         url: 'page-1.html',
       }, {
-        revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+        revision: '32_CHARACTER_HASH',
         url: 'page-2.html',
       }, {
-        revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+        revision: '32_CHARACTER_HASH',
         url: 'styles/stylesheet-1.css',
       }, {
-        revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+        revision: '32_CHARACTER_HASH',
         url: 'styles/stylesheet-2.css',
       }]);
       expect(count).to.eql(4);
@@ -209,28 +209,28 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
       expect(warnings).to.be.empty;
       expect(manifestEntries).to.deep.equal([{
         url: 'index.html',
-        revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'page-1.html',
-        revision: '544658ab25ee8762dc241e8b1c5ed96d',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'page-2.html',
-        revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'styles/stylesheet-1.css',
-        revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'styles/stylesheet-2.css',
-        revision: '884f6853a4fc655e4c2dc0c0f27a227c',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'webpackEntry.js',
-        revision: '5b652181a25e96f255d0490203d3c47e',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'url1',
-        revision: '69a043d97513b7015bf4bd95df3e308e',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'url2',
-        revision: 'c154bc7cdfbfbfb73e23f853bd8fcec0',
+        revision: '32_CHARACTER_HASH',
       }]);
       expect(count).to.eql(8);
       expect(size).to.eql(4973);
@@ -261,10 +261,10 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
       expect(warnings).to.be.empty;
       expect(manifestEntries).to.deep.equal([{
         url: '/prefix/page-1.html',
-        revision: '544658ab25ee8762dc241e8b1c5ed96d',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: '/prefix/styles/stylesheet-1.css',
-        revision: '934823cbc67ccf0d67aa2a2eeb798f12',
+        revision: '32_CHARACTER_HASH',
       }]);
       expect(count).to.eql(2);
       expect(size).to.eql(50);
@@ -284,16 +284,16 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
       expect(warnings).to.be.empty;
       expect(manifestEntries).to.deep.equal([{
         url: 'link/index.html',
-        revision: '3883c45b119c9d7e9ad75a1b4a4672ac',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'link/page-1.html',
-        revision: '544658ab25ee8762dc241e8b1c5ed96d',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'link/page-2.html',
-        revision: 'a3a71ce0b9b43c459cf58bd37e911b74',
+        revision: '32_CHARACTER_HASH',
       }, {
         url: 'link/webpackEntry.js',
-        revision: '5b652181a25e96f255d0490203d3c47e',
+        revision: '32_CHARACTER_HASH',
       }]);
       expect(count).to.eql(4);
       expect(size).to.eql(2535);

--- a/test/workbox-build/node/inject-manifest.js
+++ b/test/workbox-build/node/inject-manifest.js
@@ -169,7 +169,8 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await injectManifest(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
       expect(filePaths).to.have.members([swDest]);
 
       await validateServiceWorkerRuntime({
@@ -220,7 +221,8 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await injectManifest(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
       expect(filePaths).to.have.members([swDest]);
 
       await validateServiceWorkerRuntime({
@@ -265,7 +267,8 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await injectManifest(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
       expect(filePaths).to.have.members([swDest]);
 
       await validateServiceWorkerRuntime({
@@ -305,7 +308,8 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await injectManifest(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
       expect(filePaths).to.have.members([swDest]);
 
       await validateServiceWorkerRuntime({
@@ -353,7 +357,8 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       const {count, size, warnings} = await injectManifest(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
       await validateServiceWorkerRuntime({
         entryPoint: 'injectManifest',
         swFile: swDest,
@@ -396,7 +401,8 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await injectManifest(options);
       expect(warnings).to.be.empty;
       expect(count).to.eql(6);
-      expect(size).to.eql(2604);
+      // Line ending differences lead to different sizes on Windows.
+      expect(size).to.be.oneOf([2604, 2686]);
       expect(filePaths).to.have.members([swDest, sourcemapDest]);
 
       const actualSourcemap = await fse.readJSON(sourcemapDest);

--- a/test/workbox-build/node/inject-manifest.js
+++ b/test/workbox-build/node/inject-manifest.js
@@ -179,22 +179,22 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
         expectedMethodCalls: {
           precacheAndRoute: [[[{
             url: 'index.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'page-1.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'page-2.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'styles/stylesheet-1.css',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'styles/stylesheet-2.css',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'webpackEntry.js',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }]]],
         },
       });
@@ -232,22 +232,22 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
           importScripts: [['./sample-import.js']],
           precacheAndRoute: [[[{
             url: 'index.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'page-1.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'page-2.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'styles/stylesheet-1.css',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'styles/stylesheet-2.css',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'webpackEntry.js',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }]], [[
             '/extra-assets/example.1234.css',
             '/extra-assets/example-2.1234.js',
@@ -277,22 +277,22 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
         expectedMethodCalls: {
           precacheAndRoute: [[[{
             url: 'index.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'page-1.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'page-2.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'styles/stylesheet-1.css',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'styles/stylesheet-2.css',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'webpackEntry.js',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }]]],
         },
       });
@@ -318,22 +318,22 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
         expectedMethodCalls: {
           precacheAndRoute: [[[{
             url: 'index.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'page-1.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'page-2.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'styles/stylesheet-1.css',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'styles/stylesheet-2.css',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'webpackEntry.js',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }], {
             cleanURLs: true,
           }]],
@@ -365,22 +365,22 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
         expectedMethodCalls: {
           precacheAndRoute: [[[{
             url: 'index.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'page-1.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'page-2.html',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'styles/stylesheet-1.css',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'styles/stylesheet-2.css',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }, {
             url: 'webpackEntry.js',
-            revision: '32_CHARACTER_HASH',
+            revision: /^[0-9a-f]{32}$/,
           }]]],
         },
       });

--- a/test/workbox-build/node/inject-manifest.js
+++ b/test/workbox-build/node/inject-manifest.js
@@ -171,7 +171,7 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       expect(count).to.eql(6);
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
-      expect(filePaths).to.have.members([swDest]);
+      expect(filePaths).to.have.members([upath.resolve(swDest)]);
 
       await validateServiceWorkerRuntime({
         entryPoint: 'injectManifest',
@@ -223,7 +223,7 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       expect(count).to.eql(6);
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
-      expect(filePaths).to.have.members([swDest]);
+      expect(filePaths).to.have.members([upath.resolve(swDest)]);
 
       await validateServiceWorkerRuntime({
         entryPoint: 'injectManifest',
@@ -269,7 +269,7 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       expect(count).to.eql(6);
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
-      expect(filePaths).to.have.members([swDest]);
+      expect(filePaths).to.have.members([upath.resolve(swDest)]);
 
       await validateServiceWorkerRuntime({
         entryPoint: 'injectManifest',
@@ -310,7 +310,7 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       expect(count).to.eql(6);
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
-      expect(filePaths).to.have.members([swDest]);
+      expect(filePaths).to.have.members([upath.resolve(swDest)]);
 
       await validateServiceWorkerRuntime({
         entryPoint: 'injectManifest',
@@ -403,7 +403,7 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
       expect(count).to.eql(6);
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
-      expect(filePaths).to.have.members([swDest, sourcemapDest]);
+      expect(filePaths).to.have.members([upath.resolve(swDest), sourcemapDest]);
 
       const actualSourcemap = await fse.readJSON(sourcemapDest);
       const expectedSourcemap = await fse.readJSON(

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -87,14 +87,14 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
-              importScripts: [['./workbox-8_CHARACTER_HASH']],
+              importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry1-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry2-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry2-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
             },
@@ -147,13 +147,13 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             swFile, expectedMethodCalls: {
               // imported-[chunkhash].js.map should *not* be included.
               importScripts: [
-                ['./workbox-8_CHARACTER_HASH'],
-                ['imported-20_CHARACTER_HASH.js'],
+                [/^\.\/workbox-[0-9a-f]{8}$/],
+                [/^imported-[0-9a-f]{20}\.js$/],
               ],
               // imported-[chunkhash].js should *not* be included.
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
-                url: 'main-20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^main-[0-9a-f]{20}\.js$/,
               }], {}]],
             },
           });
@@ -202,14 +202,14 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
-              importScripts: [['./workbox-8_CHARACTER_HASH']],
+              importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry1-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry2-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry2-[0-9a-f]{20}\.js$/,
                 }, {
                   revision: null,
                   url: 'one',
@@ -261,14 +261,14 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: '32_CHARACTER_HASH',
-                url: 'entry1-20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^entry1-[0-9a-f]{20}\.js$/,
               }, {
-                revision: '32_CHARACTER_HASH',
-                url: 'entry2-20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^entry2-[0-9a-f]{20}\.js$/,
               },
             ], {}]],
           }});
@@ -314,13 +314,13 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(4);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'main.js',
               }, {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'vendors~main.js',
               },
             ], {}]],
@@ -363,14 +363,14 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: '32_CHARACTER_HASH',
-                url: 'entry1-20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^entry1-[0-9a-f]{20}\.js$/,
               }, {
-                revision: '32_CHARACTER_HASH',
-                url: 'entry2-20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^entry2-[0-9a-f]{20}\.js$/,
               },
             ], {}]],
           }});
@@ -413,11 +413,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: '32_CHARACTER_HASH',
-                url: 'entry1-20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^entry1-[0-9a-f]{20}\.js$/,
               },
             ], {}]],
           }});
@@ -459,16 +459,16 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: '32_CHARACTER_HASH',
-                url: 'entry1-20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^entry1-[0-9a-f]{20}\.js$/,
               }, {
-                revision: '32_CHARACTER_HASH',
-                url: 'entry2-20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^entry2-[0-9a-f]{20}\.js$/,
               }, {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'index.html',
               },
             ], {}]],
@@ -512,42 +512,42 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
-              importScripts: [['./workbox-8_CHARACTER_HASH']],
+              importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'images/example-jpeg.jpg',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'images/web-fundamentals-icon192x192.png',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'index.html',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'page-1.html',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'page-2.html',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'splitChunksEntry.js',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'styles/stylesheet-1.css',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'styles/stylesheet-2.css',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'webpackEntry.js',
                 },
               ], {}]],
@@ -591,15 +591,15 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(9);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: '32_CHARACTER_HASH',
+              revision: /^[0-9a-f]{32}$/,
               url: 'manifest.json',
             }, {
-              revision: '32_CHARACTER_HASH',
+              revision: /^[0-9a-f]{32}$/,
               url: 'not-ignored.js',
             }, {
-              revision: '32_CHARACTER_HASH',
+              revision: /^[0-9a-f]{32}$/,
               url: 'webpackEntry.js',
             }], {}]],
           }});
@@ -638,12 +638,12 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(6);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: '32_CHARACTER_HASH',
+              revision: /^[0-9a-f]{32}$/,
               url: 'webpackEntry.js',
             }, {
-              revision: '32_CHARACTER_HASH',
+              revision: /^[0-9a-f]{32}$/,
               url: 'webpackEntry.js.map',
             }], {}]],
           }});
@@ -685,15 +685,15 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(11);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: '32_CHARACTER_HASH',
+              revision: /^[0-9a-f]{32}$/,
               url: 'index.html',
             }, {
-              revision: '32_CHARACTER_HASH',
+              revision: /^[0-9a-f]{32}$/,
               url: 'page-1.html',
             }, {
-              revision: '32_CHARACTER_HASH',
+              revision: /^[0-9a-f]{32}$/,
               url: 'page-2.html',
             }], {}]],
           }});
@@ -736,12 +736,12 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(11);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: '32_CHARACTER_HASH',
+              revision: /^[0-9a-f]{32}$/,
               url: 'page-1.html',
             }, {
-              revision: '32_CHARACTER_HASH',
+              revision: /^[0-9a-f]{32}$/,
               url: 'page-2.html',
             }], {}]],
           }});
@@ -782,9 +782,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: '32_CHARACTER_HASH',
+              revision: /^[0-9a-f]{32}$/,
               url: 'webpackEntry.js',
             }], {}]],
           }});
@@ -832,11 +832,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           await validateServiceWorkerRuntime({
             swFile, expectedMethodCalls: {
-              importScripts: [['./workbox-8_CHARACTER_HASH']],
+              importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry1-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry1-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
             },
@@ -890,42 +890,42 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(12);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: '32_CHARACTER_HASH',
-                url: 'entry1-20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^entry1-[0-9a-f]{20}\.js$/,
               },
               {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'images/web-fundamentals-icon192x192.png',
               },
               {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'index.html',
               },
               {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'page-1.html',
               },
               {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'page-2.html',
               },
               {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'splitChunksEntry.js',
               },
               {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'styles/stylesheet-1.css',
               },
               {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'styles/stylesheet-2.css',
               },
               {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'webpackEntry.js',
               },
             ], {}]],
@@ -968,11 +968,11 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: '32_CHARACTER_HASH',
-                url: '/testing/entry1-20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^\/testing\/entry1-[0-9a-f]{20}\.js$/,
               },
             ], {}]],
           }});
@@ -1059,10 +1059,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           const swString = memoryFS.readFileSync(`${outputDir}/service-worker.js`, 'utf-8');
 
           await validateServiceWorkerRuntime({swString, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: '32_CHARACTER_HASH',
-              url: 'entry1-20_CHARACTER_HASH.js',
+              revision: /^[0-9a-f]{32}$/,
+              url: /^entry1-[0-9a-f]{20}\.js$/,
             }], {}]],
           }});
 
@@ -1161,9 +1161,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           await validateServiceWorkerRuntime({
             swFile: sw1File,
             expectedMethodCalls: {
-              importScripts: [['./workbox-8_CHARACTER_HASH']],
+              importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'index.js',
               }], {}]],
             },
@@ -1172,9 +1172,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           await validateServiceWorkerRuntime({
             swFile: sw2File,
             expectedMethodCalls: {
-              importScripts: [['./workbox-8_CHARACTER_HASH']],
+              importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'index.js',
               }], {}]],
             },
@@ -1322,9 +1322,9 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              url: 'main.20_CHARACTER_HASH.js',
+              url: /^main\.[0-9a-f]{20}\.js$/,
               revision: null,
             }], {}]],
           }});
@@ -1365,10 +1365,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: '32_CHARACTER_HASH',
-              url: 'https://example.org/main.20_CHARACTER_HASH.js',
+              revision: /^[0-9a-f]{32}$/,
+              url: /^https:\/\/example\.org\/main\.[0-9a-f]{20}\.js/,
             }], {}]],
           }});
 
@@ -1394,7 +1394,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             manifestTransforms: [(manifest, compilation) => {
               expect(manifest).to.have.lengthOf(1);
               expect(manifest[0].size).to.eql(930);
-              expect(manifest[0].url.startsWith('main.')).to.be.true;
+              expect(manifest[0].url.startsWith('main\.')).to.be.true;
               expect(manifest[0].revision).to.have.lengthOf(32);
               expect(compilation).to.exist;
 
@@ -1426,10 +1426,10 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
-            importScripts: [['./workbox-8_CHARACTER_HASH']],
+            importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
               revision: null,
-              url: 'main.20_CHARACTER_HASH.js-suffix',
+              url: /^main\.[0-9a-f]{20}\.js-suffix$/,
             }], {}]],
           }});
 

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -1394,7 +1394,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             manifestTransforms: [(manifest, compilation) => {
               expect(manifest).to.have.lengthOf(1);
               expect(manifest[0].size).to.eql(930);
-              expect(manifest[0].url.startsWith('main\.')).to.be.true;
+              expect(manifest[0].url.startsWith('main.')).to.be.true;
               expect(manifest[0].revision).to.have.lengthOf(32);
               expect(compilation).to.exist;
 

--- a/test/workbox-webpack-plugin/node/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/generate-sw.js
@@ -82,7 +82,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(4);
 
           await validateServiceWorkerRuntime({
@@ -140,7 +140,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           // There should be a warning logged, due to INVALID_CHUNK_NAME.
           expect(statsJson.warnings).to.have.length(1);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(8);
 
           await validateServiceWorkerRuntime({
@@ -197,7 +197,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(statsJson.errors).to.be.empty;
           expect(statsJson.warnings).to.have.length(0);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(4);
 
           await validateServiceWorkerRuntime({
@@ -257,7 +257,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -310,7 +310,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(4);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -359,7 +359,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -409,7 +409,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -455,7 +455,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(5);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -507,7 +507,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(11);
 
           await validateServiceWorkerRuntime({
@@ -587,7 +587,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(9);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -634,7 +634,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(6);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -681,7 +681,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(11);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -732,7 +732,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(11);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -778,7 +778,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -827,7 +827,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
             `The chunk 'doesNotExist' was provided in your Workbox chunks config, but was not found in the compilation.`,
           ]);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({
@@ -886,7 +886,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
 
           const swFile = upath.join(outputDir, 'service-worker.js');
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(12);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -964,7 +964,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -1015,7 +1015,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           // different environments. Instead of hardcoding hash checks, just
           // confirm that we output the expected number of files, which will
           // only be true if the build was successful.
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(6);
 
           done();
@@ -1113,7 +1113,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
                 expect(statsJson.warnings).to.have.length(0);
               }
 
-              const files = await globby(outputDir);
+              const files = await globby('**', {cwd: outputDir});
               expect(files).to.have.length(3);
 
               resolve();
@@ -1155,7 +1155,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(4);
 
           await validateServiceWorkerRuntime({
@@ -1214,7 +1214,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           // We can't really mock evaluation of the service worker script when
           // the Workbox runtime is inlined, so just check to make sure the
           // correct files are output.
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(2);
 
           done();
@@ -1250,7 +1250,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           // We can't really mock evaluation of the service worker script when
           // the Workbox runtime is inlined, so just check to make sure the
           // correct files are output.
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(3);
 
           done();
@@ -1318,7 +1318,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -1361,7 +1361,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
@@ -1422,7 +1422,7 @@ describe(`[workbox-webpack-plugin] GenerateSW (End to End)`, function() {
           expect(statsJson.errors, JSON.stringify(statsJson.errors)).to.be.empty;
           expect(statsJson.warnings).to.have.members([warningMessage]);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -96,11 +96,11 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry1-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry2-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry2-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
             },
@@ -150,11 +150,11 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry1-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry2-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry2-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
             },
@@ -208,10 +208,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'main.js',
                 }, {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'vendors~main.js',
                 },
               ], {}]],
@@ -262,11 +262,11 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry1-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry2-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry2-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
             },
@@ -317,8 +317,8 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry1-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry1-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
             },
@@ -369,13 +369,13 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry1-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry2-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry2-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'index.html',
                 },
               ], {}]],
@@ -427,39 +427,39 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'images/example-jpeg.jpg',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'images/web-fundamentals-icon192x192.png',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'index.html',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'page-1.html',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'page-2.html',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'splitChunksEntry.js',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'styles/stylesheet-1.css',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'styles/stylesheet-2.css',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'webpackEntry.js',
                 },
               ], {}]],
@@ -517,7 +517,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'webpackEntry.js',
               }], {}]],
             },
@@ -576,7 +576,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'webpackEntry.js',
               }], {}]],
             },
@@ -623,7 +623,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'webpackEntry.js',
               }], {}]],
             },
@@ -673,13 +673,13 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'manifest.json',
               }, {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'not-ignored.js',
               }, {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'webpackEntry.js',
               }], {}]],
             },
@@ -725,13 +725,13 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'service-worker.js.map',
               }, {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'webpackEntry.js',
               }, {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'webpackEntry.js.map',
               }], {}]],
             },
@@ -780,13 +780,13 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'index.html',
               }, {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'page-1.html',
               }, {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'page-2.html',
               }], {}]],
             },
@@ -836,10 +836,10 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'page-1.html',
               }, {
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'page-2.html',
               }], {}]],
             },
@@ -885,7 +885,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
+                revision: /^[0-9a-f]{32}$/,
                 url: 'webpackEntry.js',
               }], {}]],
             },
@@ -940,8 +940,8 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry1-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry1-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
             },
@@ -1002,39 +1002,39 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
-                  url: 'entry1-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^entry1-[0-9a-f]{20}\.js$/,
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'images/web-fundamentals-icon192x192.png',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'index.html',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'page-1.html',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'page-2.html',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'splitChunksEntry.js',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'styles/stylesheet-1.css',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'styles/stylesheet-2.css',
                 },
                 {
-                  revision: '32_CHARACTER_HASH',
+                  revision: /^[0-9a-f]{32}$/,
                   url: 'webpackEntry.js',
                 },
               ], {}]],
@@ -1086,8 +1086,8 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: '32_CHARACTER_HASH',
-                  url: '/testing/entry1-20_CHARACTER_HASH.js',
+                  revision: /^[0-9a-f]{32}$/,
+                  url: /^\/testing\/entry1-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
             },
@@ -1178,7 +1178,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                url: 'main.20_CHARACTER_HASH.js',
+                url: /^main\.[0-9a-f]{20}\.js$/,
                 revision: null,
               }], {}]],
             },
@@ -1226,8 +1226,8 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
-                url: 'https://example.org/main.20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^https:\/\/example\.org\/main\.[0-9a-f]{20}\.js/,
               }], {}]],
             },
           });
@@ -1293,7 +1293,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[{
                 revision: null,
-                url: 'main.20_CHARACTER_HASH.js-suffix',
+                url: /^main.[0-9a-f]{20}\.js-suffix$/,
               }], {}]],
             },
           });
@@ -1432,8 +1432,8 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
-                url: 'main.20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^main\.[0-9a-f]{20}\.js$/,
               }], {}]],
             },
           });
@@ -1443,8 +1443,8 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
-                url: 'main.20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^main\.[0-9a-f]{20}\.js$/,
               }], {}]],
             },
           });
@@ -1491,8 +1491,8 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: '32_CHARACTER_HASH',
-                url: 'main.20_CHARACTER_HASH.js',
+                revision: /^[0-9a-f]{32}$/,
+                url: /^main\.[0-9a-f]{20}\.js$/,
               }], {}]],
             },
           });

--- a/test/workbox-webpack-plugin/node/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/inject-manifest.js
@@ -87,7 +87,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({
@@ -141,7 +141,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(4);
 
           await validateServiceWorkerRuntime({
@@ -199,7 +199,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({
@@ -253,7 +253,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(4);
 
           await validateServiceWorkerRuntime({
@@ -308,7 +308,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(4);
 
           await validateServiceWorkerRuntime({
@@ -360,7 +360,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(4);
 
           await validateServiceWorkerRuntime({
@@ -418,7 +418,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(10);
 
           await validateServiceWorkerRuntime({
@@ -499,7 +499,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(4);
 
           const expectedSourcemap = await fse.readJSON(
@@ -557,7 +557,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(4);
 
           const expectedSourcemap = await fse.readJSON(
@@ -615,7 +615,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(2);
 
           await validateServiceWorkerRuntime({
@@ -665,7 +665,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(7);
 
           await validateServiceWorkerRuntime({
@@ -717,7 +717,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(4);
 
           await validateServiceWorkerRuntime({
@@ -772,7 +772,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(10);
 
           await validateServiceWorkerRuntime({
@@ -828,7 +828,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(10);
 
           await validateServiceWorkerRuntime({
@@ -877,7 +877,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(2);
 
           await validateServiceWorkerRuntime({
@@ -931,7 +931,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
             `The chunk 'doesNotExist' was provided in your Workbox chunks config, but was not found in the compilation.`,
           ]);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(2);
 
           await validateServiceWorkerRuntime({
@@ -993,7 +993,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
 
           const swFile = upath.join(outputDir, 'service-worker.js');
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(11);
 
           await validateServiceWorkerRuntime({
@@ -1077,7 +1077,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(2);
 
           await validateServiceWorkerRuntime({
@@ -1134,7 +1134,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           // different environments. Instead of hardcoding hash checks, just
           // confirm that we output the expected number of files, which will
           // only be true if the build was successful.
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(5);
 
           done();
@@ -1170,7 +1170,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(2);
 
           await validateServiceWorkerRuntime({
@@ -1218,7 +1218,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(2);
 
           await validateServiceWorkerRuntime({
@@ -1284,7 +1284,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
           expect(statsJson.errors).to.be.empty;
           expect(statsJson.warnings).to.have.members([warningMessage]);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(2);
 
           await validateServiceWorkerRuntime({
@@ -1378,7 +1378,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
                 expect(statsJson.warnings).to.have.length(0);
               }
 
-              const files = await globby(outputDir);
+              const files = await globby('**', {cwd: outputDir});
               expect(files).to.have.length(2);
 
               resolve();
@@ -1424,7 +1424,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(3);
 
           await validateServiceWorkerRuntime({
@@ -1483,7 +1483,7 @@ describe(`[workbox-webpack-plugin] InjectManifest (End to End)`, function() {
         try {
           webpackBuildCheck(webpackError, stats);
 
-          const files = await globby(outputDir);
+          const files = await globby('**', {cwd: outputDir});
           expect(files).to.have.length(2);
 
           await validateServiceWorkerRuntime({


### PR DESCRIPTION
R: @philipwalton 

This re-enables Windows testing of the `node` modules on GitHub Actions (not the SW runtime), which has historically been a source of bugs due to path separator differences.

It also cleans up some of the logic in place around validating hashes, switching to regexes and the `chai-match-pattern` library.

Fixes #2288