### PR TITLE
Adding scripts used during development to npm scripts 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   },
   "scripts": {
     "version": "gulp build && git add -A packages",
-    "gulp": "gulp"
+    "gulp": "gulp", 
+    "build": "gulp build",
+    "lint": "gulp lint",
+    "test_server" : "gulp test_server",
+    "test_node": "gulp test_node",
+    "test_integration": "gulp test_integration"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
This way typing gulp after npm run is optional.

I like having the shorter aliases. If for some reason you don't like it. Feel free to reject the PR.
