### PR TITLE
Don't allow copyResponse() on cross-origin redirections

### DIFF
--- a/packages/workbox-core/src/models/messages/messages.ts
+++ b/packages/workbox-core/src/models/messages/messages.ts
@@ -261,4 +261,9 @@ export const messages: MessageMap = {
   'missing-precache-entry': ({cacheName, url}) => {
     return `Unable to find a precached response in ${cacheName} for ${url}.`;
   },
+
+  'cross-origin-copy-response': ({origin}) => {
+    return `workbox-core.copyResponse() can only be used with same-origin ` +
+      `responses. It was passed a response with origin ${origin}.`;
+  },
 };

--- a/test/workbox-precaching/sw/test-PrecacheController.mjs
+++ b/test/workbox-precaching/sw/test-PrecacheController.mjs
@@ -282,9 +282,11 @@ describe(`PrecacheController`, function() {
 
     it(`should clean redirected precache entries`, async function() {
       self.fetch.restore();
-      sandbox.stub(self, 'fetch').callsFake(() => {
+      sandbox.stub(self, 'fetch').callsFake((request) => {
         const response = new Response('Redirected Response');
-        sandbox.stub(response, 'redirected').value(true);
+        sandbox.replaceGetter(response, 'redirected', () => true);
+        sandbox.replaceGetter(response, 'url',
+          () => (new URL(request.url, self.location.href)).href);
         return response;
       });
 

--- a/test/workbox-precaching/sw/test-PrecacheController.mjs
+++ b/test/workbox-precaching/sw/test-PrecacheController.mjs
@@ -286,7 +286,7 @@ describe(`PrecacheController`, function() {
         const response = new Response('Redirected Response');
         sandbox.replaceGetter(response, 'redirected', () => true);
         sandbox.replaceGetter(response, 'url',
-          () => (new URL(request.url, self.location.href)).href);
+            () => (new URL(request.url, self.location.href)).href);
         return response;
       });
 


### PR DESCRIPTION
R: @philipwalton

Fixes #2468

The most immediate impact of this PR is that if `workbox-precaching` is used with a URL that results in a redirected response, and the URL of that redirected response isn't for the same-origin as the current web app, then precaching will fail.

(Note that cross-origin URLs are still allowed when precaching; this only impacts _redirected_ cross-origin URLs.)