### PR TITLE
Fix a flakey test, and remove retries

### DIFF
--- a/gulp-tasks/test-integration.js
+++ b/gulp-tasks/test-integration.js
@@ -25,7 +25,7 @@ function runFiles(filePaths) {
 
   return new Promise((resolve, reject) => {
     const mocha = new Mocha({
-      retries: (process.env.TRAVIS || process.env.GITHUB_ACTIONS) ? 4 : 1,
+      retries: 0,
       timeout: 3 * 60 * 1000,
     });
 

--- a/test/workbox-cacheable-response/integration/test-all.js
+++ b/test/workbox-cacheable-response/integration/test-all.js
@@ -52,11 +52,9 @@ describe(`[workbox-cacheable-response] Plugin`, function() {
     });
 
     const keys = await runInSW('cachesKeys');
-    expect(keys).to.deep.equal([
-      'cacheable-response-cache',
-    ]);
+    expect(keys).to.contain('cacheable-response-cache');
 
-    const cachedRequests = await runInSW('cacheURLs', keys[0]);
+    const cachedRequests = await runInSW('cacheURLs', 'cacheable-response-cache');
     expect(cachedRequests).to.eql([
       `${baseURL}example-1.txt`,
     ]);

--- a/test/workbox-cacheable-response/integration/test-all.js
+++ b/test/workbox-cacheable-response/integration/test-all.js
@@ -19,7 +19,7 @@ const {webdriver, server} = global.__workbox;
 
 describe(`[workbox-cacheable-response]`, function() {
   it(`passes all SW unit tests`, async function() {
-    await runUnitTests('/test/workbox-broadcast-update/sw/');
+    await runUnitTests('/test/workbox-cacheable-response/sw/');
   });
 });
 
@@ -52,9 +52,11 @@ describe(`[workbox-cacheable-response] Plugin`, function() {
     });
 
     const keys = await runInSW('cachesKeys');
-    expect(keys).to.contain('cacheable-response-cache');
+    expect(keys).to.deep.equal([
+      'cacheable-response-cache',
+    ]);
 
-    const cachedRequests = await runInSW('cacheURLs', 'cacheable-response-cache');
+    const cachedRequests = await runInSW('cacheURLs', keys[0]);
     expect(cachedRequests).to.eql([
       `${baseURL}example-1.txt`,
     ]);

--- a/test/workbox-window/integration/test-all.js
+++ b/test/workbox-window/integration/test-all.js
@@ -151,12 +151,6 @@ describe(`[workbox-window] Workbox`, function() {
     });
 
     it(`reports all events for an external SW registration`, async function() {
-      // Skip this test in Safari due to this flakiness issue:
-      // https://github.com/GoogleChrome/workbox/issues/2150
-      if (seleniumBrowser.getId() === 'safari') {
-        this.skip();
-      }
-
       const firstTab = await getLastWindowHandle();
       await webdriver.switchTo().window(firstTab);
 
@@ -206,9 +200,7 @@ describe(`[workbox-window] Workbox`, function() {
         }
       });
 
-      // Close the second tab and switch back to the first tab before
-      // executing the following block.
-      await webdriver.close();
+      // Switch back to the first tab before executing the following block.
       await webdriver.switchTo().window(firstTab);
 
       const result = await executeAsyncAndCatch(async (cb) => {

--- a/test/workbox-window/integration/test-all.js
+++ b/test/workbox-window/integration/test-all.js
@@ -16,7 +16,7 @@ const {unregisterAllSWs} = require('../../../infra/testing/webdriver/unregisterA
 const {windowLoaded} = require('../../../infra/testing/webdriver/windowLoaded');
 
 // Store local references of these globals.
-const {webdriver, server, seleniumBrowser} = global.__workbox;
+const {webdriver, server} = global.__workbox;
 
 const testServerOrigin = server.getAddress();
 const testPath = `${testServerOrigin}/test/workbox-window/static/`;


### PR DESCRIPTION
R: @philipwalton

I got to the bottom of #2321 and #2150, by removing the call to close a tab prior to switching to tabs, and that seems to make Safari happy in my local testing.

I also removed all retries from our tests, as I don't think anything should currently be flakey, and honestly, if it is, I'd rather know and fix it.