### PR TITLE
Fix workbox-build types in workbox-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,10 @@ firebase-debug.log
 # Generated TypeScript files and build data
 tsconfig.tsbuildinfo
 packages/workbox-*/**/*.d.ts
+!packages/workbox-cli/src/index.d.ts
 packages/workbox-*/**/*.js
 !packages/workbox-build/**/*.js
-!packages/workbox-cli/**/*.js
 !packages/workbox-webpack-plugin/**/*.js
-
 
 # Individual package ignores during TypeScript migration
 packages/workbox-background-sync/**/*.mjs
@@ -41,4 +40,3 @@ packages/workbox-routing/**/*.mjs
 packages/workbox-strategies/**/*.mjs
 packages/workbox-streams/**/*.mjs
 packages/workbox-window/**/*.mjs
-workbocx-cli-ts.code-workspace

--- a/packages/workbox-cli/package-lock.json
+++ b/packages/workbox-cli/package-lock.json
@@ -5,24 +5,24 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-      "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "requires": {
-        "@babel/highlight": "^7.10.1"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
     },
     "@babel/highlight": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-      "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.1",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -137,9 +137,9 @@
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
     },
     "@types/node": {
-      "version": "14.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
+      "version": "14.0.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.20.tgz",
+      "integrity": "sha512-MRn/NP3dee8yL5QhbSA6riuwkS+UOcsPUMOIOG3KMUQpuor/2TopdRBu8QaaB4fGU+gz/bzyDWt0FtUbeJ8H1A==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -164,21 +164,6 @@
       "requires": {
         "@types/configstore": "*"
       }
-    },
-    "@types/workbox-build": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/workbox-build/-/workbox-build-5.0.0.tgz",
-      "integrity": "sha512-6hn6W63+U1zaTRCaHIwJTVx1FaZbXZDA9dOE/txsQk8D0nRDZLxtnTwhfyvhtxnWb+zY7nH7psuJXv4oUDZyMA==",
-      "dev": true,
-      "requires": {
-        "@types/workbox-routing": "*"
-      }
-    },
-    "@types/workbox-routing": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@types/workbox-routing/-/workbox-routing-4.3.0.tgz",
-      "integrity": "sha512-op5P/f6n+9g5X4a+sYONp9EALnNxpoU3oXuB/BjeQv9d+k0bNE4LYSF06K6tXYL4PeCIZVJOi4yMCUCOi2NaqQ==",
-      "dev": true
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -295,20 +280,20 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "async-done": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.1.tgz",
-      "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+      "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.2",
-        "process-nextick-args": "^1.0.7",
+        "process-nextick-args": "^2.0.0",
         "stream-exhaust": "^1.0.1"
       }
     },
     "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -376,9 +361,9 @@
       }
     },
     "binary-extensions": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
     "bindings": {
       "version": "1.5.0",
@@ -531,23 +516,29 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "chokidar": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-      "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "requires": {
         "anymatch": "^2.0.0",
-        "async-each": "^1.0.0",
-        "braces": "^2.3.0",
-        "fsevents": "^1.2.2",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
-        "inherits": "^2.0.1",
+        "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
         "is-glob": "^4.0.0",
-        "lodash.debounce": "^4.0.8",
-        "normalize-path": "^2.1.1",
+        "normalize-path": "^3.0.0",
         "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0",
-        "upath": "^1.0.5"
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+        }
       }
     },
     "ci-info": {
@@ -595,9 +586,9 @@
       "integrity": "sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w=="
     },
     "cli-width": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
     },
     "clone": {
       "version": "1.0.4",
@@ -640,9 +631,9 @@
       "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
     },
     "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -793,9 +784,9 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
@@ -1012,13 +1003,6 @@
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^1.0.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
-        }
       }
     },
     "fs.realpath": {
@@ -1121,9 +1105,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "hard-rejection": {
       "version": "2.1.0",
@@ -1212,9 +1196,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -1222,34 +1206,23 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.2.0.tgz",
-      "integrity": "sha512-E0c4rPwr9ByePfNlTIB8z51kK1s2n6jrHuJeEHENl/sbq2G/S1auvibgEwNR4uSyiU+PiYHqSwsgGiXjG8p5ZQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.0.tgz",
+      "integrity": "sha512-K+LZp6L/6eE5swqIcVXrxl21aGDU4S50gKH0/d96OMQnSBCyGyZl/oZhbkVmdp5sBoINHd4xZvFSARh2dk6DWA==",
       "requires": {
         "ansi-escapes": "^4.2.1",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.0",
         "cli-cursor": "^3.1.0",
-        "cli-width": "^2.0.0",
+        "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
-        "rxjs": "^6.5.3",
+        "rxjs": "^6.6.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "is-accessor-descriptor": {
@@ -1347,9 +1320,9 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -1482,9 +1455,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "latest-version": {
       "version": "5.1.0",
@@ -1508,14 +1481,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "log-symbols": {
       "version": "3.0.0",
@@ -1690,13 +1658,6 @@
         "arrify": "^1.0.1",
         "is-plain-obj": "^1.1.0",
         "kind-of": "^6.0.3"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-        }
       }
     },
     "mixin-deep": {
@@ -1974,9 +1935,9 @@
       "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "pump": {
       "version": "3.0.0",
@@ -2047,9 +2008,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -2058,13 +2019,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-        }
       }
     },
     "readdirp": {
@@ -2167,9 +2121,9 @@
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
     },
     "rxjs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
+      "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -2181,7 +2135,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -2341,11 +2295,11 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "requires": {
-        "atob": "^2.1.1",
+        "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
@@ -2429,7 +2383,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -2471,7 +2425,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {
@@ -2742,11 +2696,11 @@
           }
         },
         "@babel/compat-data": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.10.4.tgz",
-          "integrity": "sha512-t+rjExOrSVvjQQXNp5zAIYDp00KjdvGl/TpDX5REPr0S9IAIPQMTilcfG6q8c0QFmj9lSTVySV2VTsyggvtNIw==",
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.0.tgz",
+          "integrity": "sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==",
           "requires": {
-            "browserslist": "^4.12.0",
+            "browserslist": "^4.9.1",
             "invariant": "^2.2.4",
             "semver": "^5.5.0"
           }
