### PR TITLE
Adjust PrecacheEntry type to allow null revisions

### DIFF
--- a/packages/workbox-precaching/src/_types.ts
+++ b/packages/workbox-precaching/src/_types.ts
@@ -20,7 +20,7 @@ export interface CleanupResult {
 export interface PrecacheEntry {
   integrity?: string;
   url: string;
-  revision?: string;
+  revision?: string | null;
 }
 export interface PrecacheRouteOptions {
   directoryIndex?: string;


### PR DESCRIPTION
This allows the revision to be set to null, which is necessary when the revisioning information is in the URL itself.

R: @jeffposnick @philipwalton

Fixes #2644

