### PR TITLE
Fixed typo in GenerateSW JSDocs

### DIFF
--- a/packages/workbox-webpack-plugin/src/generate-sw.js
+++ b/packages/workbox-webpack-plugin/src/generate-sw.js
@@ -129,7 +129,7 @@ class GenerateSW {
    *
    * @param {string} [config.mode] If set to 'production', then an optimized service
    * worker bundle that excludes debugging info will be produced. If not explicitly
-   * configured here, the `mode` value configured in the current `webpack` compiltion
+   * configured here, the `mode` value configured in the current `webpack` compilation
    * will be used.
    *
    * @param {object<string, string>} [config.modifyURLPrefix] A mapping of prefixes


### PR DESCRIPTION
**Prior to filing a PR, please:**
- [open an issue](https://github.com/GoogleChrome/workbox/issues/new) to discuss your proposed change.
- ensure that `gulp build && gulp lint test` passes locally.

R: @jeffposnick @philipwalton

Fixes #*issue number*

*Description of what's changed/fixed.*

Fixed typo I found while going through reference docs for GenerateSW. Since no logic was changed, I don't think an issue needs to exist prior to PR. 🙂
