### PR TITLE
Mark BackgroundSyncPlugin options param as optional

### DIFF
--- a/packages/workbox-background-sync/src/BackgroundSyncPlugin.ts
+++ b/packages/workbox-background-sync/src/BackgroundSyncPlugin.ts
@@ -26,7 +26,7 @@ class BackgroundSyncPlugin implements WorkboxPlugin {
    *     [Queue]{@link module:workbox-background-sync.Queue} documentation for
    *     parameter details.
    */
-  constructor(name: string, options: QueueOptions) {
+  constructor(name: string, options?: QueueOptions) {
     this._queue = new Queue(name, options);
   }
 

--- a/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts
+++ b/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts
@@ -62,7 +62,7 @@ class BroadcastCacheUpdate {
    * Construct a BroadcastCacheUpdate instance with a specific `channelName` to
    * broadcast messages on
    *
-   * @param {Object} options
+   * @param {Object} [options]
    * @param {Array<string>} [options.headersToCheck=['content-length', 'etag', 'last-modified']]
    *     A list of headers that will be used to determine whether the responses
    *     differ.

--- a/packages/workbox-broadcast-update/src/BroadcastUpdatePlugin.ts
+++ b/packages/workbox-broadcast-update/src/BroadcastUpdatePlugin.ts
@@ -27,7 +27,7 @@ class BroadcastUpdatePlugin implements WorkboxPlugin {
    * calls its [`notifyIfUpdated()`]{@link module:workbox-broadcast-update.BroadcastCacheUpdate~notifyIfUpdated}
    * method whenever the plugin's `cacheDidUpdate` callback is invoked.
    *
-   * @param {Object} options
+   * @param {Object} [options]
    * @param {Array<string>} [options.headersToCheck=['content-length', 'etag', 'last-modified']]
    *     A list of headers that will be used to determine whether the responses
    *     differ.
@@ -35,7 +35,7 @@ class BroadcastUpdatePlugin implements WorkboxPlugin {
    *     will be used as the `payload` field in any cache update messages sent
    *     to the window clients.
    */
-  constructor(options: BroadcastCacheUpdateOptions) {
+  constructor(options?: BroadcastCacheUpdateOptions) {
     this._broadcastUpdate = new BroadcastCacheUpdate(options);
   }
 


### PR DESCRIPTION
R: @philipwalton

I just bumped into this when using the TypeScript definition of the `BackgroundSyncPlugin` constructor. I am pretty sure that the `options` param is meant to be optional.