### PR TITLE
Make use of AssetInfo in webpack build

### DIFF
--- a/packages/workbox-webpack-plugin/src/generate-sw.js
+++ b/packages/workbox-webpack-plugin/src/generate-sw.js
@@ -75,10 +75,10 @@ class GenerateSW {
    *
    * @param {RegExp} [config.dontCacheBustURLsMatching] Assets that match this will be
    * assumed to be uniquely versioned via their URL, and exempted from the normal
-   * HTTP cache-busting that's done when populating the precache. While not
-   * required, it's recommended that if your existing build process already
-   * inserts a `[hash]` value into each filename, you provide a RegExp that will
-   * detect that, as it will reduce the bandwidth consumed when precaching.
+   * HTTP cache-busting that's done when populating the precache. (As of Workbox
+   * v6, this option is usually not needed, as each
+   * [asset's metadata](https://github.com/webpack/webpack/issues/9038) is used
+   * to determine whether it's immutable or not.)
    *
    * @param {Array<string|RegExp|Function>} [config.exclude=[/\.map$/, /^manifest.*\.js$]]
    * One or more specifiers used to exclude assets from the precache manifest.

--- a/packages/workbox-webpack-plugin/src/generate-sw.js
+++ b/packages/workbox-webpack-plugin/src/generate-sw.js
@@ -304,7 +304,10 @@ class GenerateSW {
     });
 
     for (const file of files) {
-      compilation.emitAsset(file.name, new RawSource(file.contents));
+      compilation.emitAsset(file.name, new RawSource(file.contents), {
+        // See https://github.com/webpack-contrib/compression-webpack-plugin/issues/218#issuecomment-726196160
+        minimized: config.mode === 'production',
+      });
       _generatedAssetNames.add(file.name);
     }
 

--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -67,10 +67,10 @@ class InjectManifest {
    *
    * @param {RegExp} [config.dontCacheBustURLsMatching] Assets that match this will be
    * assumed to be uniquely versioned via their URL, and exempted from the normal
-   * HTTP cache-busting that's done when populating the precache. While not
-   * required, it's recommended that if your existing build process already
-   * inserts a `[hash]` value into each filename, you provide a RegExp that will
-   * detect that, as it will reduce the bandwidth consumed when precaching.
+   * HTTP cache-busting that's done when populating the precache. (As of Workbox
+   * v6, this option is usually not needed, as each
+   * [asset's metadata](https://github.com/webpack/webpack/issues/9038) is used
+   * to determine whether it's immutable or not.)
    *
    * @param {Array<string|RegExp|Function>} [config.exclude=[/\.map$/, /^manifest.*\.js$]]
    * One or more specifiers used to exclude assets from the precache manifest.

--- a/packages/workbox-webpack-plugin/src/lib/get-asset-hash.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-asset-hash.js
@@ -15,10 +15,12 @@ const crypto = require('crypto');
  * @private
  */
 module.exports = (asset) => {
-  // TODO: Check asset.info.immutable and use null when set.
-  // if (asset.info.immutable) {
-  //   return null;
-  // }
+  // If webpack has the asset marked as immutable, then we don't need to
+  // use an out-of-band revision for it.
+  // See https://github.com/webpack/webpack/issues/9038
+  if (asset.info && asset.info.immutable) {
+    return null;
+  }
 
   return crypto.createHash('md5')
       .update(Buffer.from(asset.source.source()))

--- a/test/workbox-webpack-plugin/node/v4/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/v4/generate-sw.js
@@ -109,10 +109,10 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
               importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry2-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -171,7 +171,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
               ],
               // imported-[chunkhash].js should *not* be included.
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^main-[0-9a-f]{20}\.js$/,
               }], {}]],
             },
@@ -224,10 +224,10 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
               importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry2-[0-9a-f]{20}\.js$/,
                 }, {
                   revision: null,
@@ -283,10 +283,10 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry1-[0-9a-f]{20}\.js$/,
               }, {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry2-[0-9a-f]{20}\.js$/,
               },
             ], {}]],
@@ -385,10 +385,10 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry1-[0-9a-f]{20}\.js$/,
               }, {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry2-[0-9a-f]{20}\.js$/,
               },
             ], {}]],
@@ -435,7 +435,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry1-[0-9a-f]{20}\.js$/,
               },
             ], {}]],
@@ -480,10 +480,10 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: /^[0-9a-f]{32}$/,
+              revision: null,
               url: /^entry1-[0-9a-f]{20}\.js$/,
             }, {
-              revision: /^[0-9a-f]{32}$/,
+              revision: null,
               url: /^entry2-[0-9a-f]{20}\.js$/,
             }, {
               revision: /^[0-9a-f]{32}$/,
@@ -852,7 +852,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
               importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -910,7 +910,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry1-[0-9a-f]{20}\.js$/,
               },
               {
@@ -988,7 +988,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^\/testing\/entry1-[0-9a-f]{20}\.js$/,
               },
             ], {}]],
