### PR TITLE
Add instructions to run gulp build before test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 **Prior to filing a PR, please:**
 - [open an issue](https://github.com/GoogleChrome/workbox/issues/new) to discuss your proposed change.
-- ensure that `gulp lint test` passes locally.
+- ensure that `gulp build && gulp lint test` passes locally.
 
 R: @jeffposnick @philipwalton
 


### PR DESCRIPTION
**Prior to filing a PR, please:**
- [open an issue](https://github.com/GoogleChrome/workbox/issues/new) to discuss your proposed change.
- ensure that `gulp lint test` passes locally.

R: @jeffposnick @philipwalton

Fixes #2628

See issue description for details
