### PR TITLE
Support the integrity property in manifest-entry validation

### DIFF
--- a/packages/workbox-build/src/options/objects/manifest-entry.js
+++ b/packages/workbox-build/src/options/objects/manifest-entry.js
@@ -9,6 +9,7 @@
 const joi = require('@hapi/joi');
 
 module.exports = joi.object().keys({
+  integrity: joi.string(),
   revision: joi.string().required().allow(null),
   url: joi.string().required(),
 });

--- a/test/workbox-build/node/generate-sw.js
+++ b/test/workbox-build/node/generate-sw.js
@@ -327,6 +327,8 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
           '/one',
           {url: '/two', revision: null},
           {url: '/three', revision: '333'},
+          // See https://github.com/GoogleChrome/workbox/issues/2558
+          {url: '/four', revision: '123', integrity: '456'},
         ],
         swDest,
       });
@@ -334,7 +336,7 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
       const {count, filePaths, size, warnings} = await generateSW(options);
       // The string additionalManifestEntries entry should lead to one warning.
       expect(warnings).to.have.length(1);
-      expect(count).to.eql(9);
+      expect(count).to.eql(10);
       // Line ending differences lead to different sizes on Windows.
       expect(size).to.be.oneOf([2604, 2686]);
 
@@ -366,6 +368,10 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
         }, {
           revision: '333',
           url: '/three',
+        }, {
+          url: '/four',
+          revision: '123',
+          integrity: '456',
         }], {}]],
       }});
     });


### PR DESCRIPTION
R: @philipwalton

Fixes #2558

This was left out inadvertently, making it difficult to add in `integrity` fields to `additionalManifestEntries`.
