### PR TITLE
Set preventAssignment in @rollup/plugin-replace

### DIFF
--- a/gulp-tasks/utils/rollup-helper.js
+++ b/gulp-tasks/utils/rollup-helper.js
@@ -78,6 +78,7 @@ module.exports = {
 
     // This is what the build should be
     const replaceOptions = {
+      'preventAssignment': true,
       'WORKBOX_CDN_ROOT_URL': getVersionsCDNUrl(),
     };
 

--- a/infra/testing/server/routes/sw-bundle.js
+++ b/infra/testing/server/routes/sw-bundle.js
@@ -50,6 +50,7 @@ async function handler(req, res) {
           exclude: '*.mjs',
         }),
         replace({
+          'preventAssignment': true,
           'process.env.NODE_ENV': JSON.stringify(env),
           'SW_NAMESPACES': JSON.stringify(SW_NAMESPACES),
           'WORKBOX_CDN_ROOT_URL': '/__WORKBOX/buildFile',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4073,13 +4073,13 @@
       }
     },
     "@rollup/plugin-replace": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.3.tgz",
-      "integrity": "sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.1.tgz",
+      "integrity": "sha512-XwC1oK5rrtRJ0tn1ioLHS6OV5JTluJF7QE1J/q1hN3bquwjnVxjtMyY9iCnoyH9DQbf92CxajB3o98wZbP3oAQ==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.0.8",
-        "magic-string": "^0.25.5"
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
       }
     },
     "@rollup/plugin-virtual": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-multi-entry": "^4.0.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "@rollup/plugin-replace": "^2.3.3",
+    "@rollup/plugin-replace": "^2.4.1",
     "@types/estree": "0.0.45",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",

--- a/packages/workbox-build/package-lock.json
+++ b/packages/workbox-build/package-lock.json
@@ -999,12 +999,12 @@
 			}
 		},
 		"@rollup/plugin-replace": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.3.tgz",
