### PR TITLE
JSDoc fix for sameOrigin

### DIFF
--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -296,6 +296,8 @@ class Router {
    *
    * @param {Object} options
    * @param {URL} options.url
+   * @param {boolean} options.sameOrigin The result of comparing `url.origin`
+   *     against the current origin.
    * @param {Request} options.request The request to match.
    * @param {Event} options.event The corresponding event.
    * @return {Object} An object with `route` and `params` properties.


### PR DESCRIPTION
R: @tropicadri 
CC: @cebjyre

Fixes #2782

Adding in an overlooked parameter from the JSDoc.
