### PR TITLE
Ensure bad responses aren't cached

### DIFF
--- a/packages/workbox-precaching/src/PrecacheStrategy.ts
+++ b/packages/workbox-precaching/src/PrecacheStrategy.ts
@@ -176,7 +176,7 @@ class PrecacheStrategy extends Strategy {
    * 
    * At the time the strategy is used (i.e. during an `install` event), there
    * needs to be at least one plugin that implements `cacheWillUpdate` in the
-   * array, other the `copyRedirectedCacheableResponsesPlugin`.
+   * array, other than `copyRedirectedCacheableResponsesPlugin`.
    * 
    * - If this method is called and there are no suitable `cacheWillUpdate`
    * plugins, we need to add `defaultPrecacheCacheabilityPlugin`.
@@ -205,7 +205,7 @@ class PrecacheStrategy extends Strategy {
         continue;
       }
 
-      // Save the default plugin's index, in case it needs to be remove.
+      // Save the default plugin's index, in case it needs to be removed.
       if (plugin === PrecacheStrategy.defaultPrecacheCacheabilityPlugin) {
         defaultPluginIndex = index;
       }

--- a/packages/workbox-precaching/src/PrecacheStrategy.ts
+++ b/packages/workbox-precaching/src/PrecacheStrategy.ts
@@ -140,7 +140,7 @@ class PrecacheStrategy extends Strategy {
   }
 
   async _handleInstall(request: Request, handler: StrategyHandler) {
-    const response = await handler.fetchAndCachePut(request);
+    const response = await handler.fetch(request);
 
     // Any time there's no response, consider it a precaching error.
     let responseSafeToPrecache = Boolean(response);
@@ -161,6 +161,10 @@ class PrecacheStrategy extends Strategy {
         status: response.status,
       });
     }
+
+    // Make sure we defer cachePut() until after we know the response
+    // should be cached; see https://github.com/GoogleChrome/workbox/issues/2737
+    await handler.cachePut(request, response.clone());
 
     return response;
   }

--- a/packages/workbox-precaching/src/PrecacheStrategy.ts
+++ b/packages/workbox-precaching/src/PrecacheStrategy.ts
@@ -17,13 +17,6 @@ import {StrategyHandler} from 'workbox-strategies/StrategyHandler.js';
 
 import './_version.js';
 
-
-const copyRedirectedCacheableResponsesPlugin: WorkboxPlugin = {
-  async cacheWillUpdate({response}) {
-    return response.redirected ? await copyResponse(response) : response;
-  }
-}
-
 interface PrecacheStrategyOptions extends StrategyOptions {
   fallbackToNetwork?: boolean;
 }
