### PR TITLE
Ensure getSW() always returns a promise

### DIFF
--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -254,10 +254,12 @@ class Workbox extends WorkboxEventTarget {
    *
    * @return {Promise<ServiceWorker>}
    */
-  async getSW(): Promise<ServiceWorker> {
+  getSW(): Promise<ServiceWorker> {
     // If `this._sw` is set, resolve with that as we want `getSW()` to
     // return the correct (new) service worker if an update is found.
-    return this._sw !== undefined ? this._sw : this._swDeferred.promise;
+    return this._sw !== undefined ?
+      Promise.resolve(this._sw) :
+      this._swDeferred.promise;
   }
 
   /**


### PR DESCRIPTION
R: @philipwalton
CC: @housseindjirdeh 

Fixes #2545

I think the `async` without any usage of `await` might have confused the transpilation? Anyway, being explicit seems like the best option.
