### PR TITLE
Per-method setDefaultHandler()

### DIFF
--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -7,18 +7,17 @@
 */
 
 import {assert} from 'workbox-core/_private/assert.js';
-import {logger} from 'workbox-core/_private/logger.js';
-import {WorkboxError} from 'workbox-core/_private/WorkboxError.js';
 import {getFriendlyURL} from 'workbox-core/_private/getFriendlyURL.js';
-import {Route} from './Route.js';
-import {HTTPMethod} from './utils/constants.js';
-import {normalizeHandler} from './utils/normalizeHandler.js';
 import {Handler, HandlerObject, HandlerCallbackOptions} from './_types.js';
+import {HTTPMethod, defaultMethod} from './utils/constants.js';
+import {logger} from 'workbox-core/_private/logger.js';
+import {normalizeHandler} from './utils/normalizeHandler.js';
+import {Route} from './Route.js';
+import {WorkboxError} from 'workbox-core/_private/WorkboxError.js';
+
 import './_version.js';
 
-
 type RequestArgs = string | [string, RequestInit?];
-
 
 interface CacheURLsMessageData {
   type: string;
@@ -46,7 +45,7 @@ interface CacheURLsMessageData {
  */
 class Router {
   private readonly _routes: Map<HTTPMethod, Route[]>;
-  private _defaultHandler?: HandlerObject;
+  private readonly _defaultHandler: Map<HTTPMethod, HandlerObject>;
   private _catchHandler?: HandlerObject;
 
   /**
@@ -54,6 +53,7 @@ class Router {
    */
   constructor() {
     this._routes = new Map();
+    this._defaultHandler = new Map();
   }
 
   /**
@@ -191,12 +191,13 @@ class Router {
 
     // If we don't have a handler because there was no matching route, then
     // fall back to defaultHandler if that's defined.
-    if (!handler && this._defaultHandler) {
+    const method = request.method as HTTPMethod;
+    if (!handler && this._defaultHandler.has(method)) {
       if (process.env.NODE_ENV !== 'production') {
         debugMessages.push(`Failed to find a matching route. Falling ` +
-          `back to the default handler.`);
+          `back to the default handler for ${method}.`);
       }
-      handler = this._defaultHandler;
+      handler = this._defaultHandler.get(method);
     }
 
     if (!handler) {
@@ -316,15 +317,19 @@ class Router {
   /**
    * Define a default `handler` that's called when no routes explicitly
    * match the incoming request.
+   * 
+   * Each HTTP method ('GET', 'POST', etc.) gets its own default handler.
    *
    * Without a default handler, unmatched requests will go against the
    * network as if there were no service worker present.
    *
    * @param {module:workbox-routing~handlerCallback} handler A callback
    * function that returns a Promise resulting in a Response.
+   * @param {string} [method='GET'] The HTTP method to associate with this
+   * default handler. Each method has its own default.
    */
-  setDefaultHandler(handler: Handler) {
-    this._defaultHandler = normalizeHandler(handler);
+  setDefaultHandler(handler: Handler, method: HTTPMethod = defaultMethod) {
+    this._defaultHandler.set(method, normalizeHandler(handler));
   }
 
   /**

--- a/test/workbox-routing/sw/test-Router.mjs
+++ b/test/workbox-routing/sw/test-Router.mjs
@@ -321,11 +321,21 @@ describe(`Router`, function() {
   });
 
   describe(`setDefaultHandler()`, function() {
-    it(`should update the expected internal state`, function() {
+    it(`should update the expected internal state, with the default method`, function() {
       const router = new Router();
       router.setDefaultHandler(HANDLER);
 
-      expect(router._defaultHandler).to.eql(HANDLER);
+      expect(router._defaultHandler.get('GET')).to.eql(HANDLER);
+    });
+
+    it(`should update the expected internal state, with specific methods`, function() {
+      const router = new Router();
+      router.setDefaultHandler(HANDLER, 'POST');
+      router.setDefaultHandler(HANDLER, 'PUT');
+
+      expect(router._defaultHandler.get('POST')).to.eql(HANDLER);
+      expect(router._defaultHandler.get('PUT')).to.eql(HANDLER);
+      expect(router._defaultHandler.get('GET')).to.not.exist;
     });
 
     it(`should return a response from the default handler when there's no matching route`, async function() {
@@ -345,6 +355,34 @@ describe(`Router`, function() {
       const responseBody = await response.text();
 
       expect(responseBody).to.eql(EXPECTED_RESPONSE_BODY);
+    });
+
+    it(`should return a response from the default handler when there's no matching route, for a custom method`, async function() {
+      const router = new Router();
+      const route = new Route(
+          () => false,
+          () => new Response(),
+      );
+      router.registerRoute(route);
+      router.setDefaultHandler(() => new Response(EXPECTED_RESPONSE_BODY), 'POST');
+
+      const postRequest = new Request(location, {method: 'POST'});
+      const postEvent = new FetchEvent('fetch', {request: postRequest});
+      const postResponse = await router.handleRequest({
+        request: postRequest,
+        event: postEvent,
+      });
+      expect(postResponse).to.exist;
+      const postResponseBody = await postResponse.text();
+      expect(postResponseBody).to.eql(EXPECTED_RESPONSE_BODY);
+
+      const getRequest = new Request(location, {method: 'GET'});
+      const getEvent = new FetchEvent('fetch', {request: getRequest});
+      const getResponse = await router.handleRequest({
+        request: getRequest,
+        event: getEvent,
+      });
+      expect(getResponse).to.not.exist;
     });
   });
 


### PR DESCRIPTION
R: @philipwalton

Fixes #2434

The default method is `GET` and that's likely to be the most widely used method, but this is a breaking change since moving forward, a call to `setDefaultHandler()` won't cause `POST`, `PUT`, etc. requests to also match.
