### PR TITLE
Fix NetworkFirst waitUntil

### DIFF
--- a/packages/workbox-strategies/src/NetworkFirst.ts
+++ b/packages/workbox-strategies/src/NetworkFirst.ts
@@ -112,12 +112,11 @@ class NetworkFirst extends Strategy {
         this._getNetworkPromise({timeoutId, request, logs, handler});
 
     promises.push(networkPromise);
-    for (const promise of promises) {
-      handler.waitUntil(promise);
-    }
 
     // Promise.race() will resolve as soon as the first promise resolves.
-    let response = await Promise.race(promises);
+    const combinedPromise = Promise.race(promises);
+    handler.waitUntil(combinedPromise);
+    let response = await combinedPromise;
     // If Promise.race() resolved with null, it might be due to a network
     // timeout + a cache miss. If that were to happen, we'd rather wait until
     // the networkPromise resolves instead of returning null.

--- a/packages/workbox-strategies/src/NetworkFirst.ts
+++ b/packages/workbox-strategies/src/NetworkFirst.ts
@@ -113,16 +113,16 @@ class NetworkFirst extends Strategy {
 
     promises.push(networkPromise);
 
-    const response = await handler.waitUntil((async () =>
+    const response = await handler.waitUntil((async () => {
       // Promise.race() will resolve as soon as the first promise resolves.
-      await handler.waitUntil(Promise.race(promises))
-      // If Promise.race() resolved with null, it might be due to a network
-      // timeout + a cache miss. If that were to happen, we'd rather wait until
-      // the networkPromise resolves instead of returning null.
-      // Note that it's fine to await an already-resolved promise, so we don't
-      // have to check to see if it's still "in flight".
-      || await networkPromise
-    )());
+      return await handler.waitUntil(Promise.race(promises)) ||
+          // If Promise.race() resolved with null, it might be due to a network
+          // timeout + a cache miss. If that were to happen, we'd rather wait until
+          // the networkPromise resolves instead of returning null.
+          // Note that it's fine to await an already-resolved promise, so we don't
+          // have to check to see if it's still "in flight".
+          await networkPromise;
+    })());
 
     if (process.env.NODE_ENV !== 'production') {
       logger.groupCollapsed(

--- a/packages/workbox-strategies/src/StrategyHandler.ts
+++ b/packages/workbox-strategies/src/StrategyHandler.ts
@@ -497,7 +497,7 @@ class StrategyHandler {
    * @param {Promise} promise A promise to add to the extend lifetime promises
    *     of the event that triggered the request.
    */
-  waitUntil(promise: Promise<any>): Promise<any> {
+  waitUntil<T>(promise: Promise<T>): Promise<T> {
     this._extendLifetimePromises.push(promise);
     return promise;
   }

--- a/test/workbox-strategies/sw/test-NetworkFirst.mjs
+++ b/test/workbox-strategies/sw/test-NetworkFirst.mjs
@@ -146,7 +146,6 @@ describe(`NetworkFirst`, function() {
         event,
       });
 
-      await eventDoneWaiting(event);
       await donePromise;
 
       const populatedCacheResponse = await handlePromise;
@@ -171,7 +170,6 @@ describe(`NetworkFirst`, function() {
       });
 
       const startTime = performance.now();
-      await eventDoneWaiting(event);
       await donePromise;
       expect(performance.now() - startTime).to.be.below(1000);
 

--- a/test/workbox-strategies/sw/test-NetworkFirst.mjs
+++ b/test/workbox-strategies/sw/test-NetworkFirst.mjs
@@ -158,7 +158,7 @@ describe(`NetworkFirst`, function() {
       const event = new FetchEvent('fetch', {request});
       spyOnEvent(event);
 
-      const networkTimeoutSeconds = 1000;
+      const networkTimeoutSeconds = 10;
 
       const injectedResponse = new Response('response body');
       sandbox.stub(self, 'fetch').resolves(injectedResponse);
@@ -170,8 +170,10 @@ describe(`NetworkFirst`, function() {
         event,
       });
 
+      const startTime = performance.now();
       await eventDoneWaiting(event);
       await donePromise;
+      expect(performance.now() - startTime).to.be.below(1000);
 
       const populatedCacheResponse = await handlePromise;
       await compareResponses(populatedCacheResponse, injectedResponse, true);

--- a/test/workbox-strategies/sw/test-NetworkFirst.mjs
+++ b/test/workbox-strategies/sw/test-NetworkFirst.mjs
@@ -141,12 +141,13 @@ describe(`NetworkFirst`, function() {
       const cache = await caches.open(cacheNames.getRuntimeName());
       await cache.put(request, injectedResponse.clone());
 
-      const handlePromise = networkFirst.handle({
+      const [handlePromise, donePromise] = networkFirst.handleAll({
         request,
         event,
       });
 
       await eventDoneWaiting(event);
+      await donePromise;
 
       const populatedCacheResponse = await handlePromise;
       await compareResponses(populatedCacheResponse, injectedResponse, true);


### PR DESCRIPTION
NetworkFirst uses two promises (one for the network request, and one for the timeout). If the network request succeeds, then the timeout promise's timer is canceled. However, it attempted to wait until both promises resolved before the handler resolved as done; this meant that, if the network request succeeded, then it never resolved its handlerDone / awaitComplete promise.

*Note*: There are two potential issues with this PR:

* I wasn't sure what to do about the "If Promise.race() resolved with null" case, when the NetworkFirst strategy falls back to waiting on the network request. Should the code ensure that `handler.waitUntil(networkRequest)` is called in the case of a network timeout + cache miss?
* I updated a test to try and cover this case, but I couldn't figure out how to run the test suite to confirm my changes. (I found the `test_server` gulp task and navigated to `http://localhost:3004/test/workbox-strategies/sw`, but I get console errors, so I must be doing something wrong.)

R: @jeffposnick @philipwalton

Fixes #2721