### PR TITLE
[Fix] (Workbox wizard) Manually enter the path of the web app root and unselectable separator

### DIFF
--- a/packages/workbox-cli/src/lib/questions/ask-root-of-web-app.ts
+++ b/packages/workbox-cli/src/lib/questions/ask-root-of-web-app.ts
@@ -17,8 +17,9 @@ import {constants} from '../constants';
 
 const ROOT_PROMPT = 'Please enter the path to the root of your web app:';
 
-// The key used for the question/answer.
-const name = 'globDirectory';
+// The keys used for the questions/answers.
+const question_rootDirectory = 'globDirectory';
+const question_manualInput = 'manualDirectoryInput';
 
 /**
  * @return {Promise<Array<string>>} The subdirectories of the current
@@ -41,44 +42,44 @@ async function getSubdirectories(): Promise<Array<string>> {
 /**
  * @return {Promise<Object>} The answers from inquirer.
  */
-async function askQuestion() {
-  const subdirectories = await getSubdirectories();
+async function askQuestion(): Promise<{ globDirectory: string; manualDirectoryInput?: string }> {
+  const subdirectories: (string | InstanceType<typeof Separator>)[] = await getSubdirectories();
 
   if (subdirectories.length > 0) {
     const manualEntryChoice = 'Manually enter path';
     return prompt([{
-      name,
+      name: question_rootDirectory,
       type: 'list',
       message: ol`What is the root of your web app (i.e. which directory do
         you deploy)?`,
       choices: subdirectories.concat([
-        new Separator().toString(),
+        new Separator(),
         manualEntryChoice,
       ]),
     }, {
-      name,
-      when: (answers: { [x: string]: string }) => answers[name] === manualEntryChoice,
+      name: question_manualInput,
+      when: (answers: { globDirectory: string }) => answers.globDirectory === manualEntryChoice,
       message: ROOT_PROMPT,
-    }]);
-  } else {
-    return prompt([{
-      name,
-      message: ROOT_PROMPT,
-      default: '.',
-    }]);
+    }
+    ]);
   }
+
+  return prompt([{
+    name: question_rootDirectory,
+    message: ROOT_PROMPT,
+    default: '.',
+  }]);
 }
 
 export async function askRootOfWebApp() {
-  const answers = await askQuestion();
-  const globDirectory = answers[name];
+  const { manualDirectoryInput, globDirectory } = await askQuestion();
 
   try {
-    const stat = await fse.stat(globDirectory);
+    const stat = await fse.stat(manualDirectoryInput || globDirectory);
     assert(stat.isDirectory());
   } catch (error) {
     throw new Error(errors['glob-directory-invalid']);
   }
 
-  return globDirectory;
+  return manualDirectoryInput || globDirectory;
 }

--- a/packages/workbox-cli/src/lib/questions/ask-root-of-web-app.ts
+++ b/packages/workbox-cli/src/lib/questions/ask-root-of-web-app.ts
@@ -18,8 +18,8 @@ import {constants} from '../constants';
 const ROOT_PROMPT = 'Please enter the path to the root of your web app:';
 
 // The keys used for the questions/answers.
-const question_rootDirectory = 'globDirectory';
-const question_manualInput = 'manualDirectoryInput';
+const questionRootDirectory = 'globDirectory';
+const questionManualInput = 'manualDirectoryInput';
 
 /**
  * @return {Promise<Array<string>>} The subdirectories of the current
@@ -48,7 +48,7 @@ async function askQuestion(): Promise<{ globDirectory: string; manualDirectoryIn
   if (subdirectories.length > 0) {
     const manualEntryChoice = 'Manually enter path';
     return prompt([{
-      name: question_rootDirectory,
+      name: questionRootDirectory,
       type: 'list',
       message: ol`What is the root of your web app (i.e. which directory do
         you deploy)?`,
@@ -57,7 +57,7 @@ async function askQuestion(): Promise<{ globDirectory: string; manualDirectoryIn
         manualEntryChoice,
       ]),
     }, {
-      name: question_manualInput,
+      name: questionManualInput,
       when: (answers: { globDirectory: string }) => answers.globDirectory === manualEntryChoice,
       message: ROOT_PROMPT,
     }
@@ -65,7 +65,7 @@ async function askQuestion(): Promise<{ globDirectory: string; manualDirectoryIn
   }
 
   return prompt([{
-    name: question_rootDirectory,
+    name: questionRootDirectory,
     message: ROOT_PROMPT,
     default: '.',
   }]);

--- a/test/workbox-cli/node/lib/questions/ask-root-of-web-app.js
+++ b/test/workbox-cli/node/lib/questions/ask-root-of-web-app.js
@@ -14,8 +14,12 @@ const {errors} = require('../../../../../packages/workbox-cli/build/lib/errors')
 const MODULE_PATH = '../../../../../packages/workbox-cli/build/lib/questions/ask-root-of-web-app';
 // This is the hardcoded name of the question that's passed to inquirer.
 // It's used as the key to read the response from the answer.
-const QUESTION_NAME = 'globDirectory';
+const question_rootDirectory = 'globDirectory';
+const question_manualInput = 'manualDirectoryInput';
 const DIRECTORY = '/path/to/directory';
+const CHILD_DIRECTORY = '/path/to/directory/child';
+const CHILD_DIRECTORY_WHITE_SPACE = '/path/to/directory/   child';
+const CHILD_DIRECTORY_BLANK = '  ';
 
 describe(`[workbox-cli] lib/questions/ask-root-of-web-app.js`, function() {
   it(`should reject with a 'glob-directory-invalid' error when the answer isn't a valid directory`, async function() {
@@ -24,7 +28,7 @@ describe(`[workbox-cli] lib/questions/ask-root-of-web-app.js`, function() {
         callback(null, []);
       },
       'inquirer': {
-        prompt: () => Promise.resolve({[QUESTION_NAME]: DIRECTORY}),
+        prompt: () => Promise.resolve({[question_rootDirectory]: DIRECTORY}),
       },
       'fs-extra': {
         stat: (path) => {
@@ -47,13 +51,43 @@ describe(`[workbox-cli] lib/questions/ask-root-of-web-app.js`, function() {
     }
   });
 
-  it(`should resolve with a valid answer to the question`, async function() {
+  it(`should reject with a 'glob-directory-invalid' error when the manual input is provided (directory does not exist)`, async function() {
     const {askRootOfWebApp} = proxyquire(MODULE_PATH, {
       'glob': (pattern, config, callback) => {
         callback(null, []);
       },
       'inquirer': {
-        prompt: () => Promise.resolve({[QUESTION_NAME]: DIRECTORY}),
+        prompt: () => Promise.resolve({
+          [question_rootDirectory]: DIRECTORY,
+          [question_manualInput]: CHILD_DIRECTORY,
+        }),
+      },
+      'fs-extra': {
+        stat: (path) => {
+          return {
+            isDirectory: () => {
+              return path !== CHILD_DIRECTORY;
+            },
+          };
+        },
+      },
+    });
+
+    try {
+      await askRootOfWebApp();
+      throw new Error('Unexpected success.');
+    } catch (error) {
+      expect(error.message).to.eql(errors['glob-directory-invalid']);
+    }
+  });
+
+  it(`should resolve with a valid answer to the question when no child directories are present (default: use current directory)`, async function() {
+    const {askRootOfWebApp} = proxyquire(MODULE_PATH, {
+      'glob': (pattern, config, callback) => {
+        callback(null, []);
+      },
+      'inquirer': {
+        prompt: () => Promise.resolve({[question_rootDirectory]: DIRECTORY}),
       },
       'fs-extra': {
         stat: (path) => {
@@ -70,6 +104,84 @@ describe(`[workbox-cli] lib/questions/ask-root-of-web-app.js`, function() {
 
     const answer = await askRootOfWebApp();
     expect(answer).to.eql(DIRECTORY);
+  });
+
+  it(`should resolve with a valid answer to the question when manual input is provided (directory exists)`, async function() {
+    const {askRootOfWebApp} = proxyquire(MODULE_PATH, {
+      'glob': (pattern, config, callback) => {
+        callback(null, []);
+      },
+      'inquirer': {
+        prompt: () => Promise.resolve({
+          [question_rootDirectory]: DIRECTORY,
+          [question_manualInput]: CHILD_DIRECTORY,
+        }),
+      },
+      'fs-extra': {
+        stat: (path) => {
+          return {
+            isDirectory: () => {
+              return path === CHILD_DIRECTORY;
+            },
+          };
+        },
+      },
+    });
+
+    const answer = await askRootOfWebApp();
+    expect(answer).to.eql(CHILD_DIRECTORY);
+  });
+
+  it(`should resolve with a valid answer to the question when manual input is provided (directory exists and name contains white space)`, async function() {
+    const {askRootOfWebApp} = proxyquire(MODULE_PATH, {
+      'glob': (pattern, config, callback) => {
+        callback(null, []);
+      },
+      'inquirer': {
+        prompt: () => Promise.resolve({
+          [question_rootDirectory]: DIRECTORY,
+          [question_manualInput]: CHILD_DIRECTORY_WHITE_SPACE,
+        }),
+      },
+      'fs-extra': {
+        stat: (path) => {
+          return {
+            isDirectory: () => {
+              return path === CHILD_DIRECTORY_WHITE_SPACE;
+            },
+          };
+        },
+      },
+    });
+
+    const answer = await askRootOfWebApp();
+    expect(answer).to.eql(CHILD_DIRECTORY_WHITE_SPACE);
+  });
+
+  it(`should resolve with a valid answer to the question when manual input is provided (directory exists and name is composed of only white space)`, async function() {
+    const {askRootOfWebApp} = proxyquire(MODULE_PATH, {
+      'glob': (pattern, config, callback) => {
+        callback(null, []);
+      },
+      'inquirer': {
+        prompt: () => Promise.resolve({
+          [question_rootDirectory]: DIRECTORY,
+          [question_manualInput]: CHILD_DIRECTORY_BLANK,
+        }),
+      },
+      'fs-extra': {
+        stat: (path) => {
+          return {
+            isDirectory: () => {
+              return path === CHILD_DIRECTORY_BLANK;
+            },
+          };
+        },
+      },
+    });
+
+    const answer = await askRootOfWebApp();
+    expect(answer).to.eql(CHILD_DIRECTORY_BLANK);
   });
 });
 

--- a/test/workbox-cli/node/lib/questions/ask-root-of-web-app.js
+++ b/test/workbox-cli/node/lib/questions/ask-root-of-web-app.js
@@ -14,8 +14,8 @@ const {errors} = require('../../../../../packages/workbox-cli/build/lib/errors')
 const MODULE_PATH = '../../../../../packages/workbox-cli/build/lib/questions/ask-root-of-web-app';
 // This is the hardcoded name of the question that's passed to inquirer.
 // It's used as the key to read the response from the answer.
-const question_rootDirectory = 'globDirectory';
-const question_manualInput = 'manualDirectoryInput';
+const questionRootDirectory = 'globDirectory';
+const questionManualInput = 'manualDirectoryInput';
 const DIRECTORY = '/path/to/directory';
 const CHILD_DIRECTORY = '/path/to/directory/child';
 const CHILD_DIRECTORY_WHITE_SPACE = '/path/to/directory/   child';
@@ -28,7 +28,7 @@ describe(`[workbox-cli] lib/questions/ask-root-of-web-app.js`, function() {
         callback(null, []);
       },
       'inquirer': {
-        prompt: () => Promise.resolve({[question_rootDirectory]: DIRECTORY}),
+        prompt: () => Promise.resolve({[questionRootDirectory]: DIRECTORY}),
       },
       'fs-extra': {
         stat: (path) => {
@@ -58,8 +58,8 @@ describe(`[workbox-cli] lib/questions/ask-root-of-web-app.js`, function() {
       },
       'inquirer': {
         prompt: () => Promise.resolve({
-          [question_rootDirectory]: DIRECTORY,
-          [question_manualInput]: CHILD_DIRECTORY,
+          [questionRootDirectory]: DIRECTORY,
+          [questionManualInput]: CHILD_DIRECTORY,
         }),
       },
       'fs-extra': {
@@ -87,7 +87,7 @@ describe(`[workbox-cli] lib/questions/ask-root-of-web-app.js`, function() {
         callback(null, []);
       },
       'inquirer': {
-        prompt: () => Promise.resolve({[question_rootDirectory]: DIRECTORY}),
+        prompt: () => Promise.resolve({[questionRootDirectory]: DIRECTORY}),
       },
       'fs-extra': {
         stat: (path) => {
@@ -113,8 +113,8 @@ describe(`[workbox-cli] lib/questions/ask-root-of-web-app.js`, function() {
       },
       'inquirer': {
         prompt: () => Promise.resolve({
-          [question_rootDirectory]: DIRECTORY,
-          [question_manualInput]: CHILD_DIRECTORY,
+          [questionRootDirectory]: DIRECTORY,
+          [questionManualInput]: CHILD_DIRECTORY,
         }),
       },
       'fs-extra': {
@@ -139,8 +139,8 @@ describe(`[workbox-cli] lib/questions/ask-root-of-web-app.js`, function() {
       },
       'inquirer': {
         prompt: () => Promise.resolve({
-          [question_rootDirectory]: DIRECTORY,
-          [question_manualInput]: CHILD_DIRECTORY_WHITE_SPACE,
+          [questionRootDirectory]: DIRECTORY,
+          [questionManualInput]: CHILD_DIRECTORY_WHITE_SPACE,
         }),
       },
       'fs-extra': {
@@ -165,8 +165,8 @@ describe(`[workbox-cli] lib/questions/ask-root-of-web-app.js`, function() {
       },
       'inquirer': {
         prompt: () => Promise.resolve({
-          [question_rootDirectory]: DIRECTORY,
-          [question_manualInput]: CHILD_DIRECTORY_BLANK,
+          [questionRootDirectory]: DIRECTORY,
+          [questionManualInput]: CHILD_DIRECTORY_BLANK,
         }),
       },
       'fs-extra': {


### PR DESCRIPTION
Fixes *#2764*

R: @jeffposnick @philipwalton

### Changes
* Fixed error thrown during the workbox wizard regarding the web application root directory prompt (first question) when `Manually enter path` option is chosen,
* Made the separator unselectable,
* Extended upon the existing unit tests regarding this functionality.

### Checklist
After the changes I ensured that:
 * no stylistic or unwanted errors are present, by running `npm run gulp lint` from the root directory,
 * no tests are failing, by running `npm run gulp test_node` from the root directory,
 * build passes with no issues, by running `npm run gulp build` from the root directory,
 * checked the build output locally by:
   * creating a new `npm` project and installing the `workbox` (local) package, by running `npm i ~/path/to/local/project/workbox/packages/workbox-cli`,
   * spawning the workbox wizard from the project, by running `./node_modules/.bin/workbox wizard`,
   * checked the functionality manually with cases covered:
     1. no child directories present,
     2. multiple child directories present,
     3. manual input of existing directory,
     4. manual input of non-existing directory.
   * checking the generated `workbox-config.js` file content after completing the wizard.

### Done
- [x] Added/updated unit tests for this change
- [x] Included links to related issues/PRs
