### PR TITLE
DX improvements for extending Strategy classes

### DIFF
--- a/packages/workbox-core/src/_private/dontWaitFor.ts
+++ b/packages/workbox-core/src/_private/dontWaitFor.ts
@@ -12,7 +12,7 @@ import '../_version.js';
  *
  * @private
  **/
-export function dontWaitFor(promise: Promise<any>) {
+export function dontWaitFor(promise: Promise<any>): void {
   // Effective no-op.
   promise.then(() => {});
 }

--- a/packages/workbox-strategies/src/CacheFirst.ts
+++ b/packages/workbox-strategies/src/CacheFirst.ts
@@ -44,7 +44,7 @@ class CacheFirst extends Strategy {
     if (process.env.NODE_ENV !== 'production') {
       assert!.isInstance(request, Request, {
         moduleName: 'workbox-strategies',
-        className: 'CacheFirst',
+        className: this.constructor.name,
         funcName: 'makeRequest',
         paramName: 'request',
       });
@@ -81,7 +81,7 @@ class CacheFirst extends Strategy {
 
     if (process.env.NODE_ENV !== 'production') {
       logger.groupCollapsed(
-          messages.strategyStart('CacheFirst', request));
+          messages.strategyStart(this.constructor.name, request));
       for (const log of logs) {
         logger.log(log);
       }

--- a/packages/workbox-strategies/src/CacheOnly.ts
+++ b/packages/workbox-strategies/src/CacheOnly.ts
@@ -41,7 +41,7 @@ class CacheOnly extends Strategy {
     if (process.env.NODE_ENV !== 'production') {
       assert!.isInstance(request, Request, {
         moduleName: 'workbox-strategies',
-        className: 'CacheOnly',
+        className: this.constructor.name,
         funcName: 'makeRequest',
         paramName: 'request',
       });
@@ -51,7 +51,7 @@ class CacheOnly extends Strategy {
 
     if (process.env.NODE_ENV !== 'production') {
       logger.groupCollapsed(
-          messages.strategyStart('CacheOnly', request));
+          messages.strategyStart(this.constructor.name, request));
       if (response) {
         logger.log(`Found a cached response in the '${this.cacheName}'` +
           ` cache.`);

--- a/packages/workbox-strategies/src/NetworkFirst.ts
+++ b/packages/workbox-strategies/src/NetworkFirst.ts
@@ -17,7 +17,7 @@ import {messages} from './utils/messages.js';
 import './_version.js';
 
 
-interface NetworkFirstOptions extends StrategyOptions {
+export interface NetworkFirstOptions extends StrategyOptions {
   networkTimeoutSeconds?: number;
 }
 
@@ -72,7 +72,7 @@ class NetworkFirst extends Strategy {
       if (this._networkTimeoutSeconds) {
         assert!.isType(this._networkTimeoutSeconds, 'number', {
           moduleName: 'workbox-strategies',
-          className: 'NetworkFirst',
+          className: this.constructor.name,
           funcName: 'constructor',
           paramName: 'networkTimeoutSeconds',
         });
@@ -93,7 +93,7 @@ class NetworkFirst extends Strategy {
     if (process.env.NODE_ENV !== 'production') {
       assert!.isInstance(request, Request, {
         moduleName: 'workbox-strategies',
-        className: 'NetworkFirst',
+        className: this.constructor.name,
         funcName: 'handle',
         paramName: 'makeRequest',
       });

--- a/packages/workbox-strategies/src/NetworkFirst.ts
+++ b/packages/workbox-strategies/src/NetworkFirst.ts
@@ -129,7 +129,7 @@ class NetworkFirst extends Strategy {
 
     if (process.env.NODE_ENV !== 'production') {
       logger.groupCollapsed(
-          messages.strategyStart('NetworkFirst', request));
+          messages.strategyStart(this.constructor.name, request));
       for (const log of logs) {
         logger.log(log);
       }

--- a/packages/workbox-strategies/src/NetworkOnly.ts
+++ b/packages/workbox-strategies/src/NetworkOnly.ts
@@ -41,7 +41,7 @@ class NetworkOnly extends Strategy {
     if (process.env.NODE_ENV !== 'production') {
       assert!.isInstance(request, Request, {
         moduleName: 'workbox-strategies',
-        className: 'NetworkOnly',
+        className: this.constructor.name,
         funcName: 'handle',
         paramName: 'request',
       });
@@ -57,7 +57,7 @@ class NetworkOnly extends Strategy {
 
     if (process.env.NODE_ENV !== 'production') {
       logger.groupCollapsed(
-          messages.strategyStart('NetworkOnly', request));
+          messages.strategyStart(this.constructor.name, request));
       if (response) {
         logger.log(`Got response from network.`);
       } else {

--- a/packages/workbox-strategies/src/StaleWhileRevalidate.ts
+++ b/packages/workbox-strategies/src/StaleWhileRevalidate.ts
@@ -74,7 +74,7 @@ class StaleWhileRevalidate extends Strategy {
     if (process.env.NODE_ENV !== 'production') {
       assert!.isInstance(request, Request, {
         moduleName: 'workbox-strategies',
-        className: 'StaleWhileRevalidate',
+        className: this.constructor.name,
         funcName: 'handle',
         paramName: 'request',
       });
@@ -111,7 +111,7 @@ class StaleWhileRevalidate extends Strategy {
 
     if (process.env.NODE_ENV !== 'production') {
       logger.groupCollapsed(
-          messages.strategyStart('StaleWhileRevalidate', request));
+          messages.strategyStart(this.constructor.name, request));
       for (const log of logs) {
         logger.log(log);
       }


### PR DESCRIPTION
R: @philipwalton 

This fixes a couple of awkward things I found when extending `NetworkFirst` in https://github.com/GoogleChrome/workbox/issues/2593#issuecomment-674455562:

- The log messages should use `this.constructor.name` instead of a hardcoded string.
- `NetworkFirstOptions` wasn't exported, making it awkward to call the `NetworkFirst` constructor via `super()` without using `any`.