### PR TITLE
Don't create .mjs files for node_ts projects

### DIFF
--- a/gulp-tasks/transpile-typescript.js
+++ b/gulp-tasks/transpile-typescript.js
@@ -102,7 +102,7 @@ async function transpilePackage(packageName, {failOnError = true} = {}) {
 
     const packagePath = upath.join('packages', packageName);
 
-    // Don't create `.mjs` files for the node_ts packages.  
+    // Don't create `.mjs` files for the node_ts packages.
     const pkgJson = require(`../${packagePath}/package.json`);
     if (pkgJson.workbox.packageType === 'node_ts') {
       return;

--- a/gulp-tasks/transpile-typescript.js
+++ b/gulp-tasks/transpile-typescript.js
@@ -100,9 +100,17 @@ async function transpilePackage(packageName, {failOnError = true} = {}) {
     // it will call the version in `Microsoft SDKs/TypeScript`.
     await execa('tsc', ['-b', `packages/${packageName}`], {preferLocal: true});
 
+    const packagePath = upath.join('packages', packageName);
+
+    // Don't create `.mjs` files for the node_ts packages.  
+    const pkgJson = require(`../${packagePath}/package.json`);
+    if (pkgJson.workbox.packageType === 'node_ts') {
+      return;
+    }
+
     // Mirror all `.ts` files with `.mjs` files.
     const tsFiles = await globby(`**/*.ts`, {
-      cwd: upath.join('packages', packageName, 'src'),
+      cwd: upath.join(packagePath, 'src'),
     });
 
     for (const tsFile of tsFiles) {


### PR DESCRIPTION
I realized that this was an issue with the new `workbox-cli` TypeScript files when running `gulp test_server`. We want to avoid creating the  extra `.mjs` files for any of our `node_ts` packages.