### PR TITLE
Adds handlerDidError plugin callback

### DIFF
--- a/packages/workbox-core/src/types.ts
+++ b/packages/workbox-core/src/types.ts
@@ -209,6 +209,17 @@ export interface HandlerWillRespondCallback {
   (param: HandlerWillRespondCallbackParam): Promise<Response>;
 }
 
+interface HandlerDidErrorCallbackParam {
+  request: Request;
+  event: ExtendableEvent;
+  error: Error;
+  state?: PluginState;
+}
+
+export interface HandlerDidErrorCallback {
+  (param: HandlerDidErrorCallbackParam): Promise<Response | undefined>;
+}
+
 export interface HandlerDidRespondCallbackParam {
   request: Request;
   event: ExtendableEvent;
@@ -244,6 +255,7 @@ export interface WorkboxPlugin {
   fetchDidFail?: FetchDidFailCallback;
   fetchDidSucceed?: FetchDidSucceedCallback;
   handlerDidComplete?: HandlerDidCompleteCallback;
+  handlerDidError?: HandlerDidErrorCallback;
   handlerDidRespond?: HandlerDidRespondCallback;
   handlerWillRespond?: HandlerWillRespondCallback;
   handlerWillStart?: HandlerWillStartCallback;
@@ -258,6 +270,7 @@ export interface WorkboxPluginCallbackParam {
   fetchDidFail: FetchDidFailCallbackParam;
   fetchDidSucceed: FetchDidSucceedCallbackParam;
   handlerDidComplete: HandlerDidCompleteCallbackParam;
+  handlerDidError: HandlerDidErrorCallbackParam;
   handlerDidRespond: HandlerDidRespondCallbackParam;
   handlerWillRespond: HandlerWillRespondCallbackParam;
   handlerWillStart: HandlerWillStartCallbackParam;

--- a/packages/workbox-strategies/src/Strategy.ts
+++ b/packages/workbox-strategies/src/Strategy.ts
@@ -177,8 +177,8 @@ abstract class Strategy implements RouteHandlerObject {
       response = await this._handle(request, handler);
       // The "official" Strategy subclasses all throw this error automatically,
       // but in case a third-party Strategy doesn't, ensure that we have a
-      // consistent failure when there's no response.
-      if (!response) {
+      // consistent failure when there's no response or an error response.
+      if (!response || response.type === 'error') {
         throw new WorkboxError('no-response', {url: request.url});
       }
     } catch (error) {

--- a/packages/workbox-strategies/src/Strategy.ts
+++ b/packages/workbox-strategies/src/Strategy.ts
@@ -7,6 +7,9 @@
 */
 
 import {cacheNames} from 'workbox-core/_private/cacheNames.js';
+import {WorkboxError} from 'workbox-core/_private/WorkboxError.js';
+import {logger} from 'workbox-core/_private/logger.js';
+import {getFriendlyURL} from 'workbox-core/_private/getFriendlyURL.js';
 import {HandlerCallbackOptions, RouteHandlerObject, WorkboxPlugin}
     from 'workbox-core/types.js';
 
@@ -35,7 +38,7 @@ abstract class Strategy implements RouteHandlerObject {
   protected abstract _handle(
     request: Request,
     handler: StrategyHandler
-  ): Promise<Response>;
+  ): Promise<Response | undefined>;
 
   /**
    * Creates a new instance of the strategy and sets all documented option
@@ -168,11 +171,37 @@ abstract class Strategy implements RouteHandlerObject {
 
   async _getResponse(handler: StrategyHandler, request: Request, event: ExtendableEvent) {
     await handler.runCallbacks('handlerWillStart', {event, request});
-    let response = await this._handle(request, handler);
+
+    let response: Response | undefined = undefined;
+    try {
+      response = await this._handle(request, handler);
+      // The "official" Strategy subclasses all throw this error automatically,
+      // but in case a third-party Strategy doesn't, ensure that we have a
+      // consistent failure when there's no response.
+      if (!response) {
+        throw new WorkboxError('no-response', {url: request.url});
+      }
+    } catch (error) {
+      for (const callback of handler.iterateCallbacks('handlerDidError')) {
+        response = await callback({error, event, request});
+        if (response) {
+          break;
+        }
+      }
+    
+      if (!response) {
+        throw error;
+      } else if (process.env.NODE_ENV !== 'production') {
+        logger.log(`While responding to '${getFriendlyURL(request.url)}', ` +
+          `an ${error} error occurred. Using a fallback response provided by `+
+          `a handlerDidError plugin.`);
+      }
+    }
 
     for (const callback of handler.iterateCallbacks('handlerWillRespond')) {
       response = await callback({event, request, response});
     }
+
     return response;
   }
 

--- a/test/workbox-strategies/sw/test-Strategy.mjs
+++ b/test/workbox-strategies/sw/test-Strategy.mjs
@@ -37,6 +37,22 @@ class ErrorStrategy extends Strategy {
   }
 }
 
+class HandlerThrowsStrategy extends Strategy {
+  constructor(options) {
+    super(options);
+    this._error = options.error;
+  }
+  async _handle(request, handler) {
+    throw this._error;
+  }
+}
+
+class HandlerReturnsUndefinedStrategy extends Strategy {
+  async _handle(request, handler) {
+    return undefined;
+  }
+}
+
 class ExtendingStrategy extends FetchStrategy {
   constructor(options) {
     super(options);
@@ -307,6 +323,111 @@ describe(`Strategy`, function() {
       }))).to.be.true;
       expect(await plugins[0].handlerDidComplete.firstCall.args[0].response
           .clone().text()).to.equal('generated response');
+    });
+  });
+
+  describe('handlerDidError', function() {
+    it('should use the first callback that returns a Response when _handler() throws', async function() {
+      const plugins = [{
+        handlerDidError: sandbox.stub().resolves(undefined),
+      }, {
+        handlerDidError: sandbox.stub().resolves(new Response('from plugin')),
+      }, {
+        handlerDidError: sandbox.stub().resolves(undefined),
+      }];
+      const error = new Error('thrown error');
+      const strategy = new HandlerThrowsStrategy({error, plugins});
+
+      const {request, event} = generateOptions();
+
+      const [responsePromise] = strategy.handleAll({request, event});
+      const response = await responsePromise;
+      const responseBody = await response.text();
+      const expectedArgs = [[{
+        error,
+        event,
+        request,
+        state: {},
+      }]];
+
+      expect(responseBody).to.eql('from plugin');
+      expect(plugins[0].handlerDidError.args).to.eql(expectedArgs);
+      expect(plugins[1].handlerDidError.args).to.eql(expectedArgs);
+      // This shouldn't run, since the previous plugin returns a response.
+      expect(plugins[2].handlerDidError.args).to.eql([]);
+    });
+
+    it(`should rethrow the error when the callbacks don't return a Response`, async function() {
+      const plugins = [{
+        handlerDidError: sandbox.stub().resolves(undefined),
+      }, {
+        handlerDidError: sandbox.stub().resolves(undefined),
+      }];
+      const error = new Error('thrown error');
+      const strategy = new HandlerThrowsStrategy({error, plugins});
+
+      const {request, event} = generateOptions();
+
+      const [responsePromise] = strategy.handleAll({request, event});
+      try {
+        await responsePromise;
+        throw new Error('unexpected error');
+      } catch (thrownError) {
+        expect(thrownError).to.eql(error);
+
+        const expectedArgs = [[{
+          error,
+          event,
+          request,
+          state: {},
+        }]];
+
+        expect(plugins[0].handlerDidError.args).to.eql(expectedArgs);
+        expect(plugins[1].handlerDidError.args).to.eql(expectedArgs);
+      }
+    });
+
+    it('should use the callback Response when _handler() returns undefined', async function() {
+      const plugins = [{
+        handlerDidError: sandbox.stub().resolves(new Response('from plugin')),
+      }];
+      const strategy = new HandlerReturnsUndefinedStrategy({plugins});
+
+      const {request, event} = generateOptions();
+
+      const [responsePromise] = strategy.handleAll({request, event});
+      const response = await responsePromise;
+      const responseBody = await response.text();
+
+      expect(responseBody).to.eql('from plugin');
+
+      // We can't do a deep equality check without a reference to the
+      // WorkboxError, so just do a sanity check.
+      expect(plugins[0].handlerDidError.args[0][0].error.name).to.eql('no-response');
+    });
+
+    it('should throw an error when _handler() returns undefined and the callbacks return undefined', async function() {
+      const plugins = [{
+        handlerDidError: sandbox.stub().resolves(undefined),
+      }];
+      const strategy = new HandlerReturnsUndefinedStrategy({plugins});
+
+      const {request, event} = generateOptions();
+
+      const [responsePromise] = strategy.handleAll({request, event});
+      try {
+        await responsePromise;
+        throw new Error('unexpected error');
+      } catch (thrownError) {
+        expect(thrownError.name).to.eql('no-response');
+
+        expect(plugins[0].handlerDidError.args).to.eql([[{
+          event,
+          request,
+          error: thrownError,
+          state: {},
+        }]]);
+      }
     });
   });
 


### PR DESCRIPTION
R: @philipwalton

Fixes #2569

The one thing I wasn't 100% sure about was what should happen when there are multiple `handlerDidError` plugins defined for a given `Strategy`. The implementation in this PR will run them one by one until a truthy response is returned, at which point that becomes the effective response and any additional callbacks are not run.