@@ -2782,11 +2736,11 @@
           }
         },
         "@babel/generator": {
-          "version": "7.9.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
-          "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
+          "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
           "requires": {
-            "@babel/types": "^7.9.0",
+            "@babel/types": "^7.9.5",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.13",
             "source-map": "^0.5.0"
@@ -2800,429 +2754,71 @@
           }
         },
         "@babel/helper-annotate-as-pure": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
-          "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
+          "integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
           "requires": {
-            "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
+            "@babel/types": "^7.8.3"
           }
         },
         "@babel/helper-builder-binary-assignment-operator-visitor": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
-          "integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
+          "integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
           "requires": {
-            "@babel/helper-explode-assignable-expression": "^7.10.4",
-            "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
+            "@babel/helper-explode-assignable-expression": "^7.8.3",
+            "@babel/types": "^7.8.3"
           }
         },
         "@babel/helper-compilation-targets": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
-          "integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
+          "integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
           "requires": {
-            "@babel/compat-data": "^7.10.4",
-            "browserslist": "^4.12.0",
+            "@babel/compat-data": "^7.8.6",
+            "browserslist": "^4.9.1",
             "invariant": "^2.2.4",
             "levenary": "^1.1.1",
             "semver": "^5.5.0"
           }
         },
-        "@babel/helper-create-class-features-plugin": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.4.tgz",
-          "integrity": "sha512-9raUiOsXPxzzLjCXeosApJItoMnX3uyT4QdM2UldffuGApNrF8e938MwNpDCK9CPoyxrEoCgT+hObJc3mZa6lQ==",
-          "requires": {
-            "@babel/helper-function-name": "^7.10.4",
-            "@babel/helper-member-expression-to-functions": "^7.10.4",
-            "@babel/helper-optimise-call-expression": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/helper-replace-supers": "^7.10.4",
-            "@babel/helper-split-export-declaration": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-              "requires": {
-                "@babel/highlight": "^7.10.4"
-              }
-            },
-            "@babel/generator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-              "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
-              "requires": {
-                "@babel/types": "^7.10.4",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0"
-              }
-            },
-            "@babel/helper-function-name": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-              "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-              "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-member-expression-to-functions": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-              "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-optimise-call-expression": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-              "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-replace-supers": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-              "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
-              "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.10.4",
-                "@babel/helper-optimise-call-expression": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-split-export-declaration": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-              "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/highlight": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-              "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-              "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
-            },
-            "@babel/template": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-              "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/traverse": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-              "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
-          }
-        },
         "@babel/helper-create-regexp-features-plugin": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
-          "integrity": "sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==",
+          "version": "7.8.8",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.8.tgz",
+          "integrity": "sha512-LYVPdwkrQEiX9+1R29Ld/wTrmQu1SSKYnuOk3g0CkcZMA1p0gsNxJFj/3gBdaJ7Cg0Fnek5z0DsMULePP7Lrqg==",
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.4",
-            "@babel/helper-regex": "^7.10.4",
+            "@babel/helper-annotate-as-pure": "^7.8.3",
+            "@babel/helper-regex": "^7.8.3",
             "regexpu-core": "^4.7.0"
           }
         },
         "@babel/helper-define-map": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.4.tgz",
-          "integrity": "sha512-nIij0oKErfCnLUCWaCaHW0Bmtl2RO9cN7+u2QT8yqTywgALKlyUVOvHDElh+b5DwVC6YB1FOYFOTWcN/+41EDA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
+          "integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
           "requires": {
-            "@babel/helper-function-name": "^7.10.4",
-            "@babel/types": "^7.10.4",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/types": "^7.8.3",
             "lodash": "^4.17.13"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-              "requires": {
-                "@babel/highlight": "^7.10.4"
-              }
-            },
-            "@babel/helper-function-name": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-              "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-              "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/highlight": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-              "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-              "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
-            },
-            "@babel/template": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-              "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/helper-explode-assignable-expression": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz",
-          "integrity": "sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
+          "integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
           "requires": {
-            "@babel/traverse": "^7.10.4",
-            "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-              "requires": {
-                "@babel/highlight": "^7.10.4"
-              }
-            },
-            "@babel/generator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-              "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
-              "requires": {
-                "@babel/types": "^7.10.4",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0"
-              }
-            },
-            "@babel/helper-function-name": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-              "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-              "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-split-export-declaration": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-              "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/highlight": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-              "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-              "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
-            },
-            "@babel/template": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-              "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/traverse": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-              "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
+            "@babel/traverse": "^7.8.3",
+            "@babel/types": "^7.8.3"
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+          "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
           "requires": {
             "@babel/helper-get-function-arity": "^7.8.3",
             "@babel/template": "^7.8.3",
-            "@babel/types": "^7.8.3"
+            "@babel/types": "^7.9.5"
           }
         },
         "@babel/helper-get-function-arity": {
@@ -3234,28 +2830,11 @@
           }
         },
         "@babel/helper-hoist-variables": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
-          "integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
+          "integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
           "requires": {
-            "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
+            "@babel/types": "^7.8.3"
           }
         },
         "@babel/helper-member-expression-to-functions": {
@@ -3297,136 +2876,28 @@
           }
         },
         "@babel/helper-plugin-utils": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
         },
         "@babel/helper-regex": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.4.tgz",
-          "integrity": "sha512-inWpnHGgtg5NOF0eyHlC0/74/VkdRITY9dtTpB2PrxKKn+AkVMRiZz/Adrx+Ssg+MLDesi2zohBW6MVq6b4pOQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
+          "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
           "requires": {
             "lodash": "^4.17.13"
           }
         },
         "@babel/helper-remap-async-to-generator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz",
