### PR TITLE
Switch to official webpack exports

### DIFF
--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -7,7 +7,7 @@
 */
 
 const {RawSource} = require('webpack-sources');
-const SingleEntryPlugin = require('webpack/lib/SingleEntryPlugin');
+const {SingleEntryPlugin} = require('webpack');
 const replaceAndUpdateSourceMap = require(
     'workbox-build/build/lib/replace-and-update-source-map');
 const stringify = require('fast-json-stable-stringify');

--- a/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-from-compilation.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-from-compilation.js
@@ -6,7 +6,7 @@
   https://opensource.org/licenses/MIT.
 */
 
-const {matchPart} = require('webpack/lib/ModuleFilenameHelpers');
+const {matchPart} = require('webpack').ModuleFilenameHelpers;
 const transformManifest = require('workbox-build/build/lib/transform-manifest');
 
 const getAssetHash = require('./get-asset-hash');
@@ -30,7 +30,6 @@ function checkConditions(asset, compilation, conditions = []) {
         return true;
       }
     } else {
-      // See https://github.com/webpack/webpack/blob/bf3e869a423a60581dcb64e215b8d14403e997f2/lib/ModuleFilenameHelpers.js#L151-L159
       if (matchPart(asset.name, condition)) {
         return true;
       }


### PR DESCRIPTION
R: @philipwalton

I had always felt guilty about using the package subpaths, and didn't realize that official exports existed for those bits of the `webpack` internals we need. I checked back to the `webpack` v4.0.0 release (what we specify in our `peerDependencies`) and they're both supported there.

This may fix #2385? I'm not entirely sure. But it's a good idea to switch over anyway.
