### PR TITLE
Disable Chrome Canary tests.

### DIFF
--- a/gulp-tasks/test-integration.js
+++ b/gulp-tasks/test-integration.js
@@ -138,12 +138,14 @@ gulp.task('test-integration', async () => {
     const localBrowsers = seleniumAssistant.getLocalBrowsers();
     for (const localBrowser of localBrowsers) {
       switch (localBrowser.getId()) {
-        case 'chrome':
         case 'firefox':
           if (localBrowser.getReleaseName() !== 'unstable') {
             await runIntegrationForBrowser(localBrowser);
           }
           break;
+        // Temporarily only test the stable release of Chrome, until the next
+        // https://www.npmjs.com/package/chromedriver release.
+        case 'chrome':
         case 'safari':
           if (localBrowser.getReleaseName() === 'stable') {
             await runIntegrationForBrowser(localBrowser);


### PR DESCRIPTION
R: @philipwalton 

This disables Chrome Canary tests (for the `v6` branch), as they're all failing right now due to a versioning issue with https://www.npmjs.com/package/chromedriver

We can re-enable when that's cleared up.
