### PR TITLE
Add fetch fallback option for generate SW

### DIFF
--- a/packages/workbox-build/src/lib/populate-sw-template.js
+++ b/packages/workbox-build/src/lib/populate-sw-template.js
@@ -30,6 +30,7 @@ module.exports = ({
   offlineGoogleAnalytics,
   runtimeCaching = [],
   skipWaiting,
+  fetchFallback,
 }) => {
   // There needs to be at least something to precache, or else runtime caching.
   if (!(manifestEntries.length > 0 || runtimeCaching.length > 0)) {
@@ -85,6 +86,7 @@ module.exports = ({
       precacheOptionsString,
       runtimeCaching: runtimeCachingConverter(moduleRegistry, runtimeCaching),
       skipWaiting,
+      fetchFallback,
       use: moduleRegistry.use.bind(moduleRegistry),
     });
 

--- a/packages/workbox-build/src/lib/write-sw-using-default-template.js
+++ b/packages/workbox-build/src/lib/write-sw-using-default-template.js
@@ -34,6 +34,7 @@ module.exports = async ({
   skipWaiting,
   sourcemap,
   swDest,
+  fetchFallback,
 }) => {
   const outputDir = upath.dirname(swDest);
   try {
@@ -59,6 +60,7 @@ module.exports = async ({
     offlineGoogleAnalytics,
     runtimeCaching,
     skipWaiting,
+    fetchFallback,
   });
 
   try {

--- a/packages/workbox-build/src/options/partials/generate.js
+++ b/packages/workbox-build/src/options/partials/generate.js
@@ -82,4 +82,18 @@ module.exports = {
   }),
   skipWaiting: joi.boolean().default(defaults.skipWaiting),
   sourcemap: joi.boolean().default(defaults.sourcemap),
+  fetchFallback: joi.object().keys({
+    document: joi.object().keys({
+      url: joi.string().required(),
+      precached: joi.boolean(),
+    }),
+    image: joi.object().keys({
+      url: joi.string().required(),
+      precached: joi.boolean(),
+    }),
+    font: joi.object().keys({
+      url: joi.string().required(),
+      precached: joi.boolean(),
+    }),
+  }).min(1).max(3),
 };

--- a/packages/workbox-build/src/templates/sw-template.js
+++ b/packages/workbox-build/src/templates/sw-template.js
@@ -57,4 +57,36 @@ self.addEventListener('message', (event) => {
 
 <% if (offlineAnalyticsConfigString) { %><%= use('workbox-google-analytics', 'initialize') %>(<%= offlineAnalyticsConfigString %>);<% } %>
 
-<% if (disableDevLogs) { %>self.__WB_DISABLE_DEV_LOGS = true;<% } %>`;
+<% if (disableDevLogs) { %>self.__WB_DISABLE_DEV_LOGS = true;<% } %>
+
+<% if (fetchFallback) { %><%= use('workbox-routing', 'setCatchHandler') %>(async ({ event }) => {
+  switch (event.request.destination) {
+    <% if (fetchFallback.document) { %>
+    case 'document':
+      <% if (fetchFallback.document.precached) { %>
+        return await <%= use('workbox-precaching', 'matchPrecache') %>(<%= JSON.stringify(fetchFallback.document.url) %>)
+      <% } else{ %>
+        return await caches.match(<%= JSON.stringify(fetchFallback.document.url) %>)
+      <% } %>
+    <% } %>
+    <% if (fetchFallback.image) { %>
+    case 'image':
+      <% if (fetchFallback.image.precached) { %>
+        return await <%= use('workbox-precaching', 'matchPrecache') %>(<%= JSON.stringify(fetchFallback.image.url) %>)
+      <% } else{ %>
+        return await caches.match(<%= JSON.stringify(fetchFallback.image.url) %>)
+      <% } %>
+    <% } %>
+    <% if (fetchFallback.font) { %>
+    case 'font':
+      <% if (fetchFallback.font.precached) { %>
+        return await <%= use('workbox-precaching', 'matchPrecache') %>(<%= JSON.stringify(fetchFallback.font.url) %>)
+      <% } else{ %>
+        return await caches.match(<%= JSON.stringify(fetchFallback.font.url) %>)
+      <% } %>
+    <% } %>
+    default:
+      return Response.error()
+  }
+});<% } %>
+`;

--- a/test/workbox-build/node/lib/populate-sw-template.js
+++ b/test/workbox-build/node/lib/populate-sw-template.js
@@ -82,6 +82,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
       precacheOptionsString,
       runtimeCaching: runtimeCachingPlaceholder,
       skipWaiting: undefined,
+      fetchFallback: undefined,
     }]);
   });
 
@@ -106,6 +107,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
     const skipWaiting = true;
     const swTemplate = 'template';
     const precacheOptionsString = '{\n  "directoryIndex": "index.html",\n  "ignoreURLParametersMatching": [/a/, /b/]\n}';
+    const fetchFallback = {document: {url: 'fallback'}};
 
     // There are two stages in templating: creating the active template function
     // from an initial string, and passing variables to that template function
@@ -136,6 +138,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
       offlineGoogleAnalytics,
       runtimeCaching,
       skipWaiting,
+      fetchFallback,
     });
 
     expect(templateCreationStub.alwaysCalledWith(swTemplate)).to.be.true;
@@ -159,6 +162,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
       runtimeCaching: runtimeCachingPlaceholder,
       precacheOptionsString,
       skipWaiting,
+      fetchFallback,
     }]);
   });
 
@@ -209,6 +213,7 @@ describe(`[workbox-build] lib/populate-sw-template.js`, function() {
       precacheOptionsString,
       runtimeCaching: runtimeCachingPlaceholder,
       skipWaiting: undefined,
+      fetchFallback: undefined,
     }]);
   });
 });


### PR DESCRIPTION
This provides a fallback mechanism when both network and cache is not available

All of the built-in caching strategies reject in a consistent manner when there's a network failure and/or a cache miss. This promotes the pattern of setting a global "catch" handler to deal with any failures in a single handler function.

Reference:
https://developers.google.com/web/tools/workbox/guides/advanced-recipes#comprehensive_fallbacks

R: @jeffposnick @philipwalton

Fixes: https://github.com/GoogleChrome/workbox/issues/2566 (see the issue for more detailed description)

Following is generated in the `service-worker.js` when generate SW
![image](https://user-images.githubusercontent.com/9603375/86545485-376e0700-bee4-11ea-89f9-7b986542e488.png)

