### PR TITLE
handlerCallback JSDocs update

### DIFF
--- a/packages/workbox-routing/src/_types.ts
+++ b/packages/workbox-routing/src/_types.ts
@@ -68,9 +68,8 @@ import './_version.js';
  *
  * @callback ~handlerCallback
  * @param {Object} context
- * @param {URL} context.url The URL that matched.
- * @param {Request} [context.request] The corresponding request,
- *     if available.
+ * @param {Request|string} context.request The corresponding request.
+ * @param {URL} [context.url] The URL that matched, if available.
  * @param {FetchEvent} [context.event] The corresponding event that triggered
  *     the request, if available.
  * @param {Object} [context.params] Array or Object parameters returned by the


### PR DESCRIPTION
Prompted by https://github.com/GoogleChrome/workbox/issues/2439, I found a discrepancy in our `handlerCallback` JSDocs and TypeScript definition: https://github.com/GoogleChrome/workbox/blob/3ac095656354157eb4b58c93d3b1e390a5ba34dd/packages/workbox-core/src/types.ts#L36-L56