### PR TITLE
Support for external controlling events

### DIFF
--- a/test/workbox-window/integration/test-all.js
+++ b/test/workbox-window/integration/test-all.js
@@ -84,6 +84,7 @@ describe(`[workbox-window] Workbox`, function() {
             installedSpyCallCount: installedSpy.callCount,
             waitingSpyCallCount: waitingSpy.callCount,
             controllingSpyCallCount: controllingSpy.callCount,
+            controllingIsExternal: controllingSpy.args[0][0].isExternal,
             activatedSpyCallCount: activatedSpy.callCount,
           });
         } catch (error) {
@@ -94,6 +95,7 @@ describe(`[workbox-window] Workbox`, function() {
       // Test for truthiness because some browsers structure clone
       // `undefined` to `null`.
       expect(result.isUpdate).to.not.be.ok;
+      expect(result.controllingIsExternal).to.not.be.ok;
       expect(result.installedSpyCallCount).to.equal(1);
       expect(result.activatedSpyCallCount).to.equal(1);
       expect(result.controllingSpyCallCount).to.equal(1);
@@ -107,7 +109,9 @@ describe(`[workbox-window] Workbox`, function() {
         try {
           const wb1 = new Workbox('sw-clients-claim.js.njk?v=1');
           const redundantSpy = sinon.spy();
+          const wb1ControllingSpy = sinon.spy();
           wb1.addEventListener('redundant', redundantSpy);
+          wb1.addEventListener('controlling', wb1ControllingSpy);
 
           await wb1.register();
           await window.activatedAndControlling(wb1);
@@ -117,12 +121,12 @@ describe(`[workbox-window] Workbox`, function() {
           const installedSpy = sinon.spy();
           const waitingSpy = sinon.spy();
           const activatedSpy = sinon.spy();
-          const controllingSpy = sinon.spy();
+          const wb2ControllingSpy = sinon.spy();
 
           wb2.addEventListener('installed', installedSpy);
           wb2.addEventListener('waiting', waitingSpy);
           wb2.addEventListener('activated', activatedSpy);
-          wb2.addEventListener('controlling', controllingSpy);
+          wb2.addEventListener('controlling', wb2ControllingSpy);
 
           await wb2.register();
 
@@ -131,9 +135,11 @@ describe(`[workbox-window] Workbox`, function() {
           cb({
             wb1IsUpdate: redundantSpy.args[0][0].isUpdate,
             wb2IsUpdate: installedSpy.args[0][0].isUpdate,
+            wb1ControllingIsExternal: wb1ControllingSpy.args[0][0].isExternal,
+            wb2ControllingIsExternal: wb2ControllingSpy.args[0][0].isExternal,
             installedSpyCallCount: installedSpy.callCount,
             waitingSpyCallCount: waitingSpy.callCount,
-            controllingSpyCallCount: controllingSpy.callCount,
+            controllingSpyCallCount: wb2ControllingSpy.callCount,
             activatedSpyCallCount: activatedSpy.callCount,
           });
         } catch (error) {
@@ -145,6 +151,8 @@ describe(`[workbox-window] Workbox`, function() {
       // `undefined` to `null`.
       expect(result.wb1IsUpdate).to.not.be.ok;
       expect(result.wb2IsUpdate).to.equal(true);
+      expect(result.wb1ControllingIsExternal).to.not.be.ok;
+      expect(result.wb2ControllingIsExternal).to.not.be.ok;
       expect(result.installedSpyCallCount).to.equal(1);
       expect(result.waitingSpyCallCount).to.equal(0);
       expect(result.activatedSpyCallCount).to.equal(1);

--- a/test/workbox-window/window/test-Workbox.mjs
+++ b/test/workbox-window/window/test-Workbox.mjs
@@ -846,21 +846,30 @@ describe(`[workbox-window] Workbox`, function() {
 
         expect(controlling1Spy.callCount).to.equal(1);
         assertMatchesWorkboxEvent(controlling1Spy.args[0][0], {
-          type: 'controlling',
-          target: wb1,
-          sw: await wb1.getSW(),
-          originalEvent: {type: 'controllerchange'},
+          isExternal: false,
           isUpdate: true,
+          originalEvent: {type: 'controllerchange'},
+          sw: await wb1.getSW(),
+          target: wb1,
+          type: 'controlling',
         });
 
-        expect(controlling2Spy.callCount).to.equal(0);
+        // This will be an "external" event, due to wb3's SW taking control.
+        // wb2's SW never controls, because it's stuck in waiting.
+        expect(controlling2Spy.callCount).to.equal(1);
+        assertMatchesWorkboxEvent(controlling2Spy.args[0][0], {
+          isExternal: true,
+          isUpdate: true,
+          type: 'controlling',
+        });
 
         expect(controlling3Spy.callCount).to.equal(1);
         assertMatchesWorkboxEvent(controlling3Spy.args[0][0], {
-          type: 'controlling',
-          target: wb3,
-          sw: await wb3.getSW(),
+          isExternal: false,
           originalEvent: {type: 'controllerchange'},
+          sw: await wb3.getSW(),
+          target: wb3,
+          type: 'controlling',
         });
       });
     });


### PR DESCRIPTION
R: @philipwalton @tropicadri

Fixes #2786

The intention in v6 was to fire all synthetic events on all `Workbox` instances, regardless of whether they originated from the "current" or "external" service worker. Developers who need to distinguish between the two could check the `isExternal` boolean flag on the event.

This logic wasn't implemented for the `controlling` synthetic event, causing developer confusion. This PR adds that functionality.

As mentioned in the original issue, I consider this a bug fix as opposed to a breaking change, as we state in the [updated documentation](https://developers.google.com/web/tools/workbox/modules/workbox-window#when_an_unexpected_version_of_the_service_worker_is_found):

> As of Workbox v6 and later, these events are equivalent to the events documented above, with the addition of an isExternal: true property set on each event object. If your web application needs to implement specific logic to handle an "external" service worker, you can check for that property in your event handlers.