### PR TITLE
Fix a TS import path in warmStrategyCache

### DIFF
--- a/packages/workbox-recipes/src/warmStrategyCache.ts
+++ b/packages/workbox-recipes/src/warmStrategyCache.ts
@@ -1,4 +1,4 @@
-import { Strategy } from 'workbox-strategies/src/Strategy';
+import { Strategy } from 'workbox-strategies/Strategy.js';
 
 import './_version.js';
 


### PR DESCRIPTION
R: @Snugug @philipwalton 

Without this fix, passing a legit `Strategy` subclass to `warmStrategyCache()` makes TypeScript unhappy.

<img width="815" alt="Screen Shot 2021-02-11 at 4 01 22 PM" src="https://user-images.githubusercontent.com/1749548/107698468-9538ad80-6c82-11eb-89ba-242bdfa3efbf.png">

I confirmed with a local build of the libraries that this change makes TypeScript happy again, and it matches how we handle our imports elsewhere.