### PR TITLE
Allow cacheKeyWillBeUsed to influence the request method check

### DIFF
--- a/packages/workbox-strategies/src/StrategyHandler.ts
+++ b/packages/workbox-strategies/src/StrategyHandler.ts
@@ -205,10 +205,10 @@ class StrategyHandler {
     const effectiveRequest = await this._getEffectiveRequest(request, 'write');
     
     if (process.env.NODE_ENV !== 'production') {
-      if (request.method && request.method !== 'GET') {
+      if (effectiveRequest.method && effectiveRequest.method !== 'GET') {
         throw new WorkboxError('attempt-to-cache-non-get-request', {
-          url: getFriendlyURL(request.url),
-          method: request.method,
+          url: getFriendlyURL(effectiveRequest.url),
+          method: effectiveRequest.method,
         });
       }
     }


### PR DESCRIPTION
Fixes #2615

Moves the request method check after the call to `cacheKeyWillBeUsed` so that developers can potentially cache `post` requests as `get` requests.



