### PR TITLE
Document skipWaiting message in GenerateSW

### DIFF
--- a/packages/workbox-build/src/generate-sw.js
+++ b/packages/workbox-build/src/generate-sw.js
@@ -171,7 +171,8 @@ const writeServiceWorkerUsingDefaultTemplate =
  * @param {boolean} [config.skipWaiting=false] Whether to add an
  * unconditional call to [`skipWaiting()`]{@link module:workbox-core.skipWaiting}
  * to the generated service worker. If `false`, then a `message` listener will
- * be added instead, allowing you to conditionally call `skipWaiting()`.
+ * be added instead, allowing you to conditionally call `skipWaiting()` by posting
+ * a message containing {type: 'SKIP_WAITING'}.
  *
  * @param {boolean} [config.sourcemap=true] Whether to create a sourcemap
  * for the generated service worker files.

--- a/packages/workbox-webpack-plugin/src/generate-sw.js
+++ b/packages/workbox-webpack-plugin/src/generate-sw.js
@@ -177,7 +177,8 @@ class GenerateSW {
    * @param {boolean} [config.skipWaiting=false] Whether to add an
    * unconditional call to [`skipWaiting()`]{@link module:workbox-core.skipWaiting}
    * to the generated service worker. If `false`, then a `message` listener will
-   * be added instead, allowing you to conditionally call `skipWaiting()`.
+   * be added instead, allowing you to conditionally call `skipWaiting()` by posting.
+   * a message containing {type: 'SKIP_WAITING'}.
    *
    * @param {boolean} [config.sourcemap=true] Whether to create a sourcemap
    * for the generated service worker files.

--- a/packages/workbox-webpack-plugin/src/generate-sw.js
+++ b/packages/workbox-webpack-plugin/src/generate-sw.js
@@ -177,7 +177,7 @@ class GenerateSW {
    * @param {boolean} [config.skipWaiting=false] Whether to add an
    * unconditional call to [`skipWaiting()`]{@link module:workbox-core.skipWaiting}
    * to the generated service worker. If `false`, then a `message` listener will
-   * be added instead, allowing you to conditionally call `skipWaiting()` by posting.
+   * be added instead, allowing you to conditionally call `skipWaiting()` by posting
    * a message containing {type: 'SKIP_WAITING'}.
    *
    * @param {boolean} [config.sourcemap=true] Whether to create a sourcemap


### PR DESCRIPTION
R: @jeffposnick @philipwalton

It wasn't very clear from the documentation how `skipWaiting` could be triggered via `postMessage`.