### PR TITLE
Adds the PrecacheFallbackPlugin

### DIFF
--- a/packages/workbox-precaching/src/PrecacheFallbackPlugin.ts
+++ b/packages/workbox-precaching/src/PrecacheFallbackPlugin.ts
@@ -8,7 +8,9 @@
 
 import {WorkboxPlugin} from 'workbox-core/types.js';
 
-import {matchPrecache} from './matchPrecache.js';
+import {getOrCreatePrecacheController} from
+    './utils/getOrCreatePrecacheController.js';
+import {PrecacheController} from './PrecacheController.js';
 
 import './_version.js';
 
@@ -21,13 +23,15 @@ import './_version.js';
  * and returning a precached response, taking the expected revision parameter
  * into account automatically.
  * 
- * This plugin works with the "default" `PrecacheController` instance, and
- * should not be used if you explicitly create your own `PrecacheController`.
+ * Unless you explicitly pass in a `PrecacheController` instance to the
+ * constructor, the default instance will be used. Generally speaking, most
+ * developers will end up using the default.
  *
  * @memberof module:workbox-precaching
  */
 class PrecacheFallbackPlugin implements WorkboxPlugin {
   private readonly _fallbackURL: string;
+  private readonly _precacheController: PrecacheController;
 
   /**
    * Constructs a new PrecacheFallbackPlugin with the associated fallbackURL.
@@ -35,9 +39,17 @@ class PrecacheFallbackPlugin implements WorkboxPlugin {
    * @param {Object} config
    * @param {string} config.fallbackURL A precached URL to use as the fallback
    *     if the associated strategy can't generate a response.
+   * @param {PrecacheController} [config.precacheController] An optional
+   *     PrecacheController instance. If not provided, the default
+   *     PrecacheController will be used.
    */
-  constructor({fallbackURL}: {fallbackURL: string}) {
+  constructor({fallbackURL, precacheController}: {
+    fallbackURL: string;
+    precacheController?: PrecacheController;
+  }) {
     this._fallbackURL = fallbackURL;
+    this._precacheController = precacheController ||
+        getOrCreatePrecacheController();
   }
 
   /**
@@ -46,7 +58,7 @@ class PrecacheFallbackPlugin implements WorkboxPlugin {
    * @private
    */
   handlerDidError: WorkboxPlugin['handlerDidError'] =
-    () => matchPrecache(this._fallbackURL);
+    () => this._precacheController.matchPrecache(this._fallbackURL);
 }
 
 export {PrecacheFallbackPlugin};

--- a/packages/workbox-precaching/src/PrecacheFallbackPlugin.ts
+++ b/packages/workbox-precaching/src/PrecacheFallbackPlugin.ts
@@ -1,0 +1,52 @@
+/*
+  Copyright 2020 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import {WorkboxPlugin} from 'workbox-core/types.js';
+
+import {matchPrecache} from './matchPrecache.js';
+
+import './_version.js';
+
+
+/**
+ * `PrecacheFallbackPlugin` allows you to specify an "offline fallback"
+ * response to be used when a given strategy is unable to generate a response.
+ *
+ * It does this by intercepting the `handlerDidError` plugin callback
+ * and returning a precached response, taking the expected revision parameter
+ * into account automatically.
+ * 
+ * This plugin works with the "default" `PrecacheController` instance, and
+ * should not be used if you explicitly create your own `PrecacheController`.
+ *
+ * @memberof module:workbox-precaching
+ */
+class PrecacheFallbackPlugin implements WorkboxPlugin {
+  private readonly _fallbackURL: string;
+
+  /**
+   * Constructs a new PrecacheFallbackPlugin with the associated fallbackURL.
+   *
+   * @param {Object} config
+   * @param {string} config.fallbackURL A precached URL to use as the fallback
+   *     if the associated strategy can't generate a response.
+   */
+  constructor({fallbackURL}: {fallbackURL: string}) {
+    this._fallbackURL = fallbackURL;
+  }
+
+  /**
+   * @return {Promise<Response>} The precache response for the fallback URL.
+   *
+   * @private
+   */
+  handlerDidError: WorkboxPlugin['handlerDidError'] =
+    () => matchPrecache(this._fallbackURL);
+}
+
+export {PrecacheFallbackPlugin};

--- a/packages/workbox-precaching/src/index.ts
+++ b/packages/workbox-precaching/src/index.ts
@@ -16,6 +16,7 @@ import {matchPrecache} from './matchPrecache.js';
 import {precache} from './precache.js';
 import {precacheAndRoute} from './precacheAndRoute.js';
 import {PrecacheController} from './PrecacheController.js';
+import {PrecacheFallbackPlugin} from './PrecacheFallbackPlugin.js';
 
 import './_version.js';
 
@@ -43,4 +44,5 @@ export {
   precache,
   precacheAndRoute,
   PrecacheController,
+  PrecacheFallbackPlugin,
 };

--- a/test/workbox-precaching/sw/test-PrecacheFallbackPlugin.mjs
+++ b/test/workbox-precaching/sw/test-PrecacheFallbackPlugin.mjs
@@ -7,6 +7,7 @@
 */
 
 import {precache} from 'workbox-precaching/precache.mjs';
+import {PrecacheController} from 'workbox-precaching/PrecacheController.mjs';
 import {PrecacheFallbackPlugin} from 'workbox-precaching/PrecacheFallbackPlugin.mjs';
 import {resetDefaultPrecacheController} from './resetDefaultPrecacheController.mjs';
 
@@ -23,11 +24,24 @@ describe(`PrecacheFallbackPlugin`, function() {
   });
 
   describe(`constructor`, function() {
-    it(`should construct a properly-configured PrecacheFallbackPlugin instance`, function() {
+    it(`should construct a PrecacheFallbackPlugin instance with the default PrecacheController`, function() {
       const fallbackURL = '/test/url';
       const precacheFallbackPlugin = new PrecacheFallbackPlugin({fallbackURL});
 
       expect(precacheFallbackPlugin._fallbackURL).to.eql(fallbackURL);
+      expect(precacheFallbackPlugin._precacheController).to.be.instanceOf(PrecacheController);
+    });
+
+    it(`should construct a PrecacheFallbackPlugin instance with a non-default PrecacheController`, function() {
+      const fallbackURL = '/test/url';
+      const precacheController = new PrecacheController();
+      const precacheFallbackPlugin = new PrecacheFallbackPlugin({
+        fallbackURL,
+        precacheController,
+      });
+
+      expect(precacheFallbackPlugin._fallbackURL).to.eql(fallbackURL);
+      expect(precacheFallbackPlugin._precacheController).to.eql(precacheController);
     });
 
     it(`should expose a handlerDidError method`, function() {

--- a/test/workbox-precaching/sw/test-PrecacheFallbackPlugin.mjs
+++ b/test/workbox-precaching/sw/test-PrecacheFallbackPlugin.mjs
@@ -1,0 +1,69 @@
+/*
+  Copyright 2018 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import {precache} from 'workbox-precaching/precache.mjs';
+import {PrecacheFallbackPlugin} from 'workbox-precaching/PrecacheFallbackPlugin.mjs';
+import {resetDefaultPrecacheController} from './resetDefaultPrecacheController.mjs';
+
+describe(`PrecacheFallbackPlugin`, function() {
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(function() {
+    sandbox.stub(self, 'addEventListener');
+    resetDefaultPrecacheController();
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  describe(`constructor`, function() {
+    it(`should construct a properly-configured PrecacheFallbackPlugin instance`, function() {
+      const fallbackURL = '/test/url';
+      const precacheFallbackPlugin = new PrecacheFallbackPlugin({fallbackURL});
+
+      expect(precacheFallbackPlugin._fallbackURL).to.eql(fallbackURL);
+    });
+
+    it(`should expose a handlerDidError method`, function() {
+      const fallbackURL = '/test/url';
+      const precacheFallbackPlugin = new PrecacheFallbackPlugin({fallbackURL});
+
+      expect(precacheFallbackPlugin).to.respondTo('handlerDidError');
+    });
+  });
+
+  describe(`handlerDidError`, function() {
+    it(`should return the matchPrecache value for the fallbackURL`, async function() {
+      const body = 'test body';
+      const fallbackURL = '/test/url';
+      const revision = 'abcd1234';
+
+      const matchStub = sandbox.stub().resolves(new Response(body));
+      sandbox.stub(self.caches, 'open').resolves({
+        match: matchStub,
+      });
+
+      precache([{
+        revision,
+        url: fallbackURL,
+      }]);
+
+      const precacheFallbackPlugin = new PrecacheFallbackPlugin({fallbackURL});
+
+      const response = await precacheFallbackPlugin.handlerDidError();
+      const responseBody = await response.text();
+
+      expect(responseBody).to.eql(body);
+
+      const expectedURL = new URL(fallbackURL, location.href);
+      expectedURL.searchParams.set('__WB_REVISION__', revision);
+      expect(matchStub.args).to.eql([[expectedURL.href]]);
+    });
+  });
+});


### PR DESCRIPTION
R: @philipwalton

This is a follow-up to https://github.com/GoogleChrome/workbox/pull/2576

Once this is merged, I'm going to do one more PR to add in support for using this plugin from within `runtimeCaching` as using `generateSW`.
