### PR TITLE
Update GitHub actions to use Node 12

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,17 +5,17 @@ on: [pull_request]
 jobs:
   Node_Tests_Windows:
     runs-on: windows-latest
-    
+
     steps:
     - uses: actions/checkout@v2
-      
+
     - uses: actions/cache@v1
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-          
+
     - uses: actions/setup-node@v1
       with:
         node-version: 8.x
@@ -30,7 +30,7 @@ jobs:
 
   Full_Suite_Mac:
     runs-on: macos-latest
-    
+
     steps:
     - uses: actions/checkout@v2
 
@@ -40,15 +40,15 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-          
+
     - uses: actions/cache@v1
       with:
         path: ~/.selenium-assistant
         key: ${{ runner.os }}
-          
+
     - uses: actions/setup-node@v1
       with:
-        node-version: 13.x
+        node-version: 12.x
 
     - name: Setup
       run: |


### PR DESCRIPTION
R: @jeffposnick 

This PR update the `Full_Suite_Mac` job in pull request GitHub action to use Node 12, as experimental Node 13 changes were causing breakage.