-          "integrity": "sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
+          "integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.4",
-            "@babel/helper-wrap-function": "^7.10.4",
-            "@babel/template": "^7.10.4",
-            "@babel/traverse": "^7.10.4",
-            "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-              "requires": {
-                "@babel/highlight": "^7.10.4"
-              }
-            },
-            "@babel/generator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-              "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
-              "requires": {
-                "@babel/types": "^7.10.4",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0"
-              }
-            },
-            "@babel/helper-function-name": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-              "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-              "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-split-export-declaration": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-              "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/highlight": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-              "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-              "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
-            },
-            "@babel/template": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-              "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/traverse": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-              "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
+            "@babel/helper-annotate-as-pure": "^7.8.3",
+            "@babel/helper-wrap-function": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.8.3",
+            "@babel/types": "^7.8.3"
           }
         },
         "@babel/helper-replace-supers": {
@@ -3458,127 +2929,19 @@
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
-          "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw=="
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+          "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
         },
         "@babel/helper-wrap-function": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
-          "integrity": "sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
+          "integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
           "requires": {
-            "@babel/helper-function-name": "^7.10.4",
-            "@babel/template": "^7.10.4",
-            "@babel/traverse": "^7.10.4",
-            "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-              "requires": {
-                "@babel/highlight": "^7.10.4"
-              }
-            },
-            "@babel/generator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-              "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
-              "requires": {
-                "@babel/types": "^7.10.4",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0"
-              }
-            },
-            "@babel/helper-function-name": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-              "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-              "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-split-export-declaration": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-              "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/highlight": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-              "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-              "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
-            },
-            "@babel/template": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-              "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/traverse": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-              "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.8.3",
+            "@babel/types": "^7.8.3"
           }
         },
         "@babel/helpers": {
@@ -3607,104 +2970,86 @@
           "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
         },
         "@babel/plugin-proposal-async-generator-functions": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.4.tgz",
-          "integrity": "sha512-MJbxGSmejEFVOANAezdO39SObkURO5o/8b6fSH6D1pi9RZQt+ldppKPXfqgUWpSQ9asM6xaSaSJIaeWMDRP0Zg==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
+          "integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/helper-remap-async-to-generator": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/helper-remap-async-to-generator": "^7.8.3",
             "@babel/plugin-syntax-async-generators": "^7.8.0"
           }
         },
-        "@babel/plugin-proposal-class-properties": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
-          "integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
-          "requires": {
-            "@babel/helper-create-class-features-plugin": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
-          }
-        },
         "@babel/plugin-proposal-dynamic-import": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
-          "integrity": "sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
+          "integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.8.3",
             "@babel/plugin-syntax-dynamic-import": "^7.8.0"
           }
         },
         "@babel/plugin-proposal-json-strings": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
-          "integrity": "sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
+          "integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.8.3",
             "@babel/plugin-syntax-json-strings": "^7.8.0"
           }
         },
         "@babel/plugin-proposal-nullish-coalescing-operator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
-          "integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+          "integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.8.3",
             "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
           }
         },
         "@babel/plugin-proposal-numeric-separator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
-          "integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz",
+          "integrity": "sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/plugin-syntax-numeric-separator": "^7.8.3"
           }
         },
         "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
-          "integrity": "sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz",
+          "integrity": "sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.8.3",
             "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-            "@babel/plugin-transform-parameters": "^7.10.4"
+            "@babel/plugin-transform-parameters": "^7.9.5"
           }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
-          "integrity": "sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
+          "integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.8.3",
             "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
           }
         },
         "@babel/plugin-proposal-optional-chaining": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.4.tgz",
-          "integrity": "sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==",
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.9.0.tgz",
+          "integrity": "sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.8.3",
             "@babel/plugin-syntax-optional-chaining": "^7.8.0"
           }
         },
-        "@babel/plugin-proposal-private-methods": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz",
-          "integrity": "sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==",
-          "requires": {
-            "@babel/helper-create-class-features-plugin": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
-          }
-        },
         "@babel/plugin-proposal-unicode-property-regex": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
-          "integrity": "sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==",
+          "version": "7.8.8",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.8.tgz",
+          "integrity": "sha512-EVhjVsMpbhLw9ZfHWSx2iy13Q8Z/eg8e8ccVWt23sWQK5l1UdkoLJPN5w69UA4uITGBnEZD2JOe4QOHycYKv8A==",
           "requires": {
-            "@babel/helper-create-regexp-features-plugin": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-create-regexp-features-plugin": "^7.8.8",
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-syntax-async-generators": {
@@ -3713,14 +3058,6 @@
           "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.0"
-          }
-        },
-        "@babel/plugin-syntax-class-properties": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-          "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
         "@babel/plugin-syntax-dynamic-import": {
@@ -3748,11 +3085,11 @@
           }
         },
         "@babel/plugin-syntax-numeric-separator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-          "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.8.3.tgz",
+          "integrity": "sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-syntax-object-rest-spread": {
@@ -3780,1442 +3117,353 @@
           }
         },
         "@babel/plugin-syntax-top-level-await": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
-          "integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
+          "integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-arrow-functions": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
-          "integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
+          "integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-async-to-generator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
-          "integrity": "sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
+          "integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
           "requires": {
-            "@babel/helper-module-imports": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/helper-remap-async-to-generator": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-module-imports": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-              "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
+            "@babel/helper-module-imports": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/helper-remap-async-to-generator": "^7.8.3"
           }
         },
         "@babel/plugin-transform-block-scoped-functions": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
-          "integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
+          "integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-block-scoping": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.4.tgz",
-          "integrity": "sha512-J3b5CluMg3hPUii2onJDRiaVbPtKFPLEaV5dOPY5OeAbDi1iU/UbbFFTgwb7WnanaDy7bjU35kc26W3eM5Qa0A==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
+          "integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.8.3",
             "lodash": "^4.17.13"
           }
         },
         "@babel/plugin-transform-classes": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
