### PR TITLE
Don't list mode as supported for injectManifest or getManifest

### DIFF
--- a/packages/workbox-build/src/get-manifest.js
+++ b/packages/workbox-build/src/get-manifest.js
@@ -63,11 +63,6 @@ const validate = require('./lib/validate-options');
  * prevents you from inadvertently precaching very large files that might have
  * accidentally matched one of your patterns.
  *
- * @param {string} [config.mode='production'] If set to 'production', then an
- * optimized service worker bundle that excludes debugging info will be
- * produced. If not explicitly configured here, the `process.env.NODE_ENV` value
- * will be used, and failing that, it will fall back to `'production'`.
- *
  * @param {object<string, string>} [config.modifyURLPrefix] A mapping of prefixes
  * that, if present in an entry in the precache manifest, will be replaced with
  * the corresponding value. This can be used to, for example, remove or add a

--- a/packages/workbox-build/src/inject-manifest.js
+++ b/packages/workbox-build/src/inject-manifest.js
@@ -91,11 +91,6 @@ const validate = require('./lib/validate-options');
  * prevents you from inadvertently precaching very large files that might have
  * accidentally matched one of your patterns.
  *
- * @param {string} [config.mode='production'] If set to 'production', then an
- * optimized service worker bundle that excludes debugging info will be
- * produced. If not explicitly configured here, the `process.env.NODE_ENV` value
- * will be used, and failing that, it will fall back to `'production'`.
- *
  * @param {object<string, string>} [config.modifyURLPrefix] A mapping of prefixes
  * that, if present in an entry in the precache manifest, will be replaced with
  * the corresponding value. This can be used to, for example, remove or add a

--- a/packages/workbox-build/src/options/partials/base.js
+++ b/packages/workbox-build/src/options/partials/base.js
@@ -19,6 +19,5 @@ module.exports = {
   manifestTransforms: joi.array().items(joi.func().minArity(1).maxArity(2)),
   maximumFileSizeToCacheInBytes: joi.number().min(1)
       .default(defaults.maximumFileSizeToCacheInBytes),
-  mode: joi.string().default(process.env.NODE_ENV || defaults.mode),
   modifyURLPrefix: joi.object(),
 };

--- a/packages/workbox-build/src/options/partials/generate.js
+++ b/packages/workbox-build/src/options/partials/generate.js
@@ -22,6 +22,7 @@ module.exports = {
   ignoreURLParametersMatching: joi.array().items(regExpObject),
   importScripts: joi.array().items(joi.string()),
   inlineWorkboxRuntime: joi.boolean().default(defaults.inlineWorkboxRuntime),
+  mode: joi.string().default(process.env.NODE_ENV || defaults.mode),
   navigateFallback: joi.string().default(defaults.navigateFallback),
   navigateFallbackAllowlist: joi.array().items(regExpObject),
   navigateFallbackBlacklist: joi.forbidden().error(new Error(

--- a/packages/workbox-build/src/options/partials/webpack.js
+++ b/packages/workbox-build/src/options/partials/webpack.js
@@ -17,4 +17,5 @@ module.exports = {
       .default(defaults.exclude),
   excludeChunks: joi.array().items(joi.string()),
   include: joi.array().items(joi.string(), regExpObject, joi.func().arity(1)),
+  mode: joi.string().default(process.env.NODE_ENV || defaults.mode),
 };

--- a/test/workbox-build/node/get-manifest.js
+++ b/test/workbox-build/node/get-manifest.js
@@ -42,6 +42,7 @@ describe(`[workbox-build] get-manifest.js (End to End)`, function() {
     'importScripts',
     'importWorkboxFrom',
     'injectionPointRegexp',
+    'mode',
     'navigateFallback',
     'navigateFallbackAllowlist',
     'runtimeCaching',

--- a/test/workbox-build/node/inject-manifest.js
+++ b/test/workbox-build/node/inject-manifest.js
@@ -48,6 +48,7 @@ describe(`[workbox-build] inject-manifest.js (End to End)`, function() {
     'ignoreURLParametersMatching',
     'importScripts',
     'importWorkboxFrom',
+    'mode',
     'navigateFallback',
     'navigateFallbackAllowlist',
     'runtimeCaching',


### PR DESCRIPTION
R: @philipwalton

Fixes #2427

`mode` wasn't intended to be supported for either `workbox-build`'s `injectManifest` or `getManifest` methods, but it was included due to some copy-paste errors when putting together v5.

This removes it form the JSDocs and will cause validation to fail if it's included in your config.