### PR TITLE
Discourage use of workbox-core's skipWaiting

### DIFF
--- a/infra/testing/validator/service-worker-runtime.js
+++ b/infra/testing/validator/service-worker-runtime.js
@@ -67,7 +67,6 @@ function setupSpiesAndContextForInjectManifest() {
     core: {
       clientsClaim: sinon.spy(),
       setCacheNameDetails: sinon.spy(),
-      skipWaiting: sinon.spy(),
     },
     setConfig: sinon.spy(),
     // To make testing easier, return the name of the strategy.
@@ -82,6 +81,7 @@ function setupSpiesAndContextForInjectManifest() {
     workbox,
   }, makeServiceWorkerEnv());
   context.self.addEventListener = addEventListener;
+  context.self.skipWaiting = sinon.spy();
 
   const methodsToSpies = {
     importScripts,
@@ -99,7 +99,7 @@ function setupSpiesAndContextForInjectManifest() {
     registerRoute: workbox.routing.registerRoute,
     setCacheNameDetails: workbox.core.setCacheNameDetails,
     setConfig: workbox.setConfig,
-    skipWaiting: workbox.core.skipWaiting,
+    skipWaiting: context.self.skipWaiting,
   };
 
   return {addEventListener, context, methodsToSpies};
@@ -135,6 +135,7 @@ function setupSpiesAndContextForGenerateSW() {
     },
   }, makeServiceWorkerEnv());
   context.self.addEventListener = addEventListener;
+  context.self.skipWaiting = workboxContext.skipWaiting;
 
   return {addEventListener, context, methodsToSpies: workboxContext};
 }

--- a/packages/workbox-build/src/templates/sw-template.js
+++ b/packages/workbox-build/src/templates/sw-template.js
@@ -29,7 +29,7 @@ importScripts(
 <% if (cacheId) { %><%= use('workbox-core', 'setCacheNameDetails') %>({prefix: <%= JSON.stringify(cacheId) %>});<% } %>
 
 <% if (skipWaiting) { %>
-<%= use('workbox-core', 'skipWaiting') %>();
+self.skipWaiting();
 <% } else { %>
 self.addEventListener('message', (event) => {
   if (event.data && event.data.type === 'SKIP_WAITING') {

--- a/packages/workbox-core/src/skipWaiting.ts
+++ b/packages/workbox-core/src/skipWaiting.ts
@@ -6,23 +6,30 @@
   https://opensource.org/licenses/MIT.
 */
 
-import './_version.js';
+import {logger} from './_private/logger.js';
 
+import './_version.js';
 
 // Give TypeScript the correct global.
 declare let self: ServiceWorkerGlobalScope;
 
 /**
- * Force a service worker to activate immediately, instead of
- * [waiting](https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#waiting)
- * for existing clients to close.
+ * This method is deprecated, and will be removed in Workbox v7.
+ * 
+ * Calling self.skipWaiting() is equivalent, and should be used instead.
  *
  * @memberof module:workbox-core
  */
 function skipWaiting() {
-  // We need to explicitly call `self.skipWaiting()` here because we're
-  // shadowing `skipWaiting` with this local function.
-  self.addEventListener('install', () => self.skipWaiting());
+  // Just call self.skipWaiting() directly.
+  // See https://github.com/GoogleChrome/workbox/issues/2525
+  if (process.env.NODE_ENV !== 'production') {
+    logger.warn(`skipWaiting() from workbox-core is no longer recommended ` +
+        `and will be removed in Workbox v7. Using self.skipWaiting() instead ` +
+        `is equivalent.`);
+  }
+
+  self.skipWaiting();
 }
 
 export {skipWaiting}

--- a/test/workbox-core/sw/test-skipWaiting.mjs
+++ b/test/workbox-core/sw/test-skipWaiting.mjs
@@ -6,28 +6,35 @@
   https://opensource.org/licenses/MIT.
 */
 
+import {logger} from 'workbox-core/_private/logger.mjs';
 import {skipWaiting} from 'workbox-core/skipWaiting.mjs';
-
 
 describe(`skipWaiting`, function() {
   const sandbox = sinon.createSandbox();
 
-  after(function() {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  it(`should add an install event listener that calls skipWaiting`, function(done) {
-    const skipWaitingSpy = sandbox.spy(self, 'skipWaiting');
-
-    sandbox.stub(self, 'addEventListener').callsFake((eventName, cb) => {
-      expect(eventName).to.equal('install');
-
-      cb();
-
-      expect(skipWaitingSpy.callCount).to.equal(1);
-      done();
-    });
+  it(`should call self.skipWaiting()`, function() {
+    const skipWaitingStub = sandbox.stub(self, 'skipWaiting');
 
     skipWaiting();
+
+    expect(skipWaitingStub.callCount).to.eql(1);
+  });
+
+  it(`should log a warning message in development`, function() {
+    if (process.env.NODE_ENV === 'production') {
+      this.skip();
+    }
+
+    const warnStub = sandbox.stub(logger, 'warn');
+    const skipWaitingStub = sandbox.stub(self, 'skipWaiting');
+
+    skipWaiting();
+
+    expect(skipWaitingStub.callCount).to.eql(1);
+    expect(warnStub.callCount).to.eql(1);
   });
 });


### PR DESCRIPTION
R: @philipwalton

Fixes #2525 (ignore the branch name...)

Usage of `workbox-core`'s `skipWaiting()`, which wrapped the `self.skipWaiting()` in an `install` handler, has been confusing for folks who, for instance, want to call `self.skipWaiting()` inside a `message` handler.

Since `self.skipWaiting()` can be "safely" called at any point, there's little value in wrapping it in an `install` handler, and this PR drops that.

We could remove it from `workbox-core` entirely in v7.