@@ -1078,7 +1078,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
           await validateServiceWorkerRuntime({swString, expectedMethodCalls: {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: /^[0-9a-f]{32}$/,
+              revision: null,
               url: /^entry1-[0-9a-f]{20}\.js$/,
             }], {}]],
           }});
@@ -1384,7 +1384,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: /^[0-9a-f]{32}$/,
+              revision: null,
               url: /^https:\/\/example\.org\/main\.[0-9a-f]{20}\.js/,
             }], {}]],
           }});
@@ -1412,7 +1412,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v4`, function() {
               expect(manifest).to.have.lengthOf(1);
               expect(manifest[0].size).to.eql(959);
               expect(manifest[0].url.startsWith('main.')).to.be.true;
-              expect(manifest[0].revision).to.have.lengthOf(32);
+              expect(manifest[0].revision).to.be.null;
               expect(compilation).to.exist;
 
               manifest = manifest.map((entry) => {

--- a/test/workbox-webpack-plugin/node/v4/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/v4/inject-manifest.js
@@ -119,10 +119,10 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry2-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -173,10 +173,10 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry2-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -285,10 +285,10 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry2-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -340,7 +340,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -391,10 +391,10 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry1-[0-9a-f]{20}\.js$/,
               }, {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry2-[0-9a-f]{20}\.js$/,
               }, {
                 revision: /^[0-9a-f]{32}$/,
@@ -958,7 +958,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -1020,7 +1020,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 },
                 {
@@ -1104,7 +1104,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^\/testing\/entry1-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -1244,7 +1244,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^https:\/\/example\.org\/main\.[0-9a-f]{20}\.js/,
               }], {}]],
             },
@@ -1295,7 +1295,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             expectedMethodCalls: {
               setCacheNameDetails: [[{prefix}]],
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^main\.[0-9a-f]{20}\.js$/,
               }], {}]],
             },
@@ -1326,7 +1326,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
               expect(manifest).to.have.lengthOf(1);
               expect(manifest[0].size).to.eql(959);
               expect(manifest[0].url.startsWith('main.')).to.be.true;
-              expect(manifest[0].revision).to.have.lengthOf(32);
+              expect(manifest[0].revision).to.be.null;
               expect(compilation).to.exist;
 
               manifest = manifest.map((entry) => {
@@ -1554,7 +1554,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^main\.[0-9a-f]{20}\.js$/,
               }], {}]],
             },
@@ -1565,7 +1565,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^main\.[0-9a-f]{20}\.js$/,
               }], {}]],
             },
@@ -1613,7 +1613,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^main\.[0-9a-f]{20}\.js$/,
               }], {}]],
             },
@@ -1694,7 +1694,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
 
           const manifest = await fse.readJSON(upath.join(outputDir, 'injected-manifest.json'));
           expect(manifest).to.matchPattern([{
-            revision: /^[0-9a-f]{32}$/,
+            revision: null,
             url: /^main\.[0-9a-f]{20}\.js$/,
           }]);
 
@@ -1735,7 +1735,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v4`, function() {
 
         const manifest = require(upath.join(outputDir, 'injected-manifest.js'));
         expect(manifest).to.matchPattern([{
-          revision: /^[0-9a-f]{32}$/,
+          revision: null,
           url: /^main\.[0-9a-f]{20}\.js$/,
         }]);
 

--- a/test/workbox-webpack-plugin/node/v5/generate-sw.js
+++ b/test/workbox-webpack-plugin/node/v5/generate-sw.js
@@ -107,10 +107,10 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
               importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry2-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -169,7 +169,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
               ],
               // imported-[chunkhash].js should *not* be included.
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^main-[0-9a-f]{20}\.js$/,
               }], {}]],
             },
@@ -222,10 +222,10 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
               importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry2-[0-9a-f]{20}\.js$/,
                 }, {
                   revision: null,
@@ -281,10 +281,10 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry1-[0-9a-f]{20}\.js$/,
               }, {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry2-[0-9a-f]{20}\.js$/,
               },
             ], {}]],
@@ -337,10 +337,10 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^[0-9a-f]{20}\.js$/,
               }, {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^[0-9a-f]{20}\.js$/,
               },
             ], {}]],
@@ -386,10 +386,10 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry1-[0-9a-f]{20}\.js$/,
               }, {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry2-[0-9a-f]{20}\.js$/,
               },
             ], {}]],
@@ -436,7 +436,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry1-[0-9a-f]{20}\.js$/,
               },
             ], {}]],
@@ -481,10 +481,10 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: /^[0-9a-f]{32}$/,
+              revision: null,
               url: /^entry1-[0-9a-f]{20}\.js$/,
             }, {
-              revision: /^[0-9a-f]{32}$/,
+              revision: null,
               url: /^entry2-[0-9a-f]{20}\.js$/,
             }, {
               revision: /^[0-9a-f]{32}$/,
@@ -849,7 +849,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
               importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -907,7 +907,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry1-[0-9a-f]{20}\.js$/,
               },
               {
@@ -985,7 +985,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[
               {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^\/testing\/entry1-[0-9a-f]{20}\.js$/,
               },
             ], {}]],
