### PR TITLE
Fixes unhandled rejections in Windows tests

### DIFF
--- a/infra/testing/confirm-directory-contains.js
+++ b/infra/testing/confirm-directory-contains.js
@@ -8,11 +8,11 @@
 
 const expect = require('chai').expect;
 const globby = require('globby');
-const path = require('path');
+const upath = require('upath');
 
 module.exports = async (directory, expectedContents) => {
-  const globbedFiles = await globby(directory);
-  const filesWithNativeSeparator =
-      globbedFiles.map((file) => file.replace(/\//g, path.sep));
-  expect(filesWithNativeSeparator).to.have.members(expectedContents);
+  const relativeFiles = await globby('**', {cwd: directory});
+  const absoluteFilesWithNativeSeparator = relativeFiles.map(
+      (file) => upath.resolve(directory, file).replace(/\//g, upath.sep));
+  expect(absoluteFilesWithNativeSeparator).to.have.members(expectedContents);
 };

--- a/test/workbox-build/node/generate-sw.js
+++ b/test/workbox-build/node/generate-sw.js
@@ -137,7 +137,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         __WB_DISABLE_DEV_LOGS: undefined,
@@ -178,7 +178,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         __WB_DISABLE_DEV_LOGS: true,
@@ -220,7 +220,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         importScripts: [
@@ -270,7 +270,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
@@ -321,7 +321,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
@@ -367,7 +367,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
@@ -419,7 +419,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         createHandlerBoundToURL: [[navigateFallback]],
@@ -469,7 +469,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
@@ -514,7 +514,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2535, 2611]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
@@ -548,7 +548,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
@@ -593,7 +593,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
 
       await validateServiceWorkerRuntime({swFile: swDest, expectedMethodCalls: {
         importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
@@ -637,7 +637,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
     });
 
     it(`should inline the Workbox runtime when 'inlineWorkboxRuntime' is true`, async function() {
@@ -654,7 +654,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
-      confirmDirectoryContains(outputDir, filePaths);
+      await confirmDirectoryContains(outputDir, filePaths);
       // We can't validate the generated sw.js file, unfortunately.
     });
   });


### PR DESCRIPTION
R: @philipwalton

I noticed while looking at our CI output that there are some test cases in the Windows suite that should have been failed, but passed because of a missing `await`:

https://github.com/GoogleChrome/workbox/pull/2451/checks?check_run_id=583425178#step:6:60

This PR adds that `await` to ensure that an exception in the `async` sub-function properly fails our main test case. It also fixes the logic so that the Windows tests should pass.

(They were failing because a Windows path separator isn't meant to be used in a `globby` pattern.)