### PR TITLE
Precache one request at a time

### DIFF
--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -275,18 +275,19 @@ class PrecacheController {
       }
     }
 
-    const precacheRequests = toBePrecached.map(({cacheKey, url}) => {
+    // Cache entries one at a time.
+    // See https://github.com/GoogleChrome/workbox/issues/2528
+    for (const {cacheKey, url} of toBePrecached) {
       const integrity = this._cacheKeysToIntegrities.get(cacheKey);
       const cacheMode = this._urlsToCacheModes.get(url);
-      return this._addURLToCache({
+      await this._addURLToCache({
         cacheKey,
         cacheMode,
         event,
         integrity,
         url,
       });
-    });
-    await Promise.all(precacheRequests);
+    }
 
     const updatedURLs = toBePrecached.map((item) => item.url);
 


### PR DESCRIPTION
R: @philipwalton

Fixes #2528

This is basically batched precaching with a forced batch size of 1, i.e. only have one preaching request in flight at a given time.

I think this is a win from the perspective of reducing possible bandwidth contention with the main thread during precaching as well.