### PR TITLE
Adds precacheFallback support to runtimeCaching in generateSW

### DIFF
--- a/infra/testing/validator/service-worker-runtime.js
+++ b/infra/testing/validator/service-worker-runtime.js
@@ -121,6 +121,7 @@ function setupSpiesAndContextForGenerateSW() {
     BroadcastUpdatePlugin: sinon.spy(),
     CacheableResponsePlugin: sinon.spy(),
     ExpirationPlugin: sinon.spy(),
+    PrecacheFallbackPlugin: sinon.spy(),
     precacheAndRoute: sinon.spy(),
     registerRoute: sinon.spy(),
     setCacheNameDetails: sinon.spy(),
@@ -146,7 +147,8 @@ function validateMethodCalls({methodsToSpies, expectedMethodCalls, context}) {
       const args = spy.args.map(
           (arg) => Array.isArray(arg) ? stringifyFunctionsInArray(arg) : arg);
 
-      expect(args).to.matchPattern(expectedMethodCalls[method]);
+      expect(args, `while testing method calls for ${method}`)
+          .to.matchPattern(expectedMethodCalls[method]);
     } else {
       expect(expectedMethodCalls[method],
           `while testing method calls for ${method}`).to.be.undefined;

--- a/packages/workbox-build/src/_types.js
+++ b/packages/workbox-build/src/_types.js
@@ -92,6 +92,12 @@ import './_version.mjs';
  * property to use when creating the
  * [`ExpirationPlugin`]{@link module:workbox-expiration.ExpirationPlugin}.
  *
+ * @property {Object} [options.precacheFallback]
+ *
+ * @property {number} [options.precacheFallback.fallbackURL] The `fallbackURL`
+ * property to use when creating the
+ * [`PrecacheFallbackPlugin`]{@link module:workbox-precaching.PrecacheFallbackPlugin}.
+ *
  * @property {Object} [options.matchOptions] The `matchOptions` property value
  * to use when constructing one of the
  * [Workbox strategy classes]{@link module:workbox-strategies}.

--- a/packages/workbox-build/src/lib/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/runtime-caching-converter.js
@@ -98,6 +98,15 @@ function getOptionsString(moduleRegistry, options = {}) {
         break;
       }
 
+      case 'precacheFallback': {
+        const plugin = moduleRegistry.use(
+            'workbox-precaching', 'PrecacheFallbackPlugin');
+
+        pluginCode = `new ${plugin}(${stringifyWithoutComments(pluginConfig)})`;
+
+        break;
+      }
+
       default: {
         throw new Error(errors['bad-runtime-caching-config'] + pluginName);
       }

--- a/packages/workbox-build/src/options/partials/generate.js
+++ b/packages/workbox-build/src/options/partials/generate.js
@@ -73,6 +73,9 @@ module.exports = {
       }).or('maxEntries', 'maxAgeSeconds'),
       networkTimeoutSeconds: joi.number().min(1),
       plugins: joi.array().items(joi.object()),
+      precacheFallback: joi.object().keys({
+        fallbackURL: joi.string().required(),
+      }),
       fetchOptions: joi.object(),
       matchOptions: joi.object(),
     }).with('expiration', 'cacheName'),

--- a/test/workbox-build/node/generate-sw.js
+++ b/test/workbox-build/node/generate-sw.js
@@ -862,6 +862,9 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
           },
           statuses: [0, 200],
         },
+        precacheFallback: {
+          fallbackURL: '/test',
+        },
       };
       const runtimeCaching = [{
         urlPattern: REGEXP_URL_PATTERN,
@@ -890,10 +893,11 @@ describe(`[workbox-build] generate-sw.js (End to End)`, function() {
           plugins: [{}],
         }], [{
           cacheName: secondRuntimeCachingOptions.cacheName,
-          plugins: [{}],
+          plugins: [{}, {}],
         }]],
         ExpirationPlugin: [[firstRuntimeCachingOptions.expiration]],
         CacheableResponsePlugin: [[secondRuntimeCachingOptions.cacheableResponse]],
+        PrecacheFallbackPlugin: [[secondRuntimeCachingOptions.precacheFallback]],
         importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
         precacheAndRoute: [[[{
           url: 'index.html',

--- a/test/workbox-build/node/lib/runtime-caching-converter.js
+++ b/test/workbox-build/node/lib/runtime-caching-converter.js
@@ -31,6 +31,7 @@ function validate(runtimeCachingOptions, convertedOptions) {
     workbox_expiration_ExpirationPlugin: sinon.spy(),
     workbox_background_sync_BackgroundSyncPlugin: sinon.spy(),
     workbox_broadcast_update_BroadcastUpdatePlugin: sinon.spy(),
+    workbox_precaching_PrecacheFallbackPlugin: sinon.spy(),
     workbox_routing_registerRoute: sinon.spy(),
     workbox_strategies_CacheFirst: sinon.spy(),
     workbox_strategies_CacheOnly: sinon.spy(),
@@ -95,6 +96,10 @@ function validate(runtimeCachingOptions, convertedOptions) {
 
       if (options.cacheableResponse) {
         expect(globalScope.workbox_cacheable_response_CacheableResponsePlugin.calledWith(options.cacheableResponse)).to.be.true;
+      }
+
+      if (options.precacheFallback) {
+        expect(globalScope.workbox_precaching_PrecacheFallbackPlugin.calledWith(options.precacheFallback)).to.be.true;
       }
 
       if (options.backgroundSync) {
@@ -182,6 +187,9 @@ describe(`[workbox-build] src/lib/utils/runtime-caching-converter.js`, function(
         backgroundSync: {
           name: 'test',
         },
+        precacheFallback: {
+          fallbackURL: '/test1',
+        },
         fetchOptions: {
           headers: {
             'Custom': 'Header',
@@ -209,6 +217,9 @@ describe(`[workbox-build] src/lib/utils/runtime-caching-converter.js`, function(
           options: {
             maxRetentionTime: 123,
           },
+        },
+        precacheFallback: {
+          fallbackURL: '/test2',
         },
         matchOptions: {
           ignoreSearch: true,


### PR DESCRIPTION
R: @philipwalton

Adds support for using the `PrecacheFallbackPlugin` inside of a declarative `runtimeCaching` config in `generateSW` mode of the build tools.