-          "integrity": "sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.5.tgz",
+          "integrity": "sha512-x2kZoIuLC//O5iA7PEvecB105o7TLzZo8ofBVhP79N+DO3jaX+KYfww9TQcfBEZD0nikNyYcGB1IKtRq36rdmg==",
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.4",
-            "@babel/helper-define-map": "^7.10.4",
-            "@babel/helper-function-name": "^7.10.4",
-            "@babel/helper-optimise-call-expression": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/helper-replace-supers": "^7.10.4",
-            "@babel/helper-split-export-declaration": "^7.10.4",
+            "@babel/helper-annotate-as-pure": "^7.8.3",
+            "@babel/helper-define-map": "^7.8.3",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-optimise-call-expression": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/helper-replace-supers": "^7.8.6",
+            "@babel/helper-split-export-declaration": "^7.8.3",
             "globals": "^11.1.0"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-              "requires": {
-                "@babel/highlight": "^7.10.4"
-              }
-            },
-            "@babel/generator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-              "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
-              "requires": {
-                "@babel/types": "^7.10.4",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0"
-              }
-            },
-            "@babel/helper-function-name": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-              "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-              "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-member-expression-to-functions": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-              "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-optimise-call-expression": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-              "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-replace-supers": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-              "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
-              "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.10.4",
-                "@babel/helper-optimise-call-expression": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-split-export-declaration": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-              "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/highlight": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-              "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-              "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
-            },
-            "@babel/template": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-              "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/traverse": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-              "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
           }
         },
         "@babel/plugin-transform-computed-properties": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
-          "integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
+          "integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-destructuring": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
-          "integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.9.5.tgz",
+          "integrity": "sha512-j3OEsGel8nHL/iusv/mRd5fYZ3DrOxWC82x0ogmdN/vHfAP4MYw+AFKYanzWlktNwikKvlzUV//afBW5FTp17Q==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-dotall-regex": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
-          "integrity": "sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
+          "integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
           "requires": {
-            "@babel/helper-create-regexp-features-plugin": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-duplicate-keys": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
-          "integrity": "sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
+          "integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-exponentiation-operator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
-          "integrity": "sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
+          "integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
           "requires": {
-            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-for-of": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
-          "integrity": "sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==",
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.9.0.tgz",
+          "integrity": "sha512-lTAnWOpMwOXpyDx06N+ywmF3jNbafZEqZ96CGYabxHrxNX8l5ny7dt4bK/rGwAh9utyP2b2Hv7PlZh1AAS54FQ==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-function-name": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
-          "integrity": "sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
+          "integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
           "requires": {
-            "@babel/helper-function-name": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-              "requires": {
-                "@babel/highlight": "^7.10.4"
-              }
-            },
-            "@babel/helper-function-name": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-              "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-              "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/highlight": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-              "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-              "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
-            },
-            "@babel/template": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-              "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-literals": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
-          "integrity": "sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
+          "integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-member-expression-literals": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
-          "integrity": "sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
+          "integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-modules-amd": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.4.tgz",
-          "integrity": "sha512-3Fw+H3WLUrTlzi3zMiZWp3AR4xadAEMv6XRCYnd5jAlLM61Rn+CRJaZMaNvIpcJpQ3vs1kyifYvEVPFfoSkKOA==",
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz",
+          "integrity": "sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==",
           "requires": {
-            "@babel/helper-module-transforms": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "babel-plugin-dynamic-import-node": "^2.3.3"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-              "requires": {
-                "@babel/highlight": "^7.10.4"
-              }
-            },
-            "@babel/generator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-              "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
-              "requires": {
-                "@babel/types": "^7.10.4",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0"
-              }
-            },
-            "@babel/helper-function-name": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-              "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-              "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-member-expression-to-functions": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-              "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-module-imports": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-              "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-module-transforms": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
-              "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
-              "requires": {
-                "@babel/helper-module-imports": "^7.10.4",
-                "@babel/helper-replace-supers": "^7.10.4",
-                "@babel/helper-simple-access": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/helper-optimise-call-expression": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-              "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-replace-supers": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-              "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
-              "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.10.4",
-                "@babel/helper-optimise-call-expression": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-simple-access": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-              "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
-              "requires": {
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-split-export-declaration": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-              "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/highlight": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-              "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-              "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
-            },
-            "@babel/template": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-              "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/traverse": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-              "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
           }
         },
         "@babel/plugin-transform-modules-commonjs": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
-          "integrity": "sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==",
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
+          "integrity": "sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==",
           "requires": {
-            "@babel/helper-module-transforms": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/helper-simple-access": "^7.10.4",
-            "babel-plugin-dynamic-import-node": "^2.3.3"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-              "requires": {
-                "@babel/highlight": "^7.10.4"
-              }
-            },
-            "@babel/generator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-              "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
-              "requires": {
-                "@babel/types": "^7.10.4",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0"
-              }
-            },
-            "@babel/helper-function-name": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-              "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-              "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-member-expression-to-functions": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-              "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-module-imports": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-              "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-module-transforms": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
-              "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
-              "requires": {
-                "@babel/helper-module-imports": "^7.10.4",
-                "@babel/helper-replace-supers": "^7.10.4",
-                "@babel/helper-simple-access": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/helper-optimise-call-expression": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-              "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-replace-supers": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-              "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
-              "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.10.4",
-                "@babel/helper-optimise-call-expression": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-simple-access": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-              "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
-              "requires": {
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-split-export-declaration": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-              "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/highlight": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-              "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-              "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
-            },
-            "@babel/template": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-              "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/traverse": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-              "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/helper-simple-access": "^7.8.3",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
           }
         },
         "@babel/plugin-transform-modules-systemjs": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.4.tgz",
-          "integrity": "sha512-Tb28LlfxrTiOTGtZFsvkjpyjCl9IoaRI52AEU/VIwOwvDQWtbNJsAqTXzh+5R7i74e/OZHH2c2w2fsOqAfnQYQ==",
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz",
+          "integrity": "sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==",
           "requires": {
-            "@babel/helper-hoist-variables": "^7.10.4",
-            "@babel/helper-module-transforms": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "babel-plugin-dynamic-import-node": "^2.3.3"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-              "requires": {
-                "@babel/highlight": "^7.10.4"
-              }
-            },
-            "@babel/generator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-              "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
-              "requires": {
-                "@babel/types": "^7.10.4",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0"
-              }
-            },
-            "@babel/helper-function-name": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-              "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-              "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-member-expression-to-functions": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-              "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-module-imports": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-              "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-module-transforms": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
-              "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
-              "requires": {
-                "@babel/helper-module-imports": "^7.10.4",
-                "@babel/helper-replace-supers": "^7.10.4",
-                "@babel/helper-simple-access": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/helper-optimise-call-expression": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-              "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-replace-supers": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-              "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
-              "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.10.4",
-                "@babel/helper-optimise-call-expression": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-simple-access": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-              "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
-              "requires": {
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-split-export-declaration": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-              "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/highlight": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-              "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-              "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
-            },
-            "@babel/template": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-              "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/traverse": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-              "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
+            "@babel/helper-hoist-variables": "^7.8.3",
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
           }
         },
         "@babel/plugin-transform-modules-umd": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
