### PR TITLE
Preserve symbols across builds, don't mangle _handle

### DIFF
--- a/gulp-tasks/build-packages.js
+++ b/gulp-tasks/build-packages.js
@@ -60,8 +60,9 @@ module.exports = {
       parallel(
           build_node_packages,
           build_node_ts_packages,
-          build_sw_packages,
-          build_window_packages,
+          // This needs to be a series, not in parallel, so that there isn't a
+          // race condition with the terser nameCache.
+          series(build_sw_packages, build_window_packages),
       ),
   ),
 };

--- a/gulp-tasks/build-sw-packages.js
+++ b/gulp-tasks/build-sw-packages.js
@@ -158,7 +158,9 @@ function swBundleSequence() {
 
   return series(
       parallel(transpilations),
-      parallel(builds),
+      // This needs to be a series, not in parallel, so that there isn't a
+      // race condition with the terser nameCache.
+      series(builds),
   );
 }
 

--- a/gulp-tasks/build-window-packages.js
+++ b/gulp-tasks/build-window-packages.js
@@ -102,7 +102,9 @@ function windowBundleSequence() {
 
   return series(
       parallel(transpilations),
-      parallel(builds),
+      // This needs to be a series, not in parallel, so that there isn't a
+      // race condition with the terser nameCache.
+      series(builds),
   );
 }
 

--- a/gulp-tasks/utils/rollup-helper.js
+++ b/gulp-tasks/utils/rollup-helper.js
@@ -16,7 +16,7 @@ const constants = require('./constants');
 const getVersionsCDNUrl = require('./versioned-cdn-url');
 
 // See https://github.com/GoogleChrome/workbox/issues/1674
-let nameCache = {};
+const nameCache = {};
 
 module.exports = {
   // Every use of rollup should have minification and the replace

--- a/gulp-tasks/utils/rollup-helper.js
+++ b/gulp-tasks/utils/rollup-helper.js
@@ -15,6 +15,9 @@ const terserPlugin = require('rollup-plugin-terser').terser;
 const constants = require('./constants');
 const getVersionsCDNUrl = require('./versioned-cdn-url');
 
+// See https://github.com/GoogleChrome/workbox/issues/1674
+let nameCache = {};
+
 module.exports = {
   // Every use of rollup should have minification and the replace
   // plugin set up and used to ensure as consist set of tests
@@ -46,6 +49,7 @@ module.exports = {
     const minifyBuild = buildType === constants.BUILD_TYPES.prod;
     if (minifyBuild) {
       const terserOptions = {
+        nameCache,
         module: buildFormat === 'esm' ? true : false,
         mangle: {
           properties: {
@@ -54,8 +58,10 @@ module.exports = {
               '_obj',
               // We need this to be exported correctly.
               '_private',
+              // See https://github.com/GoogleChrome/workbox/issues/2686
+              '_handle',
             ],
-            // mangle > properties > regex will allow uglify-es to minify
+            // mangle > properties > regex will allow terser to minify
             // private variable and names that start with a single underscore
             // followed by a letter. This restriction to avoid mangling
             // unintentional fields in our or other libraries code.


### PR DESCRIPTION
R: @philipwalton

Fixes #1674, #2686

This uses the `terser` [`nameCache`](https://github.com/terser/terser#minify-options) option, backed by a module-scoped variable to store the cache in-memory. Because it's not persisted to disk, this will only work as expecting if we build all the packages within the same process, but that's what's we do during our releases, so I think that's fine.

This also exempts `_handle` from the list of properties that are eligible for renaming, since it's part of the public API.

There are no new tests for this change—Phil, if you know of any similar tests that seem suitable for adapting, let me know.