### PR TITLE
canConstructResponseFromBodyStream returns false

### DIFF
--- a/packages/workbox-core/src/_private/canConstructResponseFromBodyStream.ts
+++ b/packages/workbox-core/src/_private/canConstructResponseFromBodyStream.ts
@@ -31,8 +31,9 @@ function canConstructResponseFromBodyStream(): boolean {
       } catch (error) {
         supportStatus = false;
       }
+    } else {
+      supportStatus = false;
     }
-    supportStatus = false;
   }
 
   return supportStatus;


### PR DESCRIPTION
Looks like `supportStatus` is always false no matter what.

Do i need to open an issue for this small fix? R: @jeffposnick @philipwalton

