### PR TITLE
Remove error logging caused by offline check

### DIFF
--- a/test/workbox-strategies/sw/test-NetworkFirst.mjs
+++ b/test/workbox-strategies/sw/test-NetworkFirst.mjs
@@ -196,21 +196,10 @@ describe(`NetworkFirst`, function() {
         return networkResponse;
       });
 
-      // To ensure an attempt to respond from cache is made.
-      const cacheReadSpy = sandbox.spy();
+      sandbox.stub(caches, 'match').resolves(undefined);
 
       const networkFirst = new NetworkFirst({
         networkTimeoutSeconds,
-        plugins: [
-          {
-            cacheKeyWillBeUsed: ({request, mode}) => {
-              if (mode === 'read') {
-                cacheReadSpy(request);
-              }
-              return request;
-            },
-          },
-        ],
       });
       const handlePromise = networkFirst.handle({
         request,
@@ -220,7 +209,7 @@ describe(`NetworkFirst`, function() {
       const handlerResponse = await handlePromise;
 
       expect(handlerResponse).to.equal(networkResponse);
-      expect(cacheReadSpy.firstCall.args[0]).to.equal(request);
+      expect(caches.match.firstCall.args[0]).to.equal(request);
     });
 
     it(`should throw when NetworkFirst() is called with an invalid networkTimeoutSeconds parameter`, function() {

--- a/test/workbox-strategies/sw/test-StrategyHandler.mjs
+++ b/test/workbox-strategies/sw/test-StrategyHandler.mjs
@@ -895,7 +895,7 @@ describe(`StrategyHandler`, function() {
       sandbox.spy(handler, 'cachePut');
       sandbox.spy(handler, 'waitUntil');
 
-      handler.fetchAndCachePut('/url');
+      await handler.fetchAndCachePut('/url');
 
       await handler.doneWaiting();
       expect(handler.waitUntil.calledWith(


### PR DESCRIPTION
R: @jeffposnick @tropicadri

Fixes #2749 

This PR removes confusing errors logged to the console in Chrome when doing the offline check. It does this by:

- Changing the `StrategyHandler#fetch()` method's console level to LOG from ERROR when a network request fails. Since the strategy will also error if no response is returned (e.g. nothing is found in the cache), this message should be considered more informative than actionable.
- Updating the `StrategyHandler#fetch()` and `StrategyHandler#cacheMatch()` methods to not call `this.waitUntil()` on the response. Calling `waitUntil()` in these situations is not necessary because SW implementations automatically wait on a `fetch` event's `respondWith()` promise. Furthermore, doing so in the `StrategyHandler` instance was causing response errors to be reported twice in some cases (leading do an unhandled promise rejection from the offline check).
