### PR TITLE
Switch from external<event> to isExternal property

### DIFF
--- a/packages/workbox-window/src/utils/WorkboxEvent.ts
+++ b/packages/workbox-window/src/utils/WorkboxEvent.ts
@@ -20,6 +20,7 @@ export class WorkboxEvent<K extends keyof WorkboxEventMap> {
   target?: WorkboxEventTarget;
   sw?: ServiceWorker;
   originalEvent?: Event;
+  isExternal?: boolean;
 
   constructor(public type: K, props: Omit<WorkboxEventMap[K], 'target' | 'type'>) {
     Object.assign(this, props);
@@ -46,11 +47,6 @@ export interface WorkboxLifecycleEventMap {
   'activating': WorkboxLifecycleEvent;
   'activated': WorkboxLifecycleEvent;
   'controlling': WorkboxLifecycleEvent;
-  'externalinstalling': WorkboxLifecycleEvent;
-  'externalinstalled': WorkboxLifecycleEvent;
-  'externalwaiting': WorkboxLifecycleWaitingEvent;
-  'externalactivating': WorkboxLifecycleEvent;
-  'externalactivated': WorkboxLifecycleEvent;
   'redundant': WorkboxLifecycleEvent;
 }
 


### PR DESCRIPTION
R: @philipwalton

Fixes #2031 

This keeps most of the logic the same, but swaps out the `external<something>` events for a `<something>` event that has a new `isExternal` property set.

This is a breaking change, obviously, and means that folks who did care about the distinction between non-external and external events need to explicitly check `isExternal`. Most folks didn't seem to care about the distinction, though, so the net effect is that you only need to listen to one type of event from now on.

The test suite hopefully covers the same ground as what we previously tested, but it was a bit of a struggle...