### PR TITLE
Switch the minimum supported node version to 10

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,8 +22,7 @@ jobs:
 
     - name: Setup
       run: |
-        # Use `npm i` to work around https://github.com/npm/cli/issues/558
-        npm i
+        npm ci
         gulp build
 
     - run: npx gulp test-node

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,7 @@ jobs:
 
     - uses: actions/setup-node@v1
       with:
-        node-version: 8.x
+        node-version: 10.x
 
     - name: Setup
       run: |

--- a/gulp-tasks/utils/build-node-package.js
+++ b/gulp-tasks/utils/build-node-package.js
@@ -31,7 +31,7 @@ module.exports = (packagePath) => {
       ['@babel/preset-env', {
         targets: {
           // Change this when our minimum required node version changes.
-          node: '8.0',
+          node: '10.0',
         },
       }],
     ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workbox",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "bot": "pr-bot",

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -12,7 +12,7 @@
     "file manifest"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": "Google's Web DevRel Team",
   "license": "MIT",

--- a/packages/workbox-cli/package.json
+++ b/packages/workbox-cli/package.json
@@ -18,7 +18,7 @@
     "build"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "prepublish": "gulp build-packages --package workbox-cli"

--- a/packages/workbox-webpack-plugin/package.json
+++ b/packages/workbox-webpack-plugin/package.json
@@ -25,7 +25,7 @@
     "build"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",


### PR DESCRIPTION
R: @philipwalton

This switches to `node` v10 as the minimum required version in our packages' `engines` field, and changes the `preset-env` target to 10 as well.

Fixes #2445