-          "integrity": "sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==",
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.9.0.tgz",
+          "integrity": "sha512-uTWkXkIVtg/JGRSIABdBoMsoIeoHQHPTL0Y2E7xf5Oj7sLqwVsNXOkNk0VJc7vF0IMBsPeikHxFjGe+qmwPtTQ==",
           "requires": {
-            "@babel/helper-module-transforms": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-              "requires": {
-                "@babel/highlight": "^7.10.4"
-              }
-            },
-            "@babel/generator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-              "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
-              "requires": {
-                "@babel/types": "^7.10.4",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0"
-              }
-            },
-            "@babel/helper-function-name": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-              "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-              "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-member-expression-to-functions": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-              "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-module-imports": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-              "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-module-transforms": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
-              "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
-              "requires": {
-                "@babel/helper-module-imports": "^7.10.4",
-                "@babel/helper-replace-supers": "^7.10.4",
-                "@babel/helper-simple-access": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/helper-optimise-call-expression": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-              "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-replace-supers": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-              "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
-              "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.10.4",
-                "@babel/helper-optimise-call-expression": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-simple-access": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-              "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
-              "requires": {
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-split-export-declaration": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-              "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/highlight": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-              "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-              "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
-            },
-            "@babel/template": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-              "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/traverse": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-              "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-named-capturing-groups-regex": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
-          "integrity": "sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
+          "integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
           "requires": {
-            "@babel/helper-create-regexp-features-plugin": "^7.10.4"
+            "@babel/helper-create-regexp-features-plugin": "^7.8.3"
           }
         },
         "@babel/plugin-transform-new-target": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
-          "integrity": "sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
+          "integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-object-super": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
-          "integrity": "sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
+          "integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/helper-replace-supers": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-              "requires": {
-                "@babel/highlight": "^7.10.4"
-              }
-            },
-            "@babel/generator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-              "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
-              "requires": {
-                "@babel/types": "^7.10.4",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0"
-              }
-            },
-            "@babel/helper-function-name": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-              "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-              "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-member-expression-to-functions": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-              "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-optimise-call-expression": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-              "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-replace-supers": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-              "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
-              "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.10.4",
-                "@babel/helper-optimise-call-expression": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-split-export-declaration": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-              "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/highlight": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-              "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-              }
-            },
-            "@babel/parser": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-              "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
-            },
-            "@babel/template": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-              "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/traverse": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-              "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/helper-replace-supers": "^7.8.3"
           }
         },
         "@babel/plugin-transform-parameters": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.4.tgz",
-          "integrity": "sha512-RurVtZ/D5nYfEg0iVERXYKEgDFeesHrHfx8RT05Sq57ucj2eOYAP6eu5fynL4Adju4I/mP/I6SO0DqNWAXjfLQ==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.5.tgz",
+          "integrity": "sha512-0+1FhHnMfj6lIIhVvS4KGQJeuhe1GI//h5uptK4PvLt+BGBxsoUJbd3/IW002yk//6sZPlFgsG1hY6OHLcy6kA==",
           "requires": {
-            "@babel/helper-get-function-arity": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-get-function-arity": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-              "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-property-literals": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
-          "integrity": "sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
+          "integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-regenerator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
-          "integrity": "sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==",
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.7.tgz",
+          "integrity": "sha512-TIg+gAl4Z0a3WmD3mbYSk+J9ZUH6n/Yc57rtKRnlA/7rcCvpekHXe0CMZHP1gYp7/KLe9GHTuIba0vXmls6drA==",
           "requires": {
             "regenerator-transform": "^0.14.2"
           }
         },
         "@babel/plugin-transform-reserved-words": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
-          "integrity": "sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
+          "integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-shorthand-properties": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
-          "integrity": "sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
+          "integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-spread": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.4.tgz",
-          "integrity": "sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
+          "integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-sticky-regex": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
-          "integrity": "sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
+          "integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/helper-regex": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/helper-regex": "^7.8.3"
           }
         },
         "@babel/plugin-transform-template-literals": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.4.tgz",
-          "integrity": "sha512-4NErciJkAYe+xI5cqfS8pV/0ntlY5N5Ske/4ImxAVX7mk9Rxt2bwDTGv1Msc2BRJvWQcmYEC+yoMLdX22aE4VQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
+          "integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-annotate-as-pure": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-typeof-symbol": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
-          "integrity": "sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==",
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
+          "integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
-          }
-        },
-        "@babel/plugin-transform-unicode-escapes": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz",
-          "integrity": "sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/plugin-transform-unicode-regex": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
-          "integrity": "sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
+          "integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
           "requires": {
-            "@babel/helper-create-regexp-features-plugin": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3"
           }
         },
         "@babel/preset-env": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.10.4.tgz",
