### PR TITLE
Adds CacheQueryOptions to workbox-expiration

### DIFF
--- a/packages/workbox-expiration/src/ExpirationPlugin.ts
+++ b/packages/workbox-expiration/src/ExpirationPlugin.ts
@@ -48,12 +48,15 @@ class ExpirationPlugin implements WorkboxPlugin {
    * Entries used the least will be removed as the maximum is reached.
    * @param {number} [config.maxAgeSeconds] The maximum age of an entry before
    * it's treated as stale and removed.
+   * @param {Object} [config.matchOptions] The [`CacheQueryOptions`](https://developer.mozilla.org/en-US/docs/Web/API/Cache/delete#Parameters)
+   * that will be used when calling `delete()` on the cache.
    * @param {boolean} [config.purgeOnQuotaError] Whether to opt this cache in to
    * automatic deletion if the available storage quota has been exceeded.
    */
   constructor(config: {
     maxEntries?: number;
     maxAgeSeconds?: number;
+    matchOptions?: CacheQueryOptions;
     purgeOnQuotaError?: boolean;
   } = {}) {
     if (process.env.NODE_ENV !== 'production') {

--- a/test/workbox-expiration/sw/test-ExpirationPlugin.mjs
+++ b/test/workbox-expiration/sw/test-ExpirationPlugin.mjs
@@ -89,6 +89,18 @@ describe(`ExpirationPlugin`, function() {
 
       expect(plugin.deleteCacheAndMetadata.called).to.be.false;
     });
+
+    it(`should pass matchOptions through to the CacheExpiration instance`, async function() {
+      const plugin = new ExpirationPlugin({
+        maxEntries: 10,
+        matchOptions: {
+          ignoreVary: true,
+        },
+      });
+
+      const cacheExpiration = plugin._getCacheExpiration('test-matchOptions');
+      expect(cacheExpiration._matchOptions).to.eql({ignoreVary: true});
+    });
   });
 
   describe(`cachedResponseWillBeUsed()`, function() {


### PR DESCRIPTION
R: @philipwalton

Fixes #2206

Supports setting `CacheQueryOptions` in `workbox-expiration` that will then be passed through to the underlying `cache.delete()` call.