### PR TITLE
Add test filters for selective test running

### DIFF
--- a/infra/testing/helpers/extendable-event-utils.mjs
+++ b/infra/testing/helpers/extendable-event-utils.mjs
@@ -33,11 +33,13 @@ export const spyOnEvent = (event) => {
 
   if (event instanceof FetchEvent) {
     event.respondWith = sinon.stub().callsFake((responseOrPromise) => {
-      eventResponses.set(event, responseOrPromise);
-      promises.push(Promise.resolve(responseOrPromise));
+      const promise = Promise.resolve(responseOrPromise);
+
+      eventResponses.set(event, promise);
+      promises.push(promise);
 
       // TODO(philipwalton): we cannot currently call the native
-      // `respondWith()` due to this bug in Firefix:
+      // `respondWith()` due to this bug in Firefox:
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1538756
       // FetchEvent.prototype.respondWith.call(event, responseOrPromise);
     });

--- a/infra/testing/server/routes/sw-bundle.js
+++ b/infra/testing/server/routes/sw-bundle.js
@@ -26,43 +26,60 @@ async function handler(req, res) {
   const env = process.env.NODE_ENV || 'development';
   const packageName = req.params.package;
 
-  // Ensure the TypeScript transpile step has completed first.
-  if (needsTranspile(packageName)) {
-    await queueTranspile(packageName);
+  res.set('Content-Type', 'text/javascript');
+
+  try {
+    // Ensure the TypeScript transpile step has completed first.
+    if (needsTranspile(packageName)) {
+      await queueTranspile(packageName);
+    }
+
+    // Allows you to selectively run tests by adding the `?test=` to the URL.
+    const testFilter = req.query.filter || '**/test-*.mjs';
+    const bundle = await rollup({
+      input: `./test/${packageName}/sw/` + testFilter,
+      plugins: [
+        multiEntry(),
+        resolve({
+          customResolveOptions: {
+            moduleDirectory: 'packages',
+          },
+        }),
+        // TODO(philipwalton): some of our shared testing helpers use commonjs
+        // so we have to support this for the time being.
+        commonjs({
+          exclude: '*.mjs',
+        }),
+        replace({
+          'process.env.NODE_ENV': JSON.stringify(env),
+          'BROWSER_NAMESPACES': JSON.stringify(BROWSER_NAMESPACES),
+          'WORKBOX_CDN_ROOT_URL': '/__WORKBOX/buildFile',
+        }),
+      ],
+      // Fail in the case of warning, so rebuilds work.
+      onwarn({loc, message}) {
+        if (loc) {
+          message = `${loc.file} (${loc.line}:${loc.column}) ${message}`;
+        }
+        throw new Error(message);
+      },
+      cache: caches[env],
+    });
+
+    // Update the cache so subsequent bundles are faster, and make sure it
+    // keep the dev/prod caches separate since the source files won't change
+    // between those builds, but the outputs will.
+    caches[env] = bundle.cache;
+
+    const {output} = await bundle.generate({format: 'iife'});
+
+    console.log(`Successfully built: ${req.url}`);
+    res.write(output[0].code);
+  } catch (error) {
+    res.write('skipWaiting();self.registration.unregister();');
+    console.error(error);
   }
 
-  const bundle = await rollup({
-    input: `./test/${packageName}/sw/**/test-*.mjs`,
-    plugins: [
-      multiEntry(),
-      resolve({
-        customResolveOptions: {
-          moduleDirectory: 'packages',
-        },
-      }),
-      // TODO(philipwalton): some of our shared testing helpers use commonjs
-      // so we have to support this for the time being.
-      commonjs({
-        exclude: '*.mjs',
-      }),
-      replace({
-        'process.env.NODE_ENV': JSON.stringify(env),
-        'BROWSER_NAMESPACES': JSON.stringify(BROWSER_NAMESPACES),
-        'WORKBOX_CDN_ROOT_URL': '/__WORKBOX/buildFile',
-      }),
-    ],
-    cache: caches[env],
-  });
-
-  // Update the cache so subsequent bundles are faster, and make sure it
-  // keep the dev/prod caches separate since the source files won't change
-  // between those builds, but the outputs will.
-  caches[env] = bundle.cache;
-
-  const {output} = await bundle.generate({format: 'iife'});
-
-  res.set('Content-Type', 'text/javascript');
-  res.write(output[0].code);
   res.end();
 }
 

--- a/infra/testing/server/routes/sw-bundle.js
+++ b/infra/testing/server/routes/sw-bundle.js
@@ -74,13 +74,11 @@ async function handler(req, res) {
     const {output} = await bundle.generate({format: 'iife'});
 
     console.log(`Successfully built: ${req.url}`);
-    res.write(output[0].code);
+    res.send(output[0].code);
   } catch (error) {
-    res.write('skipWaiting();self.registration.unregister();');
+    res.status(400).send('');
     console.error(error);
   }
-
-  res.end();
 }
 
 module.exports = {

--- a/infra/testing/server/routes/test-window.js
+++ b/infra/testing/server/routes/test-window.js
@@ -15,12 +15,14 @@ const match = '/test/:packageName/window/';
 
 async function handler(req, res) {
   const {packageName} = req.params;
+  const testFilter = req.query.filter || '**/test-*.mjs';
+
   const testFiles =
-      await globby(`test/${packageName}/window/**/test-*.mjs`) || [];
+      await globby(`test/${packageName}/window/**/${testFilter}`) || [];
 
   const testModules = testFiles.map((file) => '/' + file);
 
-  templateData.assign({packageName, testModules});
+  templateData.assign({packageName, testModules, testFilter});
 
   res.set('Content-Type', 'text/html');
 

--- a/infra/testing/server/templates/test-sw-runner.js.njk
+++ b/infra/testing/server/templates/test-sw-runner.js.njk
@@ -12,6 +12,9 @@ importScripts(
     '/node_modules/sinon/pkg/sinon-no-sourcemaps.js'
 );
 
+// Disable workbox logs in test mode.
+self.__WB_DISABLE_DEV_LOGS = true;
+
 self.expect = chai.expect;
 
 // TODO(philipwalton): Move these globals back into imports once the
@@ -111,4 +114,4 @@ addEventListener('install', (event) => {
   event.waitUntil(testsComplete);
 }, {once: true}); // Run once since `install` events are dispatched in tests.
 
-importScripts('sw-bundle.js');
+importScripts('sw-bundle.js?filter={{ testFilter }}');


### PR DESCRIPTION
R: @jeffposnick 

This PR fixes a few long-standing annoyance of mine:

- There was no easy way to just run one (or a few) tests.
- If a TypeScript compile or Rollup error occurred, you would need to restart the test server in order to refresh and rerun the tests.
- Dev logging made it hard to see the test output.

Now, when running the SW or window tests in the browser, you can append `?filter=` and pass a test glob, where the default is `**/test-*`. For example, if you wanted to just test the `CacheFirst` and `CacheOnly` strategies you could visit: `http://localhost:3004/test/workbox-strategies/sw/?filter=test-Cache*`