-          "integrity": "sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.5.tgz",
+          "integrity": "sha512-eWGYeADTlPJH+wq1F0wNfPbVS1w1wtmMJiYk55Td5Yu28AsdR9AsC97sZ0Qq8fHqQuslVSIYSGJMcblr345GfQ==",
           "requires": {
-            "@babel/compat-data": "^7.10.4",
-            "@babel/helper-compilation-targets": "^7.10.4",
-            "@babel/helper-module-imports": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
-            "@babel/plugin-proposal-class-properties": "^7.10.4",
-            "@babel/plugin-proposal-dynamic-import": "^7.10.4",
-            "@babel/plugin-proposal-json-strings": "^7.10.4",
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-            "@babel/plugin-proposal-numeric-separator": "^7.10.4",
-            "@babel/plugin-proposal-object-rest-spread": "^7.10.4",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-            "@babel/plugin-proposal-optional-chaining": "^7.10.4",
-            "@babel/plugin-proposal-private-methods": "^7.10.4",
-            "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
+            "@babel/compat-data": "^7.9.0",
+            "@babel/helper-compilation-targets": "^7.8.7",
+            "@babel/helper-module-imports": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+            "@babel/plugin-proposal-dynamic-import": "^7.8.3",
+            "@babel/plugin-proposal-json-strings": "^7.8.3",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+            "@babel/plugin-proposal-numeric-separator": "^7.8.3",
+            "@babel/plugin-proposal-object-rest-spread": "^7.9.5",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+            "@babel/plugin-proposal-optional-chaining": "^7.9.0",
+            "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
             "@babel/plugin-syntax-async-generators": "^7.8.0",
-            "@babel/plugin-syntax-class-properties": "^7.10.4",
             "@babel/plugin-syntax-dynamic-import": "^7.8.0",
             "@babel/plugin-syntax-json-strings": "^7.8.0",
             "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-            "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+            "@babel/plugin-syntax-numeric-separator": "^7.8.0",
             "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
             "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
             "@babel/plugin-syntax-optional-chaining": "^7.8.0",
-            "@babel/plugin-syntax-top-level-await": "^7.10.4",
-            "@babel/plugin-transform-arrow-functions": "^7.10.4",
-            "@babel/plugin-transform-async-to-generator": "^7.10.4",
-            "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
-            "@babel/plugin-transform-block-scoping": "^7.10.4",
-            "@babel/plugin-transform-classes": "^7.10.4",
-            "@babel/plugin-transform-computed-properties": "^7.10.4",
-            "@babel/plugin-transform-destructuring": "^7.10.4",
-            "@babel/plugin-transform-dotall-regex": "^7.10.4",
-            "@babel/plugin-transform-duplicate-keys": "^7.10.4",
-            "@babel/plugin-transform-exponentiation-operator": "^7.10.4",
-            "@babel/plugin-transform-for-of": "^7.10.4",
-            "@babel/plugin-transform-function-name": "^7.10.4",
-            "@babel/plugin-transform-literals": "^7.10.4",
-            "@babel/plugin-transform-member-expression-literals": "^7.10.4",
-            "@babel/plugin-transform-modules-amd": "^7.10.4",
-            "@babel/plugin-transform-modules-commonjs": "^7.10.4",
-            "@babel/plugin-transform-modules-systemjs": "^7.10.4",
-            "@babel/plugin-transform-modules-umd": "^7.10.4",
-            "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
-            "@babel/plugin-transform-new-target": "^7.10.4",
-            "@babel/plugin-transform-object-super": "^7.10.4",
-            "@babel/plugin-transform-parameters": "^7.10.4",
-            "@babel/plugin-transform-property-literals": "^7.10.4",
-            "@babel/plugin-transform-regenerator": "^7.10.4",
-            "@babel/plugin-transform-reserved-words": "^7.10.4",
-            "@babel/plugin-transform-shorthand-properties": "^7.10.4",
-            "@babel/plugin-transform-spread": "^7.10.4",
-            "@babel/plugin-transform-sticky-regex": "^7.10.4",
-            "@babel/plugin-transform-template-literals": "^7.10.4",
-            "@babel/plugin-transform-typeof-symbol": "^7.10.4",
-            "@babel/plugin-transform-unicode-escapes": "^7.10.4",
-            "@babel/plugin-transform-unicode-regex": "^7.10.4",
+            "@babel/plugin-syntax-top-level-await": "^7.8.3",
+            "@babel/plugin-transform-arrow-functions": "^7.8.3",
+            "@babel/plugin-transform-async-to-generator": "^7.8.3",
+            "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+            "@babel/plugin-transform-block-scoping": "^7.8.3",
+            "@babel/plugin-transform-classes": "^7.9.5",
+            "@babel/plugin-transform-computed-properties": "^7.8.3",
+            "@babel/plugin-transform-destructuring": "^7.9.5",
+            "@babel/plugin-transform-dotall-regex": "^7.8.3",
+            "@babel/plugin-transform-duplicate-keys": "^7.8.3",
+            "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+            "@babel/plugin-transform-for-of": "^7.9.0",
+            "@babel/plugin-transform-function-name": "^7.8.3",
+            "@babel/plugin-transform-literals": "^7.8.3",
+            "@babel/plugin-transform-member-expression-literals": "^7.8.3",
+            "@babel/plugin-transform-modules-amd": "^7.9.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.9.0",
+            "@babel/plugin-transform-modules-systemjs": "^7.9.0",
+            "@babel/plugin-transform-modules-umd": "^7.9.0",
+            "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+            "@babel/plugin-transform-new-target": "^7.8.3",
+            "@babel/plugin-transform-object-super": "^7.8.3",
+            "@babel/plugin-transform-parameters": "^7.9.5",
+            "@babel/plugin-transform-property-literals": "^7.8.3",
+            "@babel/plugin-transform-regenerator": "^7.8.7",
+            "@babel/plugin-transform-reserved-words": "^7.8.3",
+            "@babel/plugin-transform-shorthand-properties": "^7.8.3",
+            "@babel/plugin-transform-spread": "^7.8.3",
+            "@babel/plugin-transform-sticky-regex": "^7.8.3",
+            "@babel/plugin-transform-template-literals": "^7.8.3",
+            "@babel/plugin-transform-typeof-symbol": "^7.8.4",
+            "@babel/plugin-transform-unicode-regex": "^7.8.3",
             "@babel/preset-modules": "^0.1.3",
-            "@babel/types": "^7.10.4",
-            "browserslist": "^4.12.0",
+            "@babel/types": "^7.9.5",
+            "browserslist": "^4.9.1",
             "core-js-compat": "^3.6.2",
             "invariant": "^2.2.2",
             "levenary": "^1.1.1",
             "semver": "^5.5.0"
-          },
-          "dependencies": {
-            "@babel/helper-module-imports": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-              "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/preset-modules": {
@@ -5249,27 +3497,27 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
-          "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+          "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
           "requires": {
             "@babel/code-frame": "^7.8.3",
-            "@babel/generator": "^7.9.0",
-            "@babel/helper-function-name": "^7.8.3",
+            "@babel/generator": "^7.9.5",
+            "@babel/helper-function-name": "^7.9.5",
             "@babel/helper-split-export-declaration": "^7.8.3",
             "@babel/parser": "^7.9.0",
-            "@babel/types": "^7.9.0",
+            "@babel/types": "^7.9.5",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.13"
           }
         },
         "@babel/types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-          "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+          "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.9.0",
+            "@babel/helper-validator-identifier": "^7.9.5",
             "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
@@ -5315,9 +3563,9 @@
           }
         },
         "@rollup/plugin-babel": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.0.4.tgz",
