### PR TITLE
feat(build): support PnP

### DIFF
--- a/packages/workbox-build/package-lock.json
+++ b/packages/workbox-build/package-lock.json
@@ -1441,6 +1441,11 @@
         "rollup-pluginutils": "^2.8.1"
       }
     },
+    "rollup-plugin-pnp-resolve": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-pnp-resolve/-/rollup-plugin-pnp-resolve-2.0.0.tgz",
+      "integrity": "sha512-/FsgWZvYZHwee8DdNF7lo/5gkD1jhMNF6sqEXs6edYGIeSlCZPu9jOhfF85TtpfilsZq3jDB7KA9b8D9nJw4NA=="
+    },
     "rollup-plugin-terser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.2.0.tgz",

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -35,6 +35,7 @@
     "pretty-bytes": "^5.3.0",
     "rollup": "^1.31.1",
     "rollup-plugin-babel": "^4.3.3",
+    "rollup-plugin-pnp-resolve": "^2.0.0",
     "rollup-plugin-terser": "^5.2.0",
     "source-map": "^0.7.3",
     "source-map-url": "^0.4.0",

--- a/packages/workbox-build/src/lib/bundle.js
+++ b/packages/workbox-build/src/lib/bundle.js
@@ -15,6 +15,7 @@ const upath = require('upath');
 const presetEnv = require('@babel/preset-env');
 const replace = require('@rollup/plugin-replace');
 const resolve = require('@rollup/plugin-node-resolve');
+const pnpResolve = require('rollup-plugin-pnp-resolve');
 const tempy = require('tempy');
 
 module.exports = async ({
@@ -33,6 +34,7 @@ module.exports = async ({
   await writeFile(temporaryFile, unbundledCode);
 
   const plugins = [
+    pnpResolve(),
     resolve(),
     replace({'process.env.NODE_ENV': JSON.stringify(mode)}),
     babel({


### PR DESCRIPTION
Fixes #2385 (Fixes the next problem that issue would have gotten to after running `yarn add webpack`)

This PR adds support for [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp) by adding [rollup-plugin-pnp-resolve](https://www.npmjs.com/package/rollup-plugin-pnp-resolve) to `workbox-build`. The plugin does nothing if the user isn't running under the Plug'n'Play environment.