### PR TITLE
Tweaks to the publishing process

### DIFF
--- a/gulp-tasks/publish-github.js
+++ b/gulp-tasks/publish-github.js
@@ -6,15 +6,12 @@
   https://opensource.org/licenses/MIT.
 */
 
-const fse = require('fs-extra');
 const semver = require('semver');
-const upath = require('upath');
 
 const githubHelper = require('./utils/github-helper');
 const logHelper = require('../infra/utils/log-helper');
-const publishHelpers = require('./utils/publish-helpers');
 
-async function publishReleaseOnGithub(tagName, releaseInfo, tarPath, zipPath) {
+async function publishReleaseOnGithub(tagName, releaseInfo) {
   if (!releaseInfo) {
     const releaseData = await githubHelper.createRelease({
       tag_name: tagName,
@@ -24,35 +21,12 @@ async function publishReleaseOnGithub(tagName, releaseInfo, tarPath, zipPath) {
     });
     releaseInfo = releaseData.data;
   }
-
-  const tarBuffer = await fse.readFile(tarPath);
-  await githubHelper.uploadAsset({
-    url: releaseInfo.upload_url,
-    file: tarBuffer,
-    contentType: 'application/gzip',
-    contentLength: tarBuffer.length,
-    name: upath.basename(tarPath),
-    label: upath.basename(tarPath),
-  });
-
-  const zipBuffer = await fse.readFile(zipPath);
-  await githubHelper.uploadAsset({
-    url: releaseInfo.upload_url,
-    file: zipBuffer,
-    contentType: 'application/zip',
-    contentLength: zipBuffer.length,
-    name: upath.basename(zipPath),
-    label: upath.basename(zipPath),
-  });
 }
 
 async function handleGithubRelease(tagName, gitBranch, releaseInfo) {
   logHelper.log(`Creating GitHub release ${logHelper.highlight(tagName)}.`);
 
-  const {tarPath, zipPath} = await publishHelpers.createBundles(tagName,
-      gitBranch);
-
-  await publishReleaseOnGithub(tagName, releaseInfo, tarPath, zipPath);
+  await publishReleaseOnGithub(tagName, releaseInfo);
 }
 
 function filterTagsWithReleaseBundles(allTags, taggedReleases) {

--- a/gulp-tasks/publish-lerna.js
+++ b/gulp-tasks/publish-lerna.js
@@ -14,19 +14,14 @@ const logHelper = require('../infra/utils/log-helper');
 async function publish_lerna() {
   const options = ['publish', '--force-publish'];
 
-  // gulp publish_lerna --distTag=blah takes precedence.
+  // gulp publish --distTag=latest would be the most common.
   if (global.cliOptions.distTag) {
     logHelper.log(ol`Using ${logHelper.highlight(
         '--dist-tag=' + global.cliOptions.distTag)}`);
     options.push('--dist-tag', global.cliOptions.distTag);
   } else {
-    // If we're not on master, publish to next on npm.
-    const {stdout} = await execa('git', ['symbolic-ref', '--short', 'HEAD']);
-    if (stdout !== 'master') {
-      logHelper.log(ol`Using ${logHelper.highlight('--dist-tag=next')} as
-          the current git branch is ${logHelper.highlight(stdout)}.`);
-      options.push('--dist-tag', 'next');
-    }
+    throw new Error(ol`Please set the --distTag command line option, normally
+        to 'latest' (for a stable release) or 'next' (for a pre-release).`);
   }
 
   await execa('lerna', options, {

--- a/gulp-tasks/publish.js
+++ b/gulp-tasks/publish.js
@@ -9,6 +9,7 @@
 const {series} = require('gulp');
 const execa = require('execa');
 const fse = require('fs-extra');
+const ol = require('common-tags').oneLine;
 
 const {publish_cdn} = require('./publish-cdn');
 const {publish_github} = require('./publish-github');
@@ -24,7 +25,14 @@ async function publish_sign_in_check() {
   await execa('npm', ['whoami']);
 }
 
+function dist_tag_check() {
+  if (!global.cliOptions.distTag) {
+    throw new Error(ol`Please set the --distTag command line option, normally
+        to 'latest' (for a stable release) or 'next' (for a pre-release).`);
+  }
+}
+
 module.exports = {
-  publish: series(publish_sign_in_check, publish_clean, test, publish_lerna,
-      publish_github, publish_cdn),
+  publish: series(dist_tag_check, publish_sign_in_check, publish_clean, test,
+      publish_lerna, publish_github, publish_cdn),
 };

--- a/gulp-tasks/utils/publish-helpers.js
+++ b/gulp-tasks/utils/publish-helpers.js
@@ -6,7 +6,6 @@
   https://opensource.org/licenses/MIT.
 */
 
-const archiver = require('archiver');
 const execa = require('execa');
 const fse = require('fs-extra');
 const glob = require('glob');
@@ -127,53 +126,6 @@ const groupBuildFiles = async (tagName, gitBranch) => {
   return groupedBuildFiles;
 };
 
-const createArchive = async (tagName, fileExtension, format, options) => {
-  const archiveFilesPath = upath.join(getBuildPath(tagName), 'archives');
-  const archiveFilename = `workbox-${tagName}.${fileExtension}`;
-  const outputFilePath = upath.join(archiveFilesPath, archiveFilename);
-
-  logHelper.log(ol`
-    Creating ${format} and saving to
-    ${logHelper.highlight(upath.relative(process.cwd(), outputFilePath))}.
-  `);
-
-  await fse.ensureDir(upath.dirname(outputFilePath));
-
-  const groupedBuildFiles = upath.join(getBuildPath(tagName),
-      GROUPED_BUILD_FILES);
-
-  const writeStream = fse.createWriteStream(outputFilePath);
-  const archive = archiver(format, options);
-  archive.pipe(writeStream);
-  // Adds the directory contents to the zip.
-  archive.directory(groupedBuildFiles, false);
-  await archive.finalize();
-
-  return outputFilePath;
-};
-
-const createTarGz = (tagName) => {
-  return createArchive(tagName, 'tar.gz', 'tar', {gzip: true});
-};
-
-const createZip = (tagName) => {
-  return createArchive(tagName, 'zip', 'zip', {
-    zlib: {level: 9},
-  });
-};
-
-const createBundles = async (tagName, gitBranch) => {
-  await groupBuildFiles(tagName, gitBranch);
-
-  const tarPath = await createTarGz(tagName);
-  const zipPath = await createZip(tagName);
-  return {
-    tarPath,
-    zipPath,
-  };
-};
-
 module.exports = {
   groupBuildFiles,
-  createBundles,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4722,52 +4722,6 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
-    "archiver": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.0.tgz",
-      "integrity": "sha512-AEWhJz6Yi6hWtN1Sqy/H4sZo/lLMJ/NftXxGaDy/TnOMmmjsRaZc/Ts+U4BsPoBQkuunTN6t8hk7iU9A+HBxLw==",
-      "dev": true,
-      "requires": {
-        "archiver-utils": "^2.1.0",
-        "async": "^3.2.0",
-        "buffer-crc32": "^0.2.1",
-        "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.0.0",
-        "tar-stream": "^2.1.2",
-        "zip-stream": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "archiver-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^2.0.0"
-      }
-    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -5041,12 +4995,6 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "async": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-      "dev": true
-    },
     "async-done": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
@@ -5264,30 +5212,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "bl": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -5492,16 +5416,6 @@
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
       "dev": true
-    },
-    "buffer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
-      }
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -6139,31 +6053,6 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
-    },
-    "compress-commons": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.1.tgz",
-      "integrity": "sha512-xZm9o6iikekkI0GnXCmAl3LQGZj5TBDj0zLowsqi7tJtEa3FMGSEcHcqrSJIrOAk1UG/NBbDn/F1q+MG/p/EsA==",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "compressible": {
       "version": "2.0.18",
@@ -6852,38 +6741,6 @@
         "log-driver": "^1.2.7",
         "minimist": "^1.2.5",
         "request": "^2.88.2"
-      }
-    },
-    "crc": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.1.0"
-      }
-    },
-    "crc32-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.0.tgz",
-      "integrity": "sha512-tyMw2IeUX6t9jhgXI6um0eKfWq4EIDpfv5m7GX4Jzp7eVelQ360xd8EPXJhp2mHwLQIkqlnMLjzqSZI3a+0wRw==",
-      "dev": true,
-      "requires": {
-        "crc": "^3.4.4",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "create-ecdh": {
@@ -8966,12 +8823,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.1.tgz",
       "integrity": "sha512-Xu2Qh8yqYuDhQGOhD5iJGninErSfI9A3FrriD3tjUgV5VbJFeH8vfgZ9HnC6jWN80QDVNQK5vmxRAmEAp7Mevw==",
-      "dev": true
-    },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
     "fs-extra": {
@@ -12078,24 +11929,6 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
-    "lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-      "dev": true
-    },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
-    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -12112,12 +11945,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
-      "dev": true
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.set": {
@@ -12150,12 +11977,6 @@
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
-    },
-    "lodash.union": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
-      "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -15021,15 +14842,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "readdir-glob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.0.0.tgz",
-      "integrity": "sha512-km0DIcwQVZ1ZUhXhMWpF74/Wm5aFEd5/jDiVWF1Hkw2myPQovG8vCQ8+FQO2KXE9npQQvCnAMZhhWuUee4WcCQ==",
-      "dev": true,
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
-    },
     "readdir-scoped-modules": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
@@ -16759,32 +16571,6 @@
         "minizlib": "^2.1.0",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
-      }
-    },
-    "tar-stream": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-      "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
-      "dev": true,
-      "requires": {
-        "bl": "^4.0.1",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "teeny-request": {
@@ -18693,30 +18479,6 @@
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
-      }
-    },
-    "zip-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.2.tgz",
-      "integrity": "sha512-TGxB2g+1ur6MHkvM644DuZr8Uzyz0k0OYWtS3YlpfWBEmK4woaC2t3+pozEL3dBfIPmpgmClR5B2QRcMgGt22g==",
-      "dev": true,
-      "requires": {
-        "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",
     "acorn": "^8.0.1",
-    "archiver": "^5.0.0",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
     "babylon": "^6.18.0",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
R: @philipwalton 

This tweaks the release process in two ways:

- We no longer generate .tar.gz and .zip archives of each release and attach them to the corresponding GitHub release, since there are many other ways of consuming the Workbox code nowadays, and it's not clear that anyone uses those archives.

- It explicitly requires passing in `--distTag=...` when running `gulp publish`, removing the previous logic that checked for the `master` branch name and switched between `latest` and `next` based on that. Being explicit is a bit more work, but since we may not go back to using `master`, it seemed like the thing to do.