### PR TITLE
Ensure test URLs end in /

### DIFF
--- a/infra/testing/server/routes/test-sw.js
+++ b/infra/testing/server/routes/test-sw.js
@@ -14,6 +14,11 @@ const templateData = require('../template-data');
 const match = '/test/:packageName/sw/';
 
 async function handler(req, res) {
+  // See https://github.com/GoogleChrome/workbox/pull/2744#issuecomment-774138051
+  if (!req.path.endsWith('/')) {
+    return res.redirect(req.path + '/');
+  }
+
   const {packageName} = req.params;
   const testFilter = req.query.filter || '**/test-*.mjs';
 


### PR DESCRIPTION
R: @philipwalton
CC: @joshkel

This addresses the issue described in https://github.com/GoogleChrome/workbox/pull/2744#issuecomment-774138051, and ensures that if you manually navigate to a test page URL, it will end in `/`, ensuring that the service worker can register using the correct base URL.