### PR TITLE
Use an Error, not string, when adding to compilation.warnings

### DIFF
--- a/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-from-compilation.js
+++ b/packages/workbox-webpack-plugin/src/lib/get-manifest-entries-from-compilation.js
@@ -200,7 +200,10 @@ module.exports = async (compilation, config) => {
     transformParam: compilation,
   });
 
-  compilation.warnings = compilation.warnings.concat(warnings || []);
+  // See https://github.com/GoogleChrome/workbox/issues/2790
+  for (const warning of warnings) {
+    compilation.warnings.push(new Error(warning));
+  }
 
   // Ensure that the entries are properly sorted by URL.
   const sortedEntries = manifestEntries.sort(


### PR DESCRIPTION
R: @tropicadri

Fixes #2790

We made similar changes when resolving #2674, but this bit of code was overlooked. Without this change, some folks are not able to see our warning messages following a `webpack` compilation.