### PR TITLE
Add setCatchHandler option for routes

### DIFF
--- a/packages/workbox-routing/src/Route.ts
+++ b/packages/workbox-routing/src/Route.ts
@@ -27,6 +27,7 @@ class Route {
   handler: RouteHandlerObject;
   match: RouteMatchCallback;
   method: HTTPMethod;
+  catchHandler?: RouteHandlerObject;
 
   /**
    * Constructor for Route class.
@@ -61,6 +62,15 @@ class Route {
     this.handler = normalizeHandler(handler);
     this.match = match;
     this.method = method;
+  }
+
+  /**
+   * 
+   * @param {module:workbox-routing-handlerCallback} handler A callback
+   * function that returns a Promise resolving to a Response
+   */
+  setCatchHandler(handler: RouteHandler) {
+    this.catchHandler = normalizeHandler(handler)
   }
 }
 

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -282,7 +282,7 @@ class Router {
           return this._catchHandler.handle({url, request, event});
         }
 
-        return Promise.reject(err);
+        throw err;
       });
     }
 

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -244,17 +244,40 @@ class Router {
       responsePromise = Promise.reject(err);
     }
 
-    if (responsePromise instanceof Promise && this._catchHandler) {
-      responsePromise = responsePromise.catch((err) => {
+    // Get route's catch handler, if it exists
+    const catchHandler = route && route.catchHandler;
+
+    if (responsePromise instanceof Promise && (this._catchHandler || catchHandler)) {
+      responsePromise = responsePromise.catch(async (err) => {
+        // If there's a route catch handler, process that first
+        if (catchHandler) {
+          if (process.env.NODE_ENV !== 'production') {
+            // Still include URL here as it will be async from the console group
+            // and may not make sense without the URL
+            logger.groupCollapsed(`Error thrown when responding to: ` +
+              ` ${getFriendlyURL(url)}. Falling back to route's Catch Handler.`);
+            logger.error(`Error thrown by:`, route);
+            logger.error(err);
+            logger.groupEnd();
+          }
+
+          try {
+            return await catchHandler.handle({url, request, event, params});
+          } catch (catchErr) {
+            err = catchErr;
+          }
+        }
+
         if (process.env.NODE_ENV !== 'production') {
           // Still include URL here as it will be async from the console group
           // and may not make sense without the URL
           logger.groupCollapsed(`Error thrown when responding to: ` +
-            ` ${getFriendlyURL(url)}. Falling back to Catch Handler.`);
+            ` ${getFriendlyURL(url)}. Falling back to global Catch Handler.`);
           logger.error(`Error thrown by:`, route);
           logger.error(err);
           logger.groupEnd();
         }
+        
         return this._catchHandler!.handle({url, request, event});
       });
     }

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -268,17 +268,21 @@ class Router {
           }
         }
 
-        if (process.env.NODE_ENV !== 'production') {
-          // Still include URL here as it will be async from the console group
-          // and may not make sense without the URL
-          logger.groupCollapsed(`Error thrown when responding to: ` +
-            ` ${getFriendlyURL(url)}. Falling back to global Catch Handler.`);
-          logger.error(`Error thrown by:`, route);
-          logger.error(err);
-          logger.groupEnd();
+        if (this._catchHandler) {
+          if (process.env.NODE_ENV !== 'production') {
+            // Still include URL here as it will be async from the console group
+            // and may not make sense without the URL
+            logger.groupCollapsed(`Error thrown when responding to: ` +
+              ` ${getFriendlyURL(url)}. Falling back to global Catch Handler.`);
+            logger.error(`Error thrown by:`, route);
+            logger.error(err);
+            logger.groupEnd();
+          }
+          
+          return this._catchHandler.handle({url, request, event});
         }
-        
-        return this._catchHandler!.handle({url, request, event});
+
+        return Promise.reject(err);
       });
     }
 

--- a/test/workbox-routing/sw/test-Router.mjs
+++ b/test/workbox-routing/sw/test-Router.mjs
@@ -471,6 +471,43 @@ describe(`Router`, function() {
       expect(responseBody).to.eql(EXPECTED_RESPONSE_BODY);
     });
 
+    it(`should fall back to the Route's catch handler if there's an error in the Route's handler, if set`, async function() {
+      const router = new Router();
+      const route = new Route(
+          () => true,
+          () => Promise.reject(new Error()),
+      );
+      route.setCatchHandler(() => new Response(EXPECTED_RESPONSE_BODY));
+      router.registerRoute(route);
+
+      // route.match() always returns true, so the Request details don't matter.
+      const request = new Request(location);
+      const event = new FetchEvent('fetch', {request});
+      const response = await router.handleRequest({request, event});
+      const responseBody = await response.text();
+
+      expect(responseBody).to.eql(EXPECTED_RESPONSE_BODY);
+    });
+
+    it(`should fall back to the global catch handler if there's an error in the Route's catch handler`, async function() {
+      const router = new Router();
+      const route = new Route(
+          () => true,
+          () => Promise.reject(new Error()),
+      );
+      route.setCatchHandler(() => Promise.reject(new Error()));
+      router.setCatchHandler(() => new Response(EXPECTED_RESPONSE_BODY));
+      router.registerRoute(route);
+
+      // route.match() always returns true, so the Request details don't matter.
+      const request = new Request(location);
+      const event = new FetchEvent('fetch', {request});
+      const response = await router.handleRequest({request, event});
+      const responseBody = await response.text();
+
+      expect(responseBody).to.eql(EXPECTED_RESPONSE_BODY);
+    });
+
     it(`should return a response from the first matching route when there are multiple potential matches`, async function() {
       const router = new Router();
       const response1 = 'response1';


### PR DESCRIPTION
Fixes #2318

Added `setCatchHandler` to `Route` base class. Will try the route's catch handler first, if it exists, and falls back to default one if it doesn't, or if the route's catch handler has an error.
