### PR TITLE
Update message to remove duplicate `is`

### DIFF
--- a/packages/workbox-core/src/models/messages/messages.ts
+++ b/packages/workbox-core/src/models/messages/messages.ts
@@ -89,7 +89,7 @@ export const messages: MessageMap = {
     return `Two of the entries passed to ` +
       `'workbox-precaching.PrecacheController.addToCacheList()' had the URL ` +
       `${firstEntry._entryId} but different revision details. Workbox is ` +
-      `is unable to cache and version the asset correctly. Please remove one ` +
+      `unable to cache and version the asset correctly. Please remove one ` +
       `of the entries.`;
   },
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1635852/80062275-f1b2bc80-84f8-11ea-8796-05f0a7361aa1.png)

I was getting this message on a workbox build. Notice the duplicate 'is'. 

R: @jeffposnick @philipwalton
