### PR TITLE
Fix skipWaiting not working

### DIFF
--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -75,6 +75,7 @@ class Router {
       const {request} = event;
       const responsePromise = this.handleRequest({request, event});
       if (responsePromise) {
+        event.waitUntil(responsePromise);
         event.respondWith(responsePromise);
       }
     }) as EventListener);

--- a/test/workbox-routing/sw/test-Router.mjs
+++ b/test/workbox-routing/sw/test-Router.mjs
@@ -157,6 +157,7 @@ describe(`Router`, function() {
       expect(router.handleRequest.args[0][0].request).to.equal(request);
       expect(router.handleRequest.args[0][0].event).to.equal(fetchEvent);
       expect(fetchEvent.respondWith.callCount).to.equal(1);
+      expect(fetchEvent.waitUntil.callCount).to.equal(1);
 
       const response = fetchEvent.respondWith.args[0][0];
       expect(await response.text()).to.equal(EXPECTED_RESPONSE_BODY);


### PR DESCRIPTION
R: @jeffposnick @philipwalton

Fixes #2692 

*Description of what's changed/fixed.*

Fixes issue where `skipWaiting` doesn't work as expected when using `registerRoute`.