@@ -42,6 +35,22 @@ interface PrecacheStrategyOptions extends StrategyOptions {
  */
 class PrecacheStrategy extends Strategy {
   private readonly _fallbackToNetwork: boolean;
+
+  static readonly defaultPrecacheCacheabilityPlugin: WorkboxPlugin = {
+    async cacheWillUpdate({response}) {
+      if (!response || response.status >= 400) {
+        return null;
+      }
+  
+      return response;
+    }
+  };
+
+  static readonly copyRedirectedCacheableResponsesPlugin: WorkboxPlugin = {
+    async cacheWillUpdate({response}) {
+      return response.redirected ? await copyResponse(response) : response;
+    }
+  };
 
   /**
    *
@@ -70,7 +79,7 @@ class PrecacheStrategy extends Strategy {
     // any redirected response must be "copied" rather than cloned, so the new
     // response doesn't contain the `redirected` flag. See:
     // https://bugs.chromium.org/p/chromium/issues/detail?id=669363&desc=2#c1
-    this.plugins.push(copyRedirectedCacheableResponsesPlugin);
+    this.plugins.push(PrecacheStrategy.copyRedirectedCacheableResponsesPlugin);
   }
 
   /**
@@ -140,20 +149,14 @@ class PrecacheStrategy extends Strategy {
   }
 
   async _handleInstall(request: Request, handler: StrategyHandler) {
+    this._useDefaultCacheabilityPluginIfNeeded();
+
     const response = await handler.fetch(request);
 
-    // Any time there's no response, consider it a precaching error.
-    let responseSafeToPrecache = Boolean(response);
-
-    // Also consider it an error if the user didn't pass their own
-    // cacheWillUpdate plugin, and the response is a 400+ (note: this means
-    // that by default opaque responses can be precached).
-    if (response && response.status >= 400 &&
-        !this._usesCustomCacheableResponseLogic()) {
-      responseSafeToPrecache = false;
-    }
-
-    if (!responseSafeToPrecache) {
+    // Make sure we defer cachePut() until after we know the response
+    // should be cached; see https://github.com/GoogleChrome/workbox/issues/2737
+    const wasCached = await handler.cachePut(request, response.clone());
+    if (!wasCached) {
       // Throwing here will lead to the `install` handler failing, which
       // we want to do if *any* of the responses aren't safe to cache.
       throw new WorkboxError('bad-precaching-response', {
@@ -162,27 +165,63 @@ class PrecacheStrategy extends Strategy {
       });
     }
 
-    // Make sure we defer cachePut() until after we know the response
-    // should be cached; see https://github.com/GoogleChrome/workbox/issues/2737
-    await handler.cachePut(request, response.clone());
-
     return response;
   }
 
   /**
-   * Returns true if any users plugins were added containing their own
-   * `cacheWillUpdate` callback.
-   *
-   * This method indicates whether the default cacheable response logic (i.e.
-   * <400, including opaque responses) should be used. If a custom plugin
-   * with a `cacheWillUpdate` callback is passed, then the strategy should
-   * defer to that plugin's logic.
+   * This method is complex, as there a number of things to account for:
+   * 
+   * The `plugins` array can be set at construction, and/or it might be added to
+   * to at any time before the strategy is used.
+   * 
+   * At the time the strategy is used (i.e. during an `install` event), there
+   * needs to be at least one plugin that implements `cacheWillUpdate` in the
+   * array, other the `copyRedirectedCacheableResponsesPlugin`.
+   * 
+   * - If this method is called and there are no suitable `cacheWillUpdate`
+   * plugins, we need to add `defaultPrecacheCacheabilityPlugin`.
+   * 
+   * - If this method is called and there is exactly one `cacheWillUpdate`, then
+   * we don't have to do anything (this might be a previously added
+   * `defaultPrecacheCacheabilityPlugin`, or it might be a custom plugin). 
+   * 
+   * - If this method is called and there is more than one `cacheWillUpdate`,
+   * then we need to check if one is `defaultPrecacheCacheabilityPlugin`. If so,
+   * we need to remove it. (This situation is unlikely, but it could happen if
+   * the strategy is used multiple times, the first without a `cacheWillUpdate`,
+   * and then later on after manually adding a custom `cacheWillUpdate`.)
+   * 
+   * See https://github.com/GoogleChrome/workbox/issues/2737 for more context.
    *
    * @private
    */
-  _usesCustomCacheableResponseLogic(): boolean {
-    return this.plugins.some((plugin) => plugin.cacheWillUpdate &&
-        plugin !== copyRedirectedCacheableResponsesPlugin);
+  _useDefaultCacheabilityPluginIfNeeded(): void {
+    let defaultPluginIndex: number | null = null;
+    let cacheWillUpdatePluginCount = 0;
+
+    for (const [index, plugin] of this.plugins.entries()) {
+      // Ignore the copy redirected plugin when determining what to do.
+      if (plugin === PrecacheStrategy.copyRedirectedCacheableResponsesPlugin) {
+        continue;
+      }
+
+      // Save the default plugin's index, in case it needs to be remove.
+      if (plugin === PrecacheStrategy.defaultPrecacheCacheabilityPlugin) {
+        defaultPluginIndex = index;
+      }
+
+      if (plugin.cacheWillUpdate) {
+        cacheWillUpdatePluginCount++;
+      }
+    }
+
+    if (cacheWillUpdatePluginCount === 0) {
+      this.plugins.push(PrecacheStrategy.defaultPrecacheCacheabilityPlugin);
+    } else if (cacheWillUpdatePluginCount > 1 && defaultPluginIndex !== null) {
+      // Only remove the default plugin; multiple custom plugins are allowed.
+      this.plugins.splice(defaultPluginIndex, 1);
+    }
+    // Nothing needs to be done if cacheWillUpdatePluginCount is 1
   }
 }
 

--- a/packages/workbox-strategies/src/StrategyHandler.ts
+++ b/packages/workbox-strategies/src/StrategyHandler.ts
@@ -302,9 +302,11 @@ class StrategyHandler {
    * - cacheDidUpdate()
    *
    * @param {Request|string} key The request or URL to use as the cache key.
-   * @param {Promise<void>} response The response to cache.
+   * @param {Response} response The response to cache.
+   * @return {Promise<boolean>} `false` if a cacheWillUpdate caused the response
+   * not be cached, and `true` otherwise.
    */
-  async cachePut(key: RequestInfo, response: Response): Promise<void> {
+  async cachePut(key: RequestInfo, response: Response): Promise<boolean> {
     const request: Request = toRequest(key);
 
     // Run in the next task to avoid blocking other cache reads.
@@ -340,7 +342,7 @@ class StrategyHandler {
         logger.debug(`Response '${getFriendlyURL(effectiveRequest.url)}' ` +
         `will not be cached.`, responseToCache);
       }
-      return;
+      return false;
     }
 
     const {cacheName, matchOptions} = this._strategy;
@@ -379,6 +381,8 @@ class StrategyHandler {
         event: this.event,
       });
     }
+
+    return true;
   }
 
   /**

--- a/test/workbox-precaching/sw/test-PrecacheStrategy.mjs
+++ b/test/workbox-precaching/sw/test-PrecacheStrategy.mjs
@@ -34,7 +34,7 @@ describe(`PrecacheStrategy()`, function() {
     sandbox.restore();
   });
 
-  describe(`.handle`, function() {
+  describe(`handle()`, function() {
     it(`falls back to network by default on fetch`, async function() {
       sandbox.stub(self, 'fetch').callsFake((request) => {
         const response = new Response('Fetched Response');
@@ -102,7 +102,7 @@ describe(`PrecacheStrategy()`, function() {
       expect(await cachedResponse.text()).to.equal('Redirected Response');
     });
 
-    it(`errors on 400+ responses during install if no custom cacheWillUpdate plugin callback is used`, async function() {
+    it(`errors during install if the default plugin returns null`, async function() {
       // Also ensure that we don't cache the bad response;
       // see https://github.com/GoogleChrome/workbox/issues/2737
       const putStub = sandbox.stub().resolves();
@@ -111,6 +111,9 @@ describe(`PrecacheStrategy()`, function() {
       sandbox.stub(self, 'fetch').resolves(new Response('Server Error', {
         status: 400,
       }));
+
+      const defaultPluginSpy = sandbox.spy(
+        PrecacheStrategy.defaultPrecacheCacheabilityPlugin, 'cacheWillUpdate');
 
       const request = new Request('/index.html');
       const event = new ExtendableEvent('install');
@@ -122,12 +125,24 @@ describe(`PrecacheStrategy()`, function() {
 
       await eventDoneWaiting(event);
       expect(putStub.callCount).to.eql(0);
+      // Confirm that the default plugin was called.
+      expect(defaultPluginSpy.callCount).to.eql(1);
     });
 
-    it(`doesn't error on 400+ when a custom cacheWillUpdate plugin callback is used`, async function() {
-      sandbox.stub(self, 'fetch').callsFake((request) => {
-        return new Response('Server Error', {status: 400});
+    it(`doesn't error during install if the cacheWillUpdate plugin allows it`, async function() {
+      const errorResponse = new Response('Server Error', {
+        status: 400,
       });
+
+      const putStub = sandbox.stub().resolves();
+      sandbox.stub(self.caches, 'open').resolves({put: putStub});
+
+      sandbox.stub(self, 'fetch').resolves(errorResponse);
+
+      // Returning any valid Response will allow caching to proceed.
+      const cacheWillUpdateStub = sandbox.stub().resolves(errorResponse);
+      const defaultPluginSpy = sandbox.spy(
+        PrecacheStrategy.defaultPrecacheCacheabilityPlugin, 'cacheWillUpdate');
 
       const request = new Request('/index.html');
       const event = new ExtendableEvent('install');
@@ -135,12 +150,231 @@ describe(`PrecacheStrategy()`, function() {
 
       const ps = new PrecacheStrategy({
         plugins: [{
-          cacheWillUpdate: sandbox.spy(),
+          cacheWillUpdate: cacheWillUpdateStub,
         }],
       });
 
       const response = await ps.handle({event, request});
-      expect(response).to.be.instanceOf(Response);
+      // The return value should be whatever fetch() returned.
+      expect(response).to.eql(errorResponse);
+
+      await eventDoneWaiting(event);
+
+      expect(putStub.args).to.eql([[request, errorResponse]]);
+      expect(cacheWillUpdateStub.callCount).to.eql(1);
+      // The default plugin shouldn't be called if there's custom plugin(s).
+      expect(defaultPluginSpy.callCount).to.eql(0);
+    });
+
+    it(`errors during install if any of the cacheWillUpdate plugins return null`, async function() {
+      const errorResponse = new Response('Server Error', {
+        status: 400,
+      });
+
+      const putStub = sandbox.stub().resolves();
+      sandbox.stub(self.caches, 'open').resolves({put: putStub});
+
+      sandbox.stub(self, 'fetch').resolves(errorResponse);
+
+      const cacheWillUpdateAllowStub = sandbox.stub().resolves(errorResponse);
+      const cacheWillUpdateDenyStub = sandbox.stub().resolves(null);
+
+      const defaultPluginSpy = sandbox.spy(
+        PrecacheStrategy.defaultPrecacheCacheabilityPlugin, 'cacheWillUpdate');
+
+      const request = new Request('/index.html');
+      const event = new ExtendableEvent('install');
+      spyOnEvent(event);
+
+      const ps = new PrecacheStrategy({
+        plugins: [{
+          cacheWillUpdate: cacheWillUpdateAllowStub,
+        }, {
+          cacheWillUpdate: cacheWillUpdateDenyStub,
+        }],
+      });
+
+      await expectError(
+        () => ps.handle({event, request}), 'bad-precaching-response');
+
+      await eventDoneWaiting(event);
+
+      expect(putStub.callCount).to.eql(0);
+      expect(cacheWillUpdateAllowStub.callCount).to.eql(1);
+      expect(cacheWillUpdateDenyStub.callCount).to.eql(1);
+      expect(defaultPluginSpy.callCount).to.eql(0);
+    });
+  });
+
+  describe('_useDefaultCacheabilityPluginIfNeeded()', function() {
+    it(`should include the expected plugins by default`, async function() {
+      const ps = new PrecacheStrategy();
+
+      ps._useDefaultCacheabilityPluginIfNeeded();
+
+      expect(ps.plugins).to.eql([
+        PrecacheStrategy.copyRedirectedCacheableResponsesPlugin,
+        PrecacheStrategy.defaultPrecacheCacheabilityPlugin,
+      ]);
+
+      // Confirm that calling it multiple times doesn't change anything.
+
+      ps._useDefaultCacheabilityPluginIfNeeded();
+
+      expect(ps.plugins).to.eql([
+        PrecacheStrategy.copyRedirectedCacheableResponsesPlugin,
+        PrecacheStrategy.defaultPrecacheCacheabilityPlugin,
+      ]);
+    });
+
+    it(`should include the default plugin when the strategy has only non-cacheWillUpdate plugins`, async function() {
+      const cacheKeyWillBeUsedPlugin = {
+        cacheKeyWillBeUsed: sandbox.stub(),
+      };
+      const ps = new PrecacheStrategy({
+        plugins: [cacheKeyWillBeUsedPlugin],
+      });
+
+      ps._useDefaultCacheabilityPluginIfNeeded();
+
+      expect(ps.plugins).to.eql([
+        cacheKeyWillBeUsedPlugin,
+        PrecacheStrategy.copyRedirectedCacheableResponsesPlugin,
+        PrecacheStrategy.defaultPrecacheCacheabilityPlugin,
+      ]);
+
+      // Confirm that calling it multiple times doesn't change anything.
+
+      ps._useDefaultCacheabilityPluginIfNeeded();
+
+      expect(ps.plugins).to.eql([
+        cacheKeyWillBeUsedPlugin,
+        PrecacheStrategy.copyRedirectedCacheableResponsesPlugin,
+        PrecacheStrategy.defaultPrecacheCacheabilityPlugin,
+      ]);
+    });
+
+    it(`should not include the default plugin when the strategy has one cacheWillUpdate plugin`, async function() {
+      const cacheWillUpdatePlugin = {
+        cacheWillUpdate: sandbox.stub(),
+      };
+      const ps = new PrecacheStrategy({
+        plugins: [cacheWillUpdatePlugin],
+      });
+
+      ps._useDefaultCacheabilityPluginIfNeeded();
+
+      expect(ps.plugins).to.eql([
+        cacheWillUpdatePlugin,
+        PrecacheStrategy.copyRedirectedCacheableResponsesPlugin,
+      ]);
+
+      // Confirm that calling it multiple times doesn't change anything.
+
+      ps._useDefaultCacheabilityPluginIfNeeded();
+
+      expect(ps.plugins).to.eql([
+        cacheWillUpdatePlugin,
+        PrecacheStrategy.copyRedirectedCacheableResponsesPlugin,
+      ]);
+    });
+
+    it(`should not include the default plugin when the strategy has multiple cacheWillUpdate plugins`, async function() {
+      const cacheWillUpdatePlugin1 = {
+        cacheWillUpdate: sandbox.stub(),
+      };
+      const cacheWillUpdatePlugin2 = {
+        cacheWillUpdate: sandbox.stub(),
+      };
+      const cacheKeyWillBeUsedPlugin = {
+        cacheKeyWillBeUsed: sandbox.stub(),
+      };
+      const ps = new PrecacheStrategy({
+        plugins: [
+          cacheWillUpdatePlugin1,
+          cacheKeyWillBeUsedPlugin,
+          cacheWillUpdatePlugin2,
+        ],
+      });
+
+      ps._useDefaultCacheabilityPluginIfNeeded();
+
+      expect(ps.plugins).to.eql([
+        cacheWillUpdatePlugin1,
+        cacheKeyWillBeUsedPlugin,
+        cacheWillUpdatePlugin2,
+        PrecacheStrategy.copyRedirectedCacheableResponsesPlugin,
+      ]);
+
+      // Confirm that calling it multiple times doesn't change anything.
+
+      ps._useDefaultCacheabilityPluginIfNeeded();
+
+      expect(ps.plugins).to.eql([
+        cacheWillUpdatePlugin1,
+        cacheKeyWillBeUsedPlugin,
+        cacheWillUpdatePlugin2,
+        PrecacheStrategy.copyRedirectedCacheableResponsesPlugin,
+      ]);
+    });
+
+    it(`should remove the default plugin if a cacheWillUpdate plugin has been added after the initial call`, async function() {
+      const cacheWillUpdatePlugin = {
+        cacheWillUpdate: sandbox.stub(),
+      };
+      const ps = new PrecacheStrategy();
+
+      ps._useDefaultCacheabilityPluginIfNeeded();
+
+      expect(ps.plugins).to.eql([
+        PrecacheStrategy.copyRedirectedCacheableResponsesPlugin,
+        PrecacheStrategy.defaultPrecacheCacheabilityPlugin,
+      ]);
+
+      // Explicitly add a cacheWillUpdate plugin. Real users will likely do this
+      // via the addPlugins() method.
+      ps.plugins.push(cacheWillUpdatePlugin);
+
+      ps._useDefaultCacheabilityPluginIfNeeded();
+
+      expect(ps.plugins).to.eql([
+        PrecacheStrategy.copyRedirectedCacheableResponsesPlugin,
+        cacheWillUpdatePlugin,
+      ]);
+    });
+  });
+
+  describe('defaultPrecacheCacheabilityPlugin', function() {
+    it(`should return the same response when the status is 200`, async function() {
+      const response = new Response('', {status: 200});
+
+      const returnedResponse = await PrecacheStrategy.defaultPrecacheCacheabilityPlugin.cacheWillUpdate({
+        response,
+      });
+
+      expect(returnedResponse).to.eql(response);
+    });
+
+    it(`should return the same response when the status is 0`, async function() {
+      // You can't construct opaque responses, so stub out the getter.
+      const response = new Response('', {status: 599});
+      sandbox.stub(response, 'status').get(() => 0);
+
+      const returnedResponse = await PrecacheStrategy.defaultPrecacheCacheabilityPlugin.cacheWillUpdate({
+        response,
+      });
+
+      expect(returnedResponse).to.eql(response);
+    });
+
+    it(`should return null when the status is 404`, async function() {
+      const response = new Response('', {status: 404});
+
+      const returnedResponse = await PrecacheStrategy.defaultPrecacheCacheabilityPlugin.cacheWillUpdate({
+        response,
+      });
+
+      expect(returnedResponse).to.be.null;
     });
   });
 });

--- a/test/workbox-precaching/sw/test-PrecacheStrategy.mjs
+++ b/test/workbox-precaching/sw/test-PrecacheStrategy.mjs
@@ -113,7 +113,7 @@ describe(`PrecacheStrategy()`, function() {
       }));
 
       const defaultPluginSpy = sandbox.spy(
-        PrecacheStrategy.defaultPrecacheCacheabilityPlugin, 'cacheWillUpdate');
+          PrecacheStrategy.defaultPrecacheCacheabilityPlugin, 'cacheWillUpdate');
 
       const request = new Request('/index.html');
       const event = new ExtendableEvent('install');
@@ -142,7 +142,7 @@ describe(`PrecacheStrategy()`, function() {
       // Returning any valid Response will allow caching to proceed.
       const cacheWillUpdateStub = sandbox.stub().resolves(errorResponse);
       const defaultPluginSpy = sandbox.spy(
-        PrecacheStrategy.defaultPrecacheCacheabilityPlugin, 'cacheWillUpdate');
+          PrecacheStrategy.defaultPrecacheCacheabilityPlugin, 'cacheWillUpdate');
 
       const request = new Request('/index.html');
       const event = new ExtendableEvent('install');
@@ -180,7 +180,7 @@ describe(`PrecacheStrategy()`, function() {
       const cacheWillUpdateDenyStub = sandbox.stub().resolves(null);
 
       const defaultPluginSpy = sandbox.spy(
-        PrecacheStrategy.defaultPrecacheCacheabilityPlugin, 'cacheWillUpdate');
+          PrecacheStrategy.defaultPrecacheCacheabilityPlugin, 'cacheWillUpdate');
 
       const request = new Request('/index.html');
       const event = new ExtendableEvent('install');
@@ -195,7 +195,7 @@ describe(`PrecacheStrategy()`, function() {
       });
 
       await expectError(
-        () => ps.handle({event, request}), 'bad-precaching-response');
+          () => ps.handle({event, request}), 'bad-precaching-response');
 
       await eventDoneWaiting(event);
 


### PR DESCRIPTION
R: @philipwalton

Fixes #2737

This was a regression introduced in Workbox v6's modified precaching logic. This PR ensures that a bad response isn't saved to the cache before installation is halted.