### PR TITLE
Remove the isSWEnv assertion

### DIFF
--- a/packages/workbox-core/src/_private/assert.ts
+++ b/packages/workbox-core/src/_private/assert.ts
@@ -9,16 +9,6 @@
 import {WorkboxError, WorkboxErrorDetails} from '../_private/WorkboxError.js';
 import '../_version.js';
 
-
-/*
- * This method returns true if the current context is a service worker.
- */
-const isSWEnv = (moduleName: string) => {
-  if (!('ServiceWorkerGlobalScope' in self)) {
-    throw new WorkboxError('not-in-sw', {moduleName});
-  }
-};
-
 /*
  * This method throws if the supplied value is not an array.
  * The destructed values are required to produce a meaningful error for users.
@@ -101,7 +91,6 @@ const finalAssertExports = process.env.NODE_ENV === 'production' ? null : {
   isArray,
   isInstance,
   isOneOf,
-  isSWEnv,
   isType,
   isArrayOfClass,
 };

--- a/packages/workbox-core/src/models/messages/messages.ts
+++ b/packages/workbox-core/src/models/messages/messages.ts
@@ -27,13 +27,6 @@ export const messages: MessageMap = {
       `${JSON.stringify(value)}.`;
   },
 
-  'not-in-sw': ({moduleName}) => {
-    if (!moduleName) {
-      throw new Error(`Unexpected input to 'not-in-sw' error.`);
-    }
-    return `The '${moduleName}' must be used in a service worker.`;
-  },
-
   'not-an-array': ({moduleName, className, funcName, paramName}) => {
     if (!moduleName || !className || !funcName || !paramName) {
       throw new Error(`Unexpected input to 'not-an-array' error.`);

--- a/packages/workbox-precaching/src/index.ts
+++ b/packages/workbox-precaching/src/index.ts
@@ -6,8 +6,6 @@
   https://opensource.org/licenses/MIT.
 */
 
-import {assert} from 'workbox-core/_private/assert.js';
-
 import {addPlugins} from './addPlugins.js';
 import {addRoute} from './addRoute.js';
 import {cleanupOutdatedCaches} from './cleanupOutdatedCaches.js';
@@ -20,10 +18,6 @@ import {precacheAndRoute} from './precacheAndRoute.js';
 import {PrecacheController} from './PrecacheController.js';
 
 import './_version.js';
-
-if (process.env.NODE_ENV !== 'production') {
-  assert!.isSWEnv('workbox-precaching');
-}
 
 /**
  * Most consumers of this module will want to use the

--- a/test/workbox-core/sw/_private/test-assert.mjs
+++ b/test/workbox-core/sw/_private/test-assert.mjs
@@ -16,42 +16,6 @@ describe(`assert`, function() {
     }
   });
 
-  describe(`isSWEnv`, function() {
-    let sandbox;
-    before(function() {
-      sandbox = sinon.createSandbox();
-    });
-
-    afterEach(function() {
-      sandbox.restore();
-    });
-
-    it(`should throw if ServiceWorkerGlobalScope is not defined`, async function() {
-      if (process.env.NODE_ENV === 'production') this.skip();
-
-      const originalServiceWorkerGlobalScope = self.ServiceWorkerGlobalScope;
-      delete self.ServiceWorkerGlobalScope;
-
-      await expectError(() => assert.isSWEnv('example-module'), 'not-in-sw');
-
-      self.ServiceWorkerGlobalScope = originalServiceWorkerGlobalScope;
-    });
-
-    it(`should return false if self is not an instance of ServiceWorkerGlobalScope`, function() {
-      if (process.env.NODE_ENV === 'production') this.skip();
-
-      sandbox.stub(self, 'self').value({});
-
-      return expectError(() => assert.isSWEnv('example-module'), 'not-in-sw');
-    });
-
-    it(`should not throw if self is an instance of ServiceWorkerGlobalScope`, function() {
-      if (process.env.NODE_ENV === 'production') this.skip();
-
-      assert.isSWEnv('example-module');
-    });
-  });
-
   describe(`isArray`, function() {
     it(`shouldn't throw when given an array`, function() {
       if (process.env.NODE_ENV === 'production') this.skip();

--- a/test/workbox-precaching/static/addToCacheList.html
+++ b/test/workbox-precaching/static/addToCacheList.html
@@ -7,10 +7,6 @@
   <button class="js-index-unrevisioned">Add Unrevisioned Assets</button>
 
 <script src="../../../../packages/workbox-core/build/browser/workbox-core.dev.js"></script>
-<script>
-  // Make precaching think it's in the SW.
-  workbox.core.default.assert.isSWEnv = () => {}
-</script>
 <script src="../../../../packages/workbox-precaching/build/browser/workbox-precaching.dev.js"></script>
 <script>
   const precacheController = new workbox.precaching.PrecacheController();

--- a/test/workbox-precaching/static/precache.html
+++ b/test/workbox-precaching/static/precache.html
@@ -14,10 +14,6 @@
   };
 </script>
 <script src="../../../../packages/workbox-core/build/browser/workbox-core.dev.js"></script>
-<script>
-  // Make precaching think it's in the SW.
-  workbox.core.default.assert.isSWEnv = () => {}
-</script>
 <script src="../../../../packages/workbox-precaching/build/browser/workbox-precaching.dev.js"></script>
 
 <script>


### PR DESCRIPTION
R: @philipwalton

As discussed, this assertion makes it difficult to test the `workbox-precaching` class outside of the SW environment.

We don't have a similar assertions in any other module, so having it just for `workbox-precaching` is hard to justify.