### PR TITLE
Ignore fbclid by default when matching precached URLs

### DIFF
--- a/packages/workbox-build/src/generate-sw.js
+++ b/packages/workbox-build/src/generate-sw.js
@@ -88,7 +88,7 @@ const writeServiceWorkerUsingDefaultTemplate =
  * definition of `strict` in the `glob`
  * [documentation](https://github.com/isaacs/node-glob#options).
  *
- * @param {Array<RegExp>} [config.ignoreURLParametersMatching=[/^utm_/]]
+ * @param {Array<RegExp>} [config.ignoreURLParametersMatching=[/^utm_/, /^fbclid$/]]
  * Any search parameter names that match against one of the RegExp in this array
  * will be removed before looking for a precache match. This is useful if your
  * users might request URLs that contain, for example, URL parameters used to

--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -91,7 +91,7 @@ class PrecacheController {
    * @param {string} [options.directoryIndex=index.html] The `directoryIndex`
    * will check cache entries for a URLs ending with '/' to see if there is a
    * hit when appending the `directoryIndex` value.
-   * @param {Array<RegExp>} [options.ignoreURLParametersMatching=[/^utm_/]] An
+   * @param {Array<RegExp>} [options.ignoreURLParametersMatching=[/^utm_/, /^fbclid$/]] An
    * array of regex's to remove search params when looking for a cache match.
    * @param {boolean} [options.cleanURLs=true] The `cleanURLs` option will
    * check the cache for the URL with a `.html` added to the end of the end.

--- a/packages/workbox-precaching/src/addRoute.ts
+++ b/packages/workbox-precaching/src/addRoute.ts
@@ -25,7 +25,7 @@ import './_version.js';
  * @param {string} [options.directoryIndex=index.html] The `directoryIndex` will
  * check cache entries for a URLs ending with '/' to see if there is a hit when
  * appending the `directoryIndex` value.
- * @param {Array<RegExp>} [options.ignoreURLParametersMatching=[/^utm_/]] An
+ * @param {Array<RegExp>} [options.ignoreURLParametersMatching=[/^utm_/, /^fbclid$/]] An
  * array of regex's to remove search params when looking for a cache match.
  * @param {boolean} [options.cleanURLs=true] The `cleanURLs` option will
  * check the cache for the URL with a `.html` added to the end of the end.

--- a/packages/workbox-precaching/src/utils/generateURLVariations.ts
+++ b/packages/workbox-precaching/src/utils/generateURLVariations.ts
@@ -22,7 +22,7 @@ import '../_version.js';
  * @memberof module:workbox-precaching
  */
 export function* generateURLVariations(url: string, {
-  ignoreURLParametersMatching = [/^utm_/],
+  ignoreURLParametersMatching = [/^utm_/, /^fbclid$/],
   directoryIndex = 'index.html',
   cleanURLs = true,
   urlManipulation,

--- a/packages/workbox-webpack-plugin/src/generate-sw.js
+++ b/packages/workbox-webpack-plugin/src/generate-sw.js
@@ -84,7 +84,7 @@ class GenerateSW {
    * @param {Array<string>} [config.excludeChunks] One or more chunk names whose
    * corresponding output files should be excluded from the precache manifest.
    *
-   * @param {Array<RegExp>} [config.ignoreURLParametersMatching=[/^utm_/]]
+   * @param {Array<RegExp>} [config.ignoreURLParametersMatching=[/^utm_/, /^fbclid$/]]
    * Any search parameter names that match against one of the RegExp in this array
    * will be removed before looking for a precache match. This is useful if your
    * users might request URLs that contain, for example, URL parameters used to

--- a/test/workbox-precaching/integration/test-precache-and-update.js
+++ b/test/workbox-precaching/integration/test-precache-and-update.js
@@ -55,12 +55,12 @@ describe(`[workbox-precaching] Precache and Update`, function() {
     // Include the default ignoreURLParametersMatching query parameters.
     await global.__workbox.webdriver.get(`${baseURL}index.html`);
     await global.__workbox.webdriver.get(`${baseURL}index.html?utm_source=test`);
-    await global.__workbox.webdriver.get(`${baseURL}index.html?^fbclid$=test`);
+    await global.__workbox.webdriver.get(`${baseURL}index.html?fbclid=test`);
 
     expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/')).to.eql(0);
     expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html')).to.eql(0);
     expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html?utm_source=test')).to.eql(0);
-    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html?^fbclid$=test')).to.eql(0);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html?fbclid=test')).to.eql(0);
     expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/styles/index.css')).to.eql(0);
 
     // Unregister the old counter, and start a new count.

--- a/test/workbox-precaching/integration/test-precache-and-update.js
+++ b/test/workbox-precaching/integration/test-precache-and-update.js
@@ -52,10 +52,15 @@ describe(`[workbox-precaching] Precache and Update`, function() {
     requestCounter = global.__workbox.server.startCountingRequests();
 
     // Request the page and check that the precached assets weren't requested from the network.
+    // Include the default ignoreURLParametersMatching query parameters.
     await global.__workbox.webdriver.get(`${baseURL}index.html`);
+    await global.__workbox.webdriver.get(`${baseURL}index.html?utm_source=test`);
+    await global.__workbox.webdriver.get(`${baseURL}index.html?^fbclid$=test`);
 
     expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/')).to.eql(0);
     expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html')).to.eql(0);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html?utm_source=test')).to.eql(0);
+    expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/index.html?^fbclid$=test')).to.eql(0);
     expect(requestCounter.getURLCount('/test/workbox-precaching/static/precache-and-update/styles/index.css')).to.eql(0);
 
     // Unregister the old counter, and start a new count.


### PR DESCRIPTION
R: @philipwalton

Fixes #2417

This adds `fbclid` to the default list of URL query parameters that should be ignored when matching against precached URLs.