-          "integrity": "sha512-MBtNoi5gqBEbqy1gE9jZBfPsi10kbuK2CEu9bx53nk1Z3ATRvBOoZ/GsbhXOeVbS76xXi/DeYM+vYX6EGIDv9A==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.0.0.tgz",
+          "integrity": "sha512-YpVnwdUeVj/fDFN75Y3CAzJTMYNcqbH05SJs551wqj+BSwLT9pS3dqJrVDPYl3eH4OrI8ueiEseX5VgUn+0HLA==",
           "requires": {
             "@babel/helper-module-imports": "^7.7.4",
             "@rollup/pluginutils": "^3.0.8"
@@ -5336,22 +3584,22 @@
           }
         },
         "@rollup/plugin-replace": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.3.tgz",
-          "integrity": "sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.2.tgz",
+          "integrity": "sha512-KEEL7V2tMNOsbAoNMKg91l1sNXBDoiP31GFlqXVOuV5691VQKzKBh91+OKKOG4uQWYqcFskcjFyh1d5YnZd0Zw==",
           "requires": {
             "@rollup/pluginutils": "^3.0.8",
             "magic-string": "^0.25.5"
           }
         },
         "@rollup/pluginutils": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.9.tgz",
+          "integrity": "sha512-TLZavlfPAZYI7v33wQh4mTP6zojne14yok3DNSLcjoG/Hirxfkonn6icP5rrNWRn8nZsirJBFFpijVOJzkUHDg==",
           "requires": {
             "@types/estree": "0.0.39",
             "estree-walker": "^1.0.1",
-            "picomatch": "^2.2.2"
+            "micromatch": "^4.0.2"
           }
         },
         "@surma/rollup-plugin-off-main-thread": {
@@ -5369,9 +3617,9 @@
           "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
         },
         "@types/node": {
-          "version": "14.0.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-          "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ=="
+          "version": "13.13.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+          "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA=="
         },
         "@types/resolve": {
           "version": "0.0.8",
@@ -5416,15 +3664,23 @@
             "concat-map": "0.0.1"
           }
         },
-        "browserslist": {
-          "version": "4.12.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.2.tgz",
-          "integrity": "sha512-MfZaeYqR8StRZdstAK9hCKDd2StvePCYp5rHzQCPicUjfFliDgmuaBNPHYUTpAywBN8+Wc/d7NYVFkO0aqaBUw==",
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "requires": {
-            "caniuse-lite": "^1.0.30001088",
-            "electron-to-chromium": "^1.3.483",
-            "escalade": "^3.0.1",
-            "node-releases": "^1.1.58"
+            "fill-range": "^7.0.1"
+          }
+        },
+        "browserslist": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
+          "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001043",
+            "electron-to-chromium": "^1.3.413",
+            "node-releases": "^1.1.53",
+            "pkg-up": "^2.0.0"
           }
         },
         "buffer-from": {
@@ -5438,9 +3694,9 @@
           "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw=="
         },
         "caniuse-lite": {
-          "version": "1.0.30001090",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001090.tgz",
-          "integrity": "sha512-QzPRKDCyp7RhjczTPZaqK3CjPA5Ht2UnXhZhCI4f7QiB5JK6KEuZBxIzyWnB3wO4hgAj4GMRxAhuiacfw0Psjg=="
+          "version": "1.0.30001048",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001048.tgz",
+          "integrity": "sha512-g1iSHKVxornw0K8LG9LLdf+Fxnv7T1Z+mMsf0/YYLclQX4Cd522Ap0Lrw6NFqHgezit78dtyWxzlV2Xfc7vgRg=="
         },
         "chalk": {
           "version": "2.4.2",
@@ -5531,14 +3787,9 @@
           "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
         },
         "electron-to-chromium": {
-          "version": "1.3.483",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.483.tgz",
-          "integrity": "sha512-+05RF8S9rk8S0G8eBCqBRBaRq7+UN3lDs2DAvnG8SBSgQO3hjy0+qt4CmRk5eiuGbTcaicgXfPmBi31a+BD3lg=="
-        },
-        "escalade": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.1.tgz",
-          "integrity": "sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA=="
+          "version": "1.3.423",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.423.tgz",
+          "integrity": "sha512-jXdnLcawJ/EMdN+j77TC3YyeAWiIjo1U63DFCKrjtLv4cu8ToyoF4HYXtFvkVVHhEtIl7lU1uDd307Xj1/YDjw=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -5560,10 +3811,26 @@
           "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
           "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
         "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
@@ -5657,6 +3924,11 @@
           "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
           "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
         },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
         "is-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
@@ -5702,9 +3974,9 @@
           "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
         },
         "json5": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
-          "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -5729,6 +4001,15 @@
           "integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
           "requires": {
             "leven": "^3.1.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "lodash": {
@@ -5757,6 +4038,15 @@
           "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
           "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
         },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -5776,9 +4066,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node-releases": {
-          "version": "1.1.58",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.58.tgz",
-          "integrity": "sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg=="
+          "version": "1.1.53",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+          "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
         },
         "object-keys": {
           "version": "1.1.1",
@@ -5804,6 +4094,32 @@
             "wrappy": "1"
           }
         },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
         "path-is-absolute": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -5819,6 +4135,14 @@
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
           "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
         },
+        "pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+          "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
         "pretty-bytes": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
@@ -5830,9 +4154,9 @@
           "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
         },
         "regenerate": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
-          "integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A=="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+          "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
         },
         "regenerate-unicode-properties": {
           "version": "8.2.0",
@@ -5870,9 +4194,9 @@
           }
         },
         "regjsgen": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
-          "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A=="
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+          "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
         },
         "regjsparser": {
           "version": "0.6.4",
@@ -5890,17 +4214,17 @@
           }
         },
         "resolve": {
-          "version": "1.15.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
           "requires": {
             "path-parse": "^1.0.6"
           }
         },
         "rollup": {
-          "version": "2.18.1",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.18.1.tgz",
-          "integrity": "sha512-w4X77ADA+WTGlapC8Z6yggdJtODw3SBl6R2LSkA7ZW5MtdkgcB7sfaSD1UWyx8diXbMcGIb0eI9gCx/dyqOgNQ==",
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.7.3.tgz",
+          "integrity": "sha512-lAWJGZ5BQzcu/5fhMKGJrh5oy9LQUoaCid8cQV8k+E2vE9E/UWptzcM+bSBg+u8akORsvnybsqQUE/wVChIazg==",
           "requires": {
             "fsevents": "~2.1.2"
           }
@@ -5953,9 +4277,9 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         },
         "source-map-support": {
-          "version": "0.5.16",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-          "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
@@ -6018,9 +4342,9 @@
           }
         },
         "terser": {
-          "version": "4.6.7",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.7.tgz",
-          "integrity": "sha512-fmr7M1f7DBly5cX2+rFDvmGBAaaZyPrHYK4mMdHEDAdNTqXSZgSOfqsfGq2HqPGT/1V0foZZuCZFx8CHKgAk3g==",
+          "version": "4.6.12",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.12.tgz",
+          "integrity": "sha512-fnIwuaKjFPANG6MAixC/k1TDtnl1YlPLUlLVIxxGZUn1gfUx2+l3/zGNB72wya+lgsb50QBi2tUV75RiODwnww==",
           "requires": {
             "commander": "^2.20.0",
             "source-map": "~0.6.1",
@@ -6038,6 +4362,14 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
         },
         "type-fest": {
           "version": "0.12.0",

--- a/packages/workbox-cli/package.json
+++ b/packages/workbox-cli/package.json
@@ -47,7 +47,6 @@
     "@types/fs-extra": "^9.0.1",
     "@types/glob-watcher": "^5.0.0",
     "@types/inquirer": "^6.5.0",
-    "@types/update-notifier": "^4.1.0",
-    "@types/workbox-build": "^5.0.0"
+    "@types/update-notifier": "^4.1.0"
   }
 }

--- a/packages/workbox-cli/src/app.ts
+++ b/packages/workbox-cli/src/app.ts
@@ -6,10 +6,11 @@
   https://opensource.org/licenses/MIT.
 */
 
-import * as assert from 'assert';
 import {oneLine as ol} from 'common-tags';
-import * as upath from 'upath';
+import * as assert from 'assert';
+import * as meow from 'meow';
 import * as prettyBytes from 'pretty-bytes';
+import * as upath from 'upath';
 import * as watch from 'glob-watcher';
 import * as workboxBuild from 'workbox-build';
 
@@ -19,13 +20,10 @@ import {logger} from './lib/logger.js';
 import {readConfig} from './lib/read-config.js';
 import {runWizard} from './lib/run-wizard.js';
 import {SupportedFlags} from './bin.js'
-import * as meow from 'meow';
-import { InjectManifestConfig, GenerateSWConfig } from 'workbox-build';
-
 
 interface BuildCommand {
   command: 'generateSW'|'injectManifest';
-  config: GenerateSWConfig & InjectManifestConfig;
+  config: any;
   watch: boolean;
 }
 
@@ -104,7 +102,7 @@ export const app = async (params: meow.Result<SupportedFlags>) => {
       const configPath = upath.resolve(process.cwd(),
           option || constants.defaultConfigFile);
 
-      let config: GenerateSWConfig & InjectManifestConfig;
+      let config: any;
       try {
         config = readConfig(configPath);
       } catch (error) {

--- a/packages/workbox-cli/src/bin.ts
+++ b/packages/workbox-cli/src/bin.ts
@@ -12,9 +12,9 @@
 import * as meow from 'meow'
 import * as updateNotifier from 'update-notifier';
 
-import {app} from "./app";
+import {app} from './app';
 import {cleanupStackTrace} from './lib/cleanup-stack-trace.js';
-import {helpText} from'./lib/help-text';
+import {helpText} from './lib/help-text';
 import {logger} from './lib/logger';
 
 export interface SupportedFlags extends meow.AnyFlags {
@@ -25,7 +25,7 @@ export interface SupportedFlags extends meow.AnyFlags {
 
 (async () => {
   const params: meow.Result<any> = meow(helpText);
-  updateNotifier({pkg: params.pkg as updateNotifier.Package}).notify(); //FIX This is dubious
+  updateNotifier({pkg: params.pkg as updateNotifier.Package}).notify();
 
   try {
     await app(params);

--- a/packages/workbox-cli/src/index.d.ts
+++ b/packages/workbox-cli/src/index.d.ts
@@ -1,0 +1,12 @@
+declare module 'workbox-build' {
+  type BuildReturnValue = {
+    count: number;
+    filePaths: Array<string>;
+    size: number;
+    warnings: Array<string>;
+  };
+
+  export function generateSW(args: any): Promise<BuildReturnValue>;
+  export function injectManifest(args: any): Promise<BuildReturnValue>;
+  export function copyWorkboxLibraries(dir: string): Promise<string>;
+}


### PR DESCRIPTION
R: @philipwalton

This changes the dependency on `workbox-cli`'s TypeScript typings from `@types/workbox-build` to a local override file for the time being.

Once `workbox-build` is migrated to TypeScript, we can remove it.

This is necessary because `@types/workbox-build` contains references to some types exported from `workbox-routing` that are no longer valid in v6. When trying to build `workbox-cli` in a local project that has the new v6 version of `workbox-routing` linked in via `lerna bootstrap`, the `tsc -b` will fail. (This took me forever to debug.)