### PR TITLE
Remove CDN dependency from integration tests

### DIFF
--- a/test/workbox-strategies/static/cache-first/sw.js
+++ b/test/workbox-strategies/static/cache-first/sw.js
@@ -9,6 +9,8 @@
 importScripts('/__WORKBOX/buildFile/workbox-sw');
 importScripts('/infra/testing/comlink/sw-interface.js');
 
+workbox.setConfig({modulePathPrefix: '/__WORKBOX/buildFile/'});
+
 workbox.routing.registerRoute(
     new RegExp('/test/workbox-strategies/static/cache-first/example.txt'),
     new workbox.strategies.CacheFirst(),

--- a/test/workbox-strategies/static/cache-only/sw.js
+++ b/test/workbox-strategies/static/cache-only/sw.js
@@ -9,6 +9,8 @@
 importScripts('/__WORKBOX/buildFile/workbox-sw');
 importScripts('/infra/testing/comlink/sw-interface.js');
 
+workbox.setConfig({modulePathPrefix: '/__WORKBOX/buildFile/'});
+
 workbox.routing.registerRoute(
     new RegExp('/CacheOnly/.*/'),
     new workbox.strategies.CacheOnly(),

--- a/test/workbox-strategies/static/network-first/sw.js
+++ b/test/workbox-strategies/static/network-first/sw.js
@@ -9,6 +9,8 @@
 importScripts('/__WORKBOX/buildFile/workbox-sw');
 importScripts('/infra/testing/comlink/sw-interface.js');
 
+workbox.setConfig({modulePathPrefix: '/__WORKBOX/buildFile/'});
+
 workbox.routing.registerRoute(
     new RegExp('/__WORKBOX/uniqueValue'),
     new workbox.strategies.NetworkFirst({

--- a/test/workbox-strategies/static/network-only/sw.js
+++ b/test/workbox-strategies/static/network-only/sw.js
@@ -9,6 +9,8 @@
 importScripts('/__WORKBOX/buildFile/workbox-sw');
 importScripts('/infra/testing/comlink/sw-interface.js');
 
+workbox.setConfig({modulePathPrefix: '/__WORKBOX/buildFile/'});
+
 workbox.routing.registerRoute(
     new RegExp('/__WORKBOX/uniqueValue'),
     new workbox.strategies.NetworkOnly({

--- a/test/workbox-strategies/static/stale-while-revalidate/sw.js
+++ b/test/workbox-strategies/static/stale-while-revalidate/sw.js
@@ -9,6 +9,8 @@
 importScripts('/__WORKBOX/buildFile/workbox-sw');
 importScripts('/infra/testing/comlink/sw-interface.js');
 
+workbox.setConfig({modulePathPrefix: '/__WORKBOX/buildFile/'});
+
 workbox.routing.registerRoute(
     new RegExp('/__WORKBOX/uniqueValue'),
     new workbox.strategies.StaleWhileRevalidate({


### PR DESCRIPTION
R: @philipwalton

Fixes #2413

This matches what we're doing in our other integration tests to ensure that Workbox is loaded from the local build files, not the CDN.