-			"integrity": "sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.1.tgz",
+			"integrity": "sha512-XwC1oK5rrtRJ0tn1ioLHS6OV5JTluJF7QE1J/q1hN3bquwjnVxjtMyY9iCnoyH9DQbf92CxajB3o98wZbP3oAQ==",
 			"requires": {
-				"@rollup/pluginutils": "^3.0.8",
-				"magic-string": "^0.25.5"
+				"@rollup/pluginutils": "^3.1.0",
+				"magic-string": "^0.25.7"
 			}
 		},
 		"@rollup/pluginutils": {
@@ -1783,131 +1783,6 @@
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^1.0.1",
 				"webidl-conversions": "^4.0.2"
-			}
-		},
-		"workbox-background-sync": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.0.2.tgz",
-			"integrity": "sha512-KQU2ntvbvFoBvCRm+EDpWAaykt4u/oaF5j3C6io0dZVWhFc/ZwgYDii8fb34LTenug3VPWQELdw9dNBCoP4b0w==",
-			"requires": {
-				"workbox-core": "^6.0.2"
-			}
-		},
-		"workbox-broadcast-update": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-6.0.2.tgz",
-			"integrity": "sha512-yCXYEln7nU8FkMDysYQPirpgFXtsdBtxruHbvZzRsxMHvAELf3j/o6Ufae1zjl8XanLF696sqSNxehpCGSD6tw==",
-			"requires": {
-				"workbox-core": "^6.0.2"
-			}
-		},
-		"workbox-cacheable-response": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.0.2.tgz",
-			"integrity": "sha512-OrgFiYWkmFXDIbNRYSu+fchcfoZqyJ4yZbdc8WKUjr9v/MghKHfR9u7UI077xBkjno5J3YNpbwx73/no3HkrzA==",
-			"requires": {
-				"workbox-core": "^6.0.2"
-			}
-		},
-		"workbox-core": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.0.2.tgz",
-			"integrity": "sha512-Ksl6qeikGb+BOCILoCUJGxwlEQOeeqdpOnpOr9UDt3NtacPYbfYBmpYpKArw5DFWK+5geBsFqgUUlXThlCYfKQ=="
-		},
-		"workbox-expiration": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-6.0.2.tgz",
-			"integrity": "sha512-6+nbR18cklAdI3BPT675ytftXPwnVbXGR8mPWNWTJtl5y2urRYv56ZOJLD7FBFVkZ8EjWiRhNP/A0fkxgdKtWQ==",
-			"requires": {
-				"workbox-core": "^6.0.2"
-			}
-		},
-		"workbox-google-analytics": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-6.0.2.tgz",
-			"integrity": "sha512-xmYJurR1M6Pzc2SBM/E7AgwmBszhu/YYDzBnU+HJPZFLbTG97ASIJyTXV1vcczA/dNaS0miIf0cFqneozVlDRw==",
-			"requires": {
-				"workbox-background-sync": "^6.0.2",
-				"workbox-core": "^6.0.2",
-				"workbox-routing": "^6.0.2",
-				"workbox-strategies": "^6.0.2"
-			}
-		},
-		"workbox-navigation-preload": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-6.0.2.tgz",
-			"integrity": "sha512-7+ojLrjXmTFZBfGmUQIcBWB+xrFgXLMJGNQAtxT7Ta9A23rEWo8jqAgeuwAylebcORUlM+ztgYTV7eGp+AD+Yg==",
-			"requires": {
-				"workbox-core": "^6.0.2"
-			}
-		},
-		"workbox-precaching": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-6.0.2.tgz",
-			"integrity": "sha512-sqKWL2emzmGnfJpna+9RjUkUiqQO++AKfwljCbgkHg8wBbVLy/rnui3eelKgAI7D8R31LJFfiZkY/kXmwkjtlQ==",
-			"requires": {
-				"workbox-core": "^6.0.2",
-				"workbox-routing": "^6.0.2",
-				"workbox-strategies": "^6.0.2"
-			}
-		},
-		"workbox-range-requests": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-6.0.2.tgz",
-			"integrity": "sha512-qCrDbH9AzDbCErde71Nys2iNZO9I9M9Jgl/9/Q67dGQVwFsEq73SuIzS2DGIBKqtIdC5QUigC3d7XJONajclUQ==",
-			"requires": {
-				"workbox-core": "^6.0.2"
-			}
-		},
-		"workbox-recipes": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-6.0.2.tgz",
-			"integrity": "sha512-ewZIHO4jYE6bnEeUIYS6joQy3l+MydpOsVr2F6EpE8ps++z1ScbSdLtJU+yu6WuO3lH44HFZLeFxYQqYm50QAA==",
-			"requires": {
-				"workbox-cacheable-response": "^6.0.2",
-				"workbox-core": "^6.0.2",
-				"workbox-expiration": "^6.0.2",
-				"workbox-precaching": "^6.0.2",
-				"workbox-routing": "^6.0.2",
-				"workbox-strategies": "^6.0.2"
-			}
-		},
-		"workbox-routing": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.0.2.tgz",
-			"integrity": "sha512-iQ9ch3fL1YpztDLfHNURaHQ0ispgPCdzWmZZhtSHUyy/+YkTlIiDVTbOQCIpHIrWlKQiim6X3K2ItIy1FW9+wA==",
-			"requires": {
-				"workbox-core": "^6.0.2"
-			}
-		},
-		"workbox-strategies": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.0.2.tgz",
-			"integrity": "sha512-HjLnYCVS60U7OKhl5NIq8NAQXrotJQRDakmIONnRlQIlP2If/kAiQSUP3QCHMq4EeXGiF+/CdlR1/bhYBHZzZg==",
-			"requires": {
-				"workbox-core": "^6.0.2"
-			}
-		},
-		"workbox-streams": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-6.0.2.tgz",
-			"integrity": "sha512-bckftu/iMlg5LFXPZ6NX/FUc/w4illgxSuwtsZkQAO6Uen1EeegjfLyenO01/dwoyc3D/AlZepMdhv87XhE7HQ==",
-			"requires": {
-				"workbox-core": "^6.0.2",
-				"workbox-routing": "^6.0.2"
-			}
-		},
-		"workbox-sw": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-6.0.2.tgz",
-			"integrity": "sha512-EoOjbyy5bpoBoSqt2PIeDOZ/JJ41f+WJjb979PkfIUWw4F+F/w2uKJJrMA5fk+nWnVge83Fwy8nF3dWNsqOrdg=="
-		},
-		"workbox-window": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-6.0.2.tgz",
-			"integrity": "sha512-I/X+qUh1AwN9x/MxFbXsPn7DA27BMtzkXo55w1tBD8V54fv8nUCeC5E4RpXt/mlgdSwBztnURCQTWsdhTrSUjg==",
-			"requires": {
-				"workbox-core": "^6.0.2"
 			}
 		},
 		"wrappy": {

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -26,7 +26,7 @@
     "@hapi/joi": "^16.1.8",
     "@rollup/plugin-babel": "^5.2.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "@rollup/plugin-replace": "^2.3.3",
+    "@rollup/plugin-replace": "^2.4.1",
     "@surma/rollup-plugin-off-main-thread": "^1.4.1",
     "common-tags": "^1.8.0",
     "fast-json-stable-stringify": "^2.1.0",

--- a/packages/workbox-build/src/lib/bundle.js
+++ b/packages/workbox-build/src/lib/bundle.js
@@ -34,7 +34,11 @@ module.exports = async ({
 
   const plugins = [
     nodeResolve(),
-    replace({'process.env.NODE_ENV': JSON.stringify(mode)}),
+    replace({
+      // See https://github.com/GoogleChrome/workbox/issues/2769
+      'preventAssignment': true,
+      'process.env.NODE_ENV': JSON.stringify(mode),
+    }),
     babel({
       babelHelpers: 'bundled',
       // Disable the logic that checks for local Babel config files:

--- a/test/workbox-build/node/lib/bundle.js
+++ b/test/workbox-build/node/lib/bundle.js
@@ -105,6 +105,7 @@ describe(`[workbox-build] lib/bundle.js`, function() {
     });
 
     expect(stubs['@rollup/plugin-replace'].args).to.eql([[{
+      'preventAssignment': true,
       'process.env.NODE_ENV': `"${mode}"`,
     }]]);
   });


### PR DESCRIPTION
R: @tropicadri  @philipwalton

Fixes #2769

The latest minor release of `@rollup/plugin-replace` has started logging messages about the new `preventAssignment` option, apparently in advance of some breaking changes in the next major release.

Folks using Workbox who end up with `@rollup/plugin-replace` v.2.4.0+ installed will get this message.

This PR explicitly updates our `workbox-build` and repo-level dependencies to require `@rollup/plugin-replace` v2.4.1, and explicitly sets `preventAssignment: true`, which should stop the logged warning messages.

(Based on how we're using `@rollup/plugin-replace`, `preventAssignment: true` should not result in any noticeable change.)