### PR TITLE
fix(build): migrate to the main lodash package

### DIFF
--- a/packages/workbox-build/package-lock.json
+++ b/packages/workbox-build/package-lock.json
@@ -1334,28 +1334,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
-    "lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -32,7 +32,7 @@
     "fast-json-stable-stringify": "^2.1.0",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.6",
-    "lodash.template": "^4.5.0",
+    "lodash": "^4.17.15",
     "pretty-bytes": "^5.3.0",
     "rollup": "^2.7.3",
     "rollup-plugin-terser": "^5.3.0",

--- a/packages/workbox-build/src/lib/populate-sw-template.js
+++ b/packages/workbox-build/src/lib/populate-sw-template.js
@@ -6,7 +6,7 @@
   https://opensource.org/licenses/MIT.
 */
 
-const template = require('lodash.template');
+const template = require('lodash/template');
 const swTemplate = require('../templates/sw-template');
 
 const errors = require('./errors');

--- a/test/workbox-build/node/lib/populate-sw-template.js
+++ b/test/workbox-build/node/lib/populate-sw-template.js
@@ -19,7 +19,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
     const manifestEntries = ['ignored'];
 
     const populateSWTemplate = proxyquire(MODULE_PATH, {
-      'lodash.template': () => {
+      'lodash/template': () => {
         throw new Error();
       },
     });
@@ -34,7 +34,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
 
   it(`should throw an error if both manifestEntries and runtimeCaching are empty`, function() {
     const populateSWTemplate = proxyquire(MODULE_PATH, {
-      'lodash.template': () => {},
+      'lodash/template': () => {},
     });
 
     try {
@@ -54,7 +54,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
     const innerStub = sinon.stub().returns('');
     const outerStub = sinon.stub().returns(innerStub);
     const populateSWTemplate = proxyquire(MODULE_PATH, {
-      'lodash.template': outerStub,
+      'lodash/template': outerStub,
       './runtime-caching-converter': () => runtimeCachingPlaceholder,
       '../templates/sw-template': swTemplate,
     });
@@ -114,7 +114,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
     const templatePopulationStub = sinon.stub().returns('');
     const templateCreationStub = sinon.stub().returns(templatePopulationStub);
     const populateSWTemplate = proxyquire(MODULE_PATH, {
-      'lodash.template': templateCreationStub,
+      'lodash/template': templateCreationStub,
       './runtime-caching-converter': () => runtimeCachingPlaceholder,
       '../templates/sw-template': swTemplate,
     });
@@ -181,7 +181,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
     const innerStub = sinon.stub().returns('');
     const outerStub = sinon.stub().returns(innerStub);
     const populateSWTemplate = proxyquire(MODULE_PATH, {
-      'lodash.template': outerStub,
+      'lodash/template': outerStub,
       './runtime-caching-converter': () => runtimeCachingPlaceholder,
       '../templates/sw-template': swTemplate,
     });


### PR DESCRIPTION
**What's the problem this PR addresses?**

The per method packages for lodash has been deprecated and the use of them is discouraged.
See https://lodash.com/per-method-packages for more

**How did you fix it?**

Replaced the per method packages with lodash and required the method directly