@@ -1034,7 +1034,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
           await validateServiceWorkerRuntime({swString, expectedMethodCalls: {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: /^[0-9a-f]{32}$/,
+              revision: null,
               url: /^entry1-[0-9a-f]{20}\.js$/,
             }], {}]],
           }});
@@ -1340,7 +1340,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
           await validateServiceWorkerRuntime({swFile, expectedMethodCalls: {
             importScripts: [[/^\.\/workbox-[0-9a-f]{8}$/]],
             precacheAndRoute: [[[{
-              revision: /^[0-9a-f]{32}$/,
+              revision: null,
               url: /^https:\/\/example\.org\/main\.[0-9a-f]{20}\.js/,
             }], {}]],
           }});
@@ -1368,7 +1368,7 @@ describe(`[workbox-webpack-plugin] GenerateSW with webpack v5`, function() {
               expect(manifest).to.have.lengthOf(1);
               expect(manifest[0].size).to.eql(30);
               expect(manifest[0].url.startsWith('main.')).to.be.true;
-              expect(manifest[0].revision).to.have.lengthOf(32);
+              expect(manifest[0].revision).to.be.null;
               expect(compilation).to.exist;
 
               manifest = manifest.map((entry) => {

--- a/test/workbox-webpack-plugin/node/v5/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/v5/inject-manifest.js
@@ -118,10 +118,10 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry2-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -172,10 +172,10 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry2-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -233,10 +233,10 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -287,10 +287,10 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 }, {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry2-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -342,7 +342,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -393,10 +393,10 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry1-[0-9a-f]{20}\.js$/,
               }, {
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^entry2-[0-9a-f]{20}\.js$/,
               }, {
                 revision: /^[0-9a-f]{32}$/,
@@ -957,7 +957,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -1019,7 +1019,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^entry1-[0-9a-f]{20}\.js$/,
                 },
                 {
@@ -1103,7 +1103,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             expectedMethodCalls: {
               precacheAndRoute: [[[
                 {
-                  revision: /^[0-9a-f]{32}$/,
+                  revision: null,
                   url: /^\/testing\/entry1-[0-9a-f]{20}\.js$/,
                 },
               ], {}]],
@@ -1199,7 +1199,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^https:\/\/example\.org\/main\.[0-9a-f]{20}\.js/,
               }], {}]],
             },
@@ -1250,7 +1250,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             expectedMethodCalls: {
               setCacheNameDetails: [[{prefix}]],
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^main\.[0-9a-f]{20}\.js$/,
               }], {}]],
             },
@@ -1281,7 +1281,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
               expect(manifest).to.have.lengthOf(1);
               expect(manifest[0].size).to.eql(30);
               expect(manifest[0].url.startsWith('main.')).to.be.true;
-              expect(manifest[0].revision).to.have.lengthOf(32);
+              expect(manifest[0].revision).to.be.null;
               expect(compilation).to.exist;
 
               manifest = manifest.map((entry) => {
@@ -1509,7 +1509,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^main\.[0-9a-f]{20}\.js$/,
               }], {}]],
             },
@@ -1520,7 +1520,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^main\.[0-9a-f]{20}\.js$/,
               }], {}]],
             },
@@ -1568,7 +1568,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
             entryPoint: 'injectManifest',
             expectedMethodCalls: {
               precacheAndRoute: [[[{
-                revision: /^[0-9a-f]{32}$/,
+                revision: null,
                 url: /^main\.[0-9a-f]{20}\.js$/,
               }], {}]],
             },
@@ -1649,7 +1649,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
 
           const manifest = await fse.readJSON(upath.join(outputDir, 'injected-manifest.json'));
           expect(manifest).to.matchPattern([{
-            revision: /^[0-9a-f]{32}$/,
+            revision: null,
             url: /^main\.[0-9a-f]{20}\.js$/,
           }]);
 
@@ -1690,7 +1690,7 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
 
         const manifest = require(upath.join(outputDir, 'injected-manifest.js'));
         expect(manifest).to.matchPattern([{
-          revision: /^[0-9a-f]{32}$/,
+          revision: null,
           url: /^main\.[0-9a-f]{20}\.js$/,
         }]);
 


### PR DESCRIPTION
R: @Snugug @housseindjirdeh @philipwalton

Fixes #2221, fixes #2672

Some small changes to the `workbox-webpack-plugin` to take proper advantage of `webpack`'s `AssetInfo` capabilities.

When we create an asset via `GenerateSW` and we know that it's already been compressed, we now set `minimized: true`.

When we read assets from the build to generate our precache manifest, if any assets have `immutable: true`, that's a clear sign that we don't need to generate hashes for them, so we can return `null` for the `revision` parameter. The JSDoc for `dontCacheBustURLsMatching` has also been updated to reflect this.