### PR TITLE
Adds gulp build to top-level version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=10.0.0"
   },
   "scripts": {
-    "version": "git add -A packages",
+    "version": "gulp build && git add -A packages",
     "gulp": "gulp"
   },
   "nyc": {


### PR DESCRIPTION
R: @Snugug @philipwalton

Fixes #2610

I *think* this should work, and will result in `gulp build` only being run once (as opposed to being run once per package, like our old release system did, which took forever).

This top-level `version` script is [automatically run](https://github.com/lerna/lerna/tree/main/commands/version#lifecycle-scripts) by `lerna` once, prior to commiting to `git`.