### PR TITLE
Adding the QueueDb and using it in background sync instead of DBWrapper

### DIFF
--- a/infra/testing/server/routes/sw-bundle.js
+++ b/infra/testing/server/routes/sw-bundle.js
@@ -40,7 +40,7 @@ async function handler(req, res) {
       plugins: [
         multiEntry(),
         nodeResolve({
-          moduleDirectories: ['packages'],
+          moduleDirectories: ['packages', 'node_modules'],
         }),
         // TODO(philipwalton): some of our shared testing helpers use commonjs
         // so we have to support this for the time being.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10864,6 +10864,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "idb": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-6.0.0.tgz",
+      "integrity": "sha512-+M367poGtpzAylX4pwcrZIa7cFQLfNkAOlMMLN2kw/2jGfJP6h+TB/unQNSVYwNtP8XqkLYrfuiVnxLQNP1tjA=="
+    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "html-webpack-plugin-v4": "npm:html-webpack-plugin@^4.5.0",
     "html-webpack-plugin-v5": "npm:html-webpack-plugin@^5.0.0-alpha.14",
     "husky": "^4.2.5",
+    "idb": "^6.0.0",
     "jsdoc": "^3.6.5",
     "jsdoc-baseline": "^0.1.5",
     "lerna": "^3.22.1",

--- a/packages/workbox-background-sync/package-lock.json
+++ b/packages/workbox-background-sync/package-lock.json
@@ -4,8 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "idb": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-6.0.0.tgz",
+      "integrity": "sha512-+M367poGtpzAylX4pwcrZIa7cFQLfNkAOlMMLN2kw/2jGfJP6h+TB/unQNSVYwNtP8XqkLYrfuiVnxLQNP1tjA=="
+    },
     "workbox-core": {
-      "version": "5.0.0-alpha.0"
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.1.2.tgz",
+      "integrity": "sha512-69rch7EyPsNAx5Y5YlSoHV39/EEE1oDeb5zmLIy6+mgB4BnaG6u/tlDtvjvKqHcPM0gz2L5SzYtTEvWmk5WRTQ=="
     }
   }
 }

--- a/packages/workbox-background-sync/package.json
+++ b/packages/workbox-background-sync/package.json
@@ -26,5 +26,5 @@
   "dependencies": {
     "workbox-core": "^6.1.5",
     "idb": "^6.0.0"
-  },
+  }
 }

--- a/packages/workbox-background-sync/package.json
+++ b/packages/workbox-background-sync/package.json
@@ -25,6 +25,6 @@
   "types": "index.d.ts",
   "dependencies": {
     "workbox-core": "^6.1.2",
-    "idb":"^6.0.0"  
+    "idb": "^6.0.0"
   }
 }

--- a/packages/workbox-background-sync/package.json
+++ b/packages/workbox-background-sync/package.json
@@ -24,6 +24,7 @@
   "module": "index.mjs",
   "types": "index.d.ts",
   "dependencies": {
-    "workbox-core": "^6.1.2"
+    "workbox-core": "^6.1.2",
+    "idb":"^6.0.0"  
   }
 }

--- a/packages/workbox-background-sync/src/Queue.ts
+++ b/packages/workbox-background-sync/src/Queue.ts
@@ -10,10 +10,10 @@ import {WorkboxError} from 'workbox-core/_private/WorkboxError.js';
 import {logger} from 'workbox-core/_private/logger.js';
 import {assert} from 'workbox-core/_private/assert.js';
 import {getFriendlyURL} from 'workbox-core/_private/getFriendlyURL.js';
-import {UnidentifiedQueueStoreEntry, QueueStore} from './lib/QueueStore.js';
+import {QueueStore} from './lib/QueueStore.js';
+import {UnidentifiedQueueStoreEntry} from './lib/QueueDb';
 import {StorableRequest} from './lib/StorableRequest.js';
 import './_version.js';
-
 
 // Give TypeScript the correct global.
 declare let self: ServiceWorkerGlobalScope;
@@ -238,7 +238,6 @@ class Queue {
 
     return unexpiredEntries;
   }
-
 
   /**
    * Adds the entry to the QueueStore and registers for a sync event.

--- a/packages/workbox-background-sync/src/Queue.ts
+++ b/packages/workbox-background-sync/src/Queue.ts
@@ -11,7 +11,7 @@ import {logger} from 'workbox-core/_private/logger.js';
 import {assert} from 'workbox-core/_private/assert.js';
 import {getFriendlyURL} from 'workbox-core/_private/getFriendlyURL.js';
 import {QueueStore} from './lib/QueueStore.js';
-import {UnidentifiedQueueStoreEntry} from './lib/QueueDb';
+import {UnidentifiedQueueStoreEntry} from './lib/QueueDb.js';
 import {StorableRequest} from './lib/StorableRequest.js';
 import './_version.js';
 

--- a/packages/workbox-background-sync/src/lib/QueueDb.ts
+++ b/packages/workbox-background-sync/src/lib/QueueDb.ts
@@ -13,7 +13,7 @@ import '../_version.js';
 interface QueueDBSchema extends DBSchema {
   requests: {
     key: number;
-    value: UnidentifiedQueueStoreEntry;
+    value: QueueStoreEntry;
     indexes: {queueName: string};
   };
 }
@@ -53,7 +53,7 @@ export class QueueDb {
    */
   async addEntry(entry: UnidentifiedQueueStoreEntry) {
     const db = await this.getDb();
-    await db.add(REQUEST_OBJECT_STORE_NAME, entry);
+    await db.add(REQUEST_OBJECT_STORE_NAME, entry as QueueStoreEntry);
   }
 
   /**
@@ -77,7 +77,7 @@ export class QueueDb {
     queueName: string,
   ): Promise<QueueStoreEntry[]> {
     const db = await this.getDb();
-    const results = await db.getAllFromIndex(REQUEST_OBJECT_STORE_NAME, QUEUE_NAME_INDEX, IDBKeyRange.only(queueName)) as QueueStoreEntry[];
+    const results = await db.getAllFromIndex(REQUEST_OBJECT_STORE_NAME, QUEUE_NAME_INDEX, IDBKeyRange.only(queueName));
     return results ? results : new Array<QueueStoreEntry>();
   }
 
@@ -127,7 +127,7 @@ export class QueueDb {
     const cursor = await db.transaction(REQUEST_OBJECT_STORE_NAME)
       .store.index(QUEUE_NAME_INDEX)
       .openCursor(query, direction);
-    return cursor?.value as QueueStoreEntry;
+    return cursor?.value;
   }
 
   /**
@@ -141,7 +141,7 @@ export class QueueDb {
         upgrade: this._upgradeDb,
       });
     }
-    return this._db
+    return this._db;
   }
 
   /**

--- a/packages/workbox-background-sync/src/lib/QueueDb.ts
+++ b/packages/workbox-background-sync/src/lib/QueueDb.ts
@@ -1,0 +1,149 @@
+/*
+  Copyright 2018 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import {openDB, DBSchema, IDBPDatabase} from 'idb';
+import {RequestData} from './StorableRequest.js';
+
+interface QueueDBSchema extends DBSchema {
+  requests: {
+    key: number;
+    value: UnidentifiedQueueStoreEntry;
+    indexes: {queueName: string};
+  };
+}
+
+const DB_VERSION = 3;
+const DB_NAME = 'workbox-background-sync';
+const OBJECT_STORE_NAME = 'requests';
+const INDEXED_PROP = 'queueName';
+
+export interface UnidentifiedQueueStoreEntry {
+  requestData: RequestData;
+  timestamp: number;
+  id?: number;
+  queueName?: string;
+  metadata?: object;
+}
+
+export interface QueueStoreEntry extends UnidentifiedQueueStoreEntry {
+  id: number;
+}
+
+/**
+ * A class to interact directly with IndexedDB to store a retrieve queue requests.
+ *
+ * @private
+ */
+
+export class QueueDb {
+  private _db: IDBPDatabase<QueueDBSchema> | null = null;
+
+  /**
+   * Opens a connection to IDBDatabase.
+   *
+   * @private
+   */
+  private async open() {
+    if (!this._db) {
+      this._db = await openDB(DB_NAME, DB_VERSION, {
+        upgrade: this._upgradeDb,
+      });
+    }
+  }
+
+  /**
+   *
+   * @param {UnidentifiedQueueStoreEntry} entry
+   */
+  async addEntry(entry: UnidentifiedQueueStoreEntry) {
+    await this.open();
+    await this._db!.add(OBJECT_STORE_NAME, entry);
+  }
+
+  /**
+   * Returns the first entry in the ObjectStore
+   *
+   * @return {QueueStoreEntry}
+   */
+  async getFirstEntry(): Promise<QueueStoreEntry | any> {
+    await this.open();
+    const cursor = await this._db
+      ?.transaction(OBJECT_STORE_NAME)
+      .store.openCursor();
+
+    if (cursor) {
+      return cursor.value as QueueStoreEntry;
+    }
+  }
+
+  /**
+   *
+   * @param query
+   * @return {Promise<QueueStoreEntry[]>}
+   */
+  async getAllEntriesFromIndex(
+    query?: IDBKeyRange,
+  ): Promise<QueueStoreEntry[]> {
+    await this.open();
+    const results =
+      await this._db?.getAllFromIndex(OBJECT_STORE_NAME, INDEXED_PROP, query) as QueueStoreEntry[];
+    return results ? results : new Array<QueueStoreEntry>();
+  }
+
+  /**
+   *
+   * @param {number} id the id of the entry to be deleted
+   */
+  async deleteEntry(id: number) {
+    await this.open();
+    await this._db?.delete(OBJECT_STORE_NAME, id);
+  }
+
+  /**
+   * Returns either the first or the last entries, depending on direction. Uses the index.
+   *
+   * @param {IDBCursorDirection} direction
+   * @param {IDBKeyRange} query
+   * @return {Promise<QueueStoreEntry | any>}
+   */
+  async getEndEntryFromIndex(
+    {direction}: {direction?: IDBCursorDirection},
+    query?: IDBKeyRange,
+  ): Promise<QueueStoreEntry | any> {
+    await this.open();
+
+    const cursor = await this._db?.transaction(OBJECT_STORE_NAME)
+      .store.index(INDEXED_PROP)
+      .openCursor(query, direction);
+
+    if (cursor) {
+      return cursor.value as QueueStoreEntry;
+    }
+  }
+
+  /**
+   * Upgrades QueueDB
+   *
+   * @param {IDBPDatabase<QueueDBSchema>} db
+   * @param {number} oldVersion
+   * @private
+   */
+  private _upgradeDb(db: IDBPDatabase<QueueDBSchema>, oldVersion: number) {
+    if (oldVersion > 0 && oldVersion < DB_VERSION) {
+      if (db.objectStoreNames.contains(OBJECT_STORE_NAME)) {
+        db.deleteObjectStore(OBJECT_STORE_NAME);
+      }
+    }
+
+    const objStore = db.createObjectStore(OBJECT_STORE_NAME, {
+      autoIncrement: true,
+      keyPath: 'id',
+    });
+    objStore.createIndex(INDEXED_PROP, INDEXED_PROP, {unique: false});
+  }
+}

--- a/packages/workbox-background-sync/src/lib/QueueDb.ts
+++ b/packages/workbox-background-sync/src/lib/QueueDb.ts
@@ -20,8 +20,8 @@ interface QueueDBSchema extends DBSchema {
 
 const DB_VERSION = 3;
 const DB_NAME = 'workbox-background-sync';
-const OBJECT_STORE_NAME = 'requests';
-const INDEXED_PROP = 'queueName';
+const REQUEST_OBJECT_STORE_NAME = 'requests';
+const QUEUE_NAME_INDEX = 'queueName';
 
 export interface UnidentifiedQueueStoreEntry {
   requestData: RequestData;
@@ -36,7 +36,9 @@ export interface QueueStoreEntry extends UnidentifiedQueueStoreEntry {
 }
 
 /**
- * A class to interact directly with IndexedDB to store a retrieve queue requests.
+ * A class to interact directly an IndexedDB created specifically to save and 
+ * retrieve QueueStoreEntries. This class encapsulates all the schema details
+ * to store the representation of a Queue.
  *
  * @private
  */
@@ -45,86 +47,101 @@ export class QueueDb {
   private _db: IDBPDatabase<QueueDBSchema> | null = null;
 
   /**
-   * Opens a connection to IDBDatabase.
+   * Add QueueStoreEntry to underlying db.
+   * 
+   * @param {UnidentifiedQueueStoreEntry} entry
+   */
+  async addEntry(entry: UnidentifiedQueueStoreEntry) {
+    const db = await this.getDb();
+    await db.add(REQUEST_OBJECT_STORE_NAME, entry);
+  }
+
+  /**
+   * Returns the first entry id in the ObjectStore.
+   *
+   * @return {number | undefined}
+   */
+  async getFirstEntryId(): Promise<number | undefined> {
+    const db = await this.getDb();
+    const cursor = await db.transaction(REQUEST_OBJECT_STORE_NAME).store.openCursor();
+    return cursor?.value.id;
+  }
+
+  /**
+   * Get all the entries filtered by index
+   * 
+   * @param queueName
+   * @return {Promise<QueueStoreEntry[]>}
+   */
+  async getAllEntriesByQueueName(
+    queueName: string,
+  ): Promise<QueueStoreEntry[]> {
+    const db = await this.getDb();
+    const results = await db.getAllFromIndex(REQUEST_OBJECT_STORE_NAME, QUEUE_NAME_INDEX, IDBKeyRange.only(queueName)) as QueueStoreEntry[];
+    return results ? results : new Array<QueueStoreEntry>();
+  }
+
+  /**
+   * Deletes a single entry by id.
+   * 
+   * @param {number} id the id of the entry to be deleted
+   */
+  async deleteEntry(id: number) {
+    const db = await this.getDb();
+    await db.delete(REQUEST_OBJECT_STORE_NAME, id);
+  }
+
+  /**
+   * 
+   * @param queueName 
+   * @returns {Promise<QueueStoreEntry | undefined>}
+   */
+  async getFirstEntryByQueueName(queueName: string): Promise<QueueStoreEntry | undefined> {
+    return await this.getEndEntryFromIndex(IDBKeyRange.only(queueName), 'next');
+  }
+
+  /**
+   * 
+   * @param queueName
+   * @returns {Promise<QueueStoreEntry | undefined>}
+   */
+  async getLastEntryByQueueName(queueName: string): Promise<QueueStoreEntry | undefined> {
+    return await this.getEndEntryFromIndex(IDBKeyRange.only(queueName), 'prev');
+  }
+
+  /**
+   * Returns either the first or the last entries, depending on direction. 
+   * Filtered by index.
+   *
+   * @param {IDBCursorDirection} direction
+   * @param {IDBKeyRange} query
+   * @return {Promise<QueueStoreEntry | undefined>}
+   * @private
+   */
+  async getEndEntryFromIndex(
+    query: IDBKeyRange,
+    direction: IDBCursorDirection,
+  ): Promise<QueueStoreEntry | undefined> {
+    const db = await this.getDb();
+
+    const cursor = await db.transaction(REQUEST_OBJECT_STORE_NAME)
+      .store.index(QUEUE_NAME_INDEX)
+      .openCursor(query, direction);
+    return cursor?.value as QueueStoreEntry;
+  }
+
+  /**
+   * Returns an open connection to the database.
    *
    * @private
    */
-  private async open() {
+  private async getDb() {
     if (!this._db) {
       this._db = await openDB(DB_NAME, DB_VERSION, {
         upgrade: this._upgradeDb,
       });
     }
-  }
-
-  /**
-   *
-   * @param {UnidentifiedQueueStoreEntry} entry
-   */
-  async addEntry(entry: UnidentifiedQueueStoreEntry) {
-    await this.open();
-    await this._db!.add(OBJECT_STORE_NAME, entry);
-  }
-
-  /**
-   * Returns the first entry in the ObjectStore
-   *
-   * @return {QueueStoreEntry}
-   */
-  async getFirstEntry(): Promise<QueueStoreEntry | any> {
-    await this.open();
-    const cursor = await this._db
-      ?.transaction(OBJECT_STORE_NAME)
-      .store.openCursor();
-
-    if (cursor) {
-      return cursor.value as QueueStoreEntry;
-    }
-  }
-
-  /**
-   *
-   * @param query
-   * @return {Promise<QueueStoreEntry[]>}
-   */
-  async getAllEntriesFromIndex(
-    query?: IDBKeyRange,
-  ): Promise<QueueStoreEntry[]> {
-    await this.open();
-    const results =
-      await this._db?.getAllFromIndex(OBJECT_STORE_NAME, INDEXED_PROP, query) as QueueStoreEntry[];
-    return results ? results : new Array<QueueStoreEntry>();
-  }
-
-  /**
-   *
-   * @param {number} id the id of the entry to be deleted
-   */
-  async deleteEntry(id: number) {
-    await this.open();
-    await this._db?.delete(OBJECT_STORE_NAME, id);
-  }
-
-  /**
-   * Returns either the first or the last entries, depending on direction. Uses the index.
-   *
-   * @param {IDBCursorDirection} direction
-   * @param {IDBKeyRange} query
-   * @return {Promise<QueueStoreEntry | any>}
-   */
-  async getEndEntryFromIndex(
-    {direction}: {direction?: IDBCursorDirection},
-    query?: IDBKeyRange,
-  ): Promise<QueueStoreEntry | any> {
-    await this.open();
-
-    const cursor = await this._db?.transaction(OBJECT_STORE_NAME)
-      .store.index(INDEXED_PROP)
-      .openCursor(query, direction);
-
-    if (cursor) {
-      return cursor.value as QueueStoreEntry;
-    }
+    return this._db
   }
 
   /**
@@ -136,15 +153,15 @@ export class QueueDb {
    */
   private _upgradeDb(db: IDBPDatabase<QueueDBSchema>, oldVersion: number) {
     if (oldVersion > 0 && oldVersion < DB_VERSION) {
-      if (db.objectStoreNames.contains(OBJECT_STORE_NAME)) {
-        db.deleteObjectStore(OBJECT_STORE_NAME);
+      if (db.objectStoreNames.contains(REQUEST_OBJECT_STORE_NAME)) {
+        db.deleteObjectStore(REQUEST_OBJECT_STORE_NAME);
       }
     }
 
-    const objStore = db.createObjectStore(OBJECT_STORE_NAME, {
+    const objStore = db.createObjectStore(REQUEST_OBJECT_STORE_NAME, {
       autoIncrement: true,
       keyPath: 'id',
     });
-    objStore.createIndex(INDEXED_PROP, INDEXED_PROP, {unique: false});
+    objStore.createIndex(QUEUE_NAME_INDEX, QUEUE_NAME_INDEX, {unique: false});
   }
 }

--- a/packages/workbox-background-sync/src/lib/QueueDb.ts
+++ b/packages/workbox-background-sync/src/lib/QueueDb.ts
@@ -8,7 +8,7 @@
 
 import {openDB, DBSchema, IDBPDatabase} from 'idb';
 import {RequestData} from './StorableRequest.js';
-import './_version.js';
+import '../_version.js';
 
 interface QueueDBSchema extends DBSchema {
   requests: {

--- a/packages/workbox-background-sync/src/lib/QueueDb.ts
+++ b/packages/workbox-background-sync/src/lib/QueueDb.ts
@@ -1,5 +1,5 @@
 /*
-  Copyright 2018 Google LLC
+  Copyright 2021 Google LLC
 
   Use of this source code is governed by an MIT-style
   license that can be found in the LICENSE file or at
@@ -8,6 +8,7 @@
 
 import {openDB, DBSchema, IDBPDatabase} from 'idb';
 import {RequestData} from './StorableRequest.js';
+import './_version.js';
 
 interface QueueDBSchema extends DBSchema {
   requests: {

--- a/test/workbox-background-sync/sw/lib/test-QueueDb.mjs
+++ b/test/workbox-background-sync/sw/lib/test-QueueDb.mjs
@@ -1,5 +1,5 @@
 /*
-  Copyright 2018 Google LLC
+  Copyright 2021 Google LLC
 
   Use of this source code is governed by an MIT-style
   license that can be found in the LICENSE file or at

--- a/test/workbox-background-sync/sw/lib/test-QueueDb.mjs
+++ b/test/workbox-background-sync/sw/lib/test-QueueDb.mjs
@@ -269,8 +269,8 @@ describe(`QueueDb`, () => {
     });
   });
 
-  describe('getFirstEntry', () => {
-    it(`should return the first entry in the IBDObjectStore`, async () => {
+  describe('getFirstEntryId', () => {
+    it(`should return the first entry id in the IBDObjectStore`, async () => {
       const queueDb = new QueueDb();
 
       await queueDb.addEntry(entry1);
@@ -281,18 +281,12 @@ describe(`QueueDb`, () => {
       await queueDb.addEntry(entry2);
       await queueDb.addEntry(entry3);
 
-      const result = await queueDb.getFirstEntry();
-      expect(result).to.deep.equal({
-        id: firstId,
-        queueName: 'a',
-        requestData: requestData1,
-        timestamp: 1000,
-        metadata: {name: 'meta1'},
-      });
+      const result = await queueDb.getFirstEntryId();
+      expect(result).to.equal(firstId);
     });
   });
 
-  describe('getAllEntriesFromIndex', () => {
+  describe('getAllEntriesByQueueName', () => {
     it(`should return all entries in IDB filtered by index`, async () => {
       const queueDb = new QueueDb();
 
@@ -306,7 +300,7 @@ describe(`QueueDb`, () => {
       await queueDb.addEntry(entry4);
       await queueDb.addEntry(entry5);
 
-      let results = await queueDb.getAllEntriesFromIndex(IDBKeyRange.only('b'));
+      let results = await queueDb.getAllEntriesByQueueName('b');
       expect(results).to.deep.equal([
         {
           id: firstId + 3,
@@ -324,7 +318,7 @@ describe(`QueueDb`, () => {
         },
       ]);
 
-      results = await queueDb.getAllEntriesFromIndex(IDBKeyRange.only('a'));
+      results = await queueDb.getAllEntriesByQueueName('a');
       expect(results).to.deep.equal([
         {
           id: firstId,
@@ -351,8 +345,8 @@ describe(`QueueDb`, () => {
 
       await db.clear('requests');
 
-      expect(await queueDb.getAllEntriesFromIndex(IDBKeyRange.only('a'))).to.deep.equal([]);
-      expect(await queueDb.getAllEntriesFromIndex(IDBKeyRange.only('b'))).to.deep.equal([]);
+      expect(await queueDb.getAllEntriesByQueueName('a')).to.deep.equal([]);
+      expect(await queueDb.getAllEntriesByQueueName('b')).to.deep.equal([]);
     });
   });
 
@@ -453,7 +447,7 @@ describe(`QueueDb`, () => {
     });
   });
 
-  describe('getEndEntryFromIndex', () => {
+  describe('getFirstEntryByQueueName', () => {
     it(`should return first entry in IDB filtered by index`, async () => {
       const queueDb = new QueueDb();
 
@@ -467,7 +461,7 @@ describe(`QueueDb`, () => {
       await queueDb.addEntry(entry4);
       await queueDb.addEntry(entry5);
 
-      let result = await queueDb.getEndEntryFromIndex({direction: 'next'}, IDBKeyRange.only('b'));
+      let result = await queueDb.getFirstEntryByQueueName('b');
       expect(result).to.deep.equal({
         id: firstId + 3,
         queueName: 'b',
@@ -476,7 +470,7 @@ describe(`QueueDb`, () => {
         metadata: {name: 'meta4'},
       });
 
-      result = await queueDb.getEndEntryFromIndex({direction: 'next'}, IDBKeyRange.only('a'));
+      result = await queueDb.getFirstEntryByQueueName('a');
       expect(result).to.deep.equal({
         id: firstId,
         queueName: 'a',
@@ -485,7 +479,9 @@ describe(`QueueDb`, () => {
         metadata: {name: 'meta1'},
       });
     });
+  });
 
+  describe('getLastEntryByQueueName', () => {
     it(`should return last entry in IDB filtered by index`, async () => {
       const queueDb = new QueueDb();
 
@@ -499,7 +495,7 @@ describe(`QueueDb`, () => {
       await queueDb.addEntry(entry4);
       await queueDb.addEntry(entry5);
 
-      let result = await queueDb.getEndEntryFromIndex({direction: 'prev'}, IDBKeyRange.only('b'));
+      let result = await queueDb.getLastEntryByQueueName('b');
       expect(result).to.deep.equal({
         id: firstId + 4,
         queueName: 'b',
@@ -508,7 +504,7 @@ describe(`QueueDb`, () => {
         metadata: {name: 'meta5'},
       });
 
-      result = await queueDb.getEndEntryFromIndex({direction: 'prev'}, IDBKeyRange.only('a'));
+      result = await queueDb.getLastEntryByQueueName('a');
       expect(result).to.deep.equal({
         id: firstId + 2,
         queueName: 'a',
@@ -516,11 +512,6 @@ describe(`QueueDb`, () => {
         timestamp: 3000,
         metadata: {name: 'meta3'},
       });
-
-      await db.clear('requests');
-
-      expect(await queueDb.getAllEntriesFromIndex(IDBKeyRange.only('a'))).to.deep.equal([]);
-      expect(await queueDb.getAllEntriesFromIndex(IDBKeyRange.only('b'))).to.deep.equal([]);
     });
   });
 });

--- a/test/workbox-background-sync/sw/lib/test-QueueDb.mjs
+++ b/test/workbox-background-sync/sw/lib/test-QueueDb.mjs
@@ -1,0 +1,526 @@
+/*
+  Copyright 2018 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import {QueueDb} from 'workbox-background-sync/lib/QueueDb.mjs';
+import {openDB, deleteDB} from 'idb';
+
+describe(`QueueDb`, () => {
+  let db = null;
+
+  const requestData1 = {
+    url: `${location.origin}/one`,
+    requestInit: {
+      mode: 'cors',
+    },
+  };
+
+  const requestData2 = {
+    url: `${location.origin}/two`,
+    requestInit: {
+      mode: 'cors',
+    },
+  };
+
+  const requestData3 = {
+    url: `${location.origin}/three`,
+    requestInit: {
+      mode: 'cors',
+    },
+  };
+
+  const requestData4 = {
+    url: `${location.origin}/four`,
+    requestInit: {
+      mode: 'cors',
+    },
+  };
+
+  const requestData5 = {
+    url: `${location.origin}/five`,
+    requestInit: {
+      mode: 'cors',
+    },
+  };
+
+  const entry1 = {
+    queueName: 'a',
+    requestData: requestData1,
+    timestamp: 1000,
+    metadata: {name: 'meta1'},
+  };
+
+  const entry2 = {
+    queueName: 'a',
+    requestData: requestData2,
+    timestamp: 2000,
+    metadata: {name: 'meta2'},
+  };
+
+  const entry3 = {
+    queueName: 'a',
+    requestData: requestData3,
+    timestamp: 3000,
+    metadata: {name: 'meta3'},
+  };
+
+  const entry4 = {
+    queueName: 'b',
+    requestData: requestData4,
+    timestamp: 4000,
+    metadata: {name: 'meta4'},
+  };
+
+  const entry5 = {
+    queueName: 'b',
+    requestData: requestData5,
+    timestamp: 5000,
+    metadata: {name: 'meta5'},
+  };
+
+  beforeEach(async () => {
+    db = await openDB('workbox-background-sync', 3, {
+      upgrade: QueueDb.prototype._upgradeDb,
+    });
+    await db.clear('requests');
+  });
+
+  describe(`_upgradeDb`, () => {
+    const v3Entry = {
+      queueName: 'a',
+      metadata: {
+        one: '1',
+        two: '2',
+      },
+      timestamp: 123,
+      requestData: {
+        url: `${location.origin}/one`,
+        requestInit: {
+          mode: 'cors',
+        },
+      },
+    };
+
+    it(`should handle upgrading from no previous version`, async () => {
+      const dbv3 = await openDB('workbox-background-sync-from-v3', 3, {
+        upgrade: QueueDb.prototype._upgradeDb,
+      });
+
+      let entries = await dbv3.getAll('requests');
+      expect(entries.length).to.equal(0);
+
+      await dbv3.add('requests', v3Entry);
+
+      entries = await dbv3.getAll('requests');
+      expect(entries[0].id).to.equal(1);
+      expect(entries[0].timestamp).to.equal(v3Entry.timestamp);
+      expect(entries[0].metadata).to.deep.equal(v3Entry.metadata);
+      expect(entries[0].queueName).to.equal(v3Entry.queueName);
+      expect(entries[0].requestData).to.deep.equal(v3Entry.requestData);
+
+      await deleteDB('workbox-background-sync-from-v3', {
+        blocked() {
+          dbv3.close();
+        },
+      });
+    });
+
+    it(`should handle upgrading from version 1`, async () => {
+      await deleteDB('workbox-background-sync-from-v1');
+
+      const dbv1 = await openDB('workbox-background-sync-from-v1', 1, {
+        upgrade(db) {
+          db.createObjectStore('requests', {
+            autoIncrement: true,
+          }).createIndex('queueName', 'queueName', {unique: false});
+        },
+      });
+
+      // Add entries in v1 format.
+      await dbv1.add('requests', {
+        queueName: 'a',
+        storableRequest: {
+          url: `${location.origin}/one`,
+          timestamp: 123,
+          requestInit: {
+            method: 'POST',
+            mode: 'cors',
+            headers: {
+              'x-foo': 'bar',
+              'x-qux': 'baz',
+            },
+          },
+        },
+      });
+      await dbv1.add('requests', {
+        queueName: 'b',
+        storableRequest: {
+          url: `${location.origin}/two`,
+          timestamp: 234,
+          requestInit: {
+            mode: 'cors',
+          },
+        },
+      });
+      await dbv1.add('requests', {
+        queueName: 'a',
+        storableRequest: {
+          url: `${location.origin}/three`,
+          timestamp: 345,
+          requestInit: {},
+        },
+      });
+
+      const dbv3 = await openDB('workbox-background-sync-from-v1', 3, {
+        upgrade: QueueDb.prototype._upgradeDb,
+        blocked() {
+          dbv1.close();
+        },
+      });
+
+      let entries = await dbv3.getAll('requests');
+      expect(entries.length).to.equal(0);
+
+      await dbv3.add('requests', v3Entry);
+
+      entries = await dbv3.getAll('requests');
+      expect(entries[0].id).to.equal(1);
+      expect(entries[0].timestamp).to.equal(v3Entry.timestamp);
+      expect(entries[0].metadata).to.deep.equal(v3Entry.metadata);
+      expect(entries[0].queueName).to.equal(v3Entry.queueName);
+      expect(entries[0].requestData).to.deep.equal(v3Entry.requestData);
+
+      await deleteDB('workbox-background-sync-from-v1', {
+        blocked() {
+          dbv3.close();
+        },
+      });
+    });
+
+    it(`should handle upgrading from version 2`, async () => {
+      await deleteDB('workbox-background-sync-from-v2');
+
+      const dbv2 = await openDB('workbox-background-sync-from-v2', 2, {
+        upgrade(db) {
+          db.createObjectStore('requests', {
+            autoIncrement: true,
+            keyPath: 'id',
+          }).createIndex('queueName', 'queueName', {unique: false});
+        },
+      });
+
+      // Add entries in v2 format.
+      await dbv2.add('requests', {
+        queueName: 'a',
+        metadata: {one: '1', two: '2'},
+        storableRequest: {
+          url: `${location.origin}/one`,
+          timestamp: 123,
+          requestInit: {
+            method: 'POST',
+            mode: 'cors',
+            headers: {
+              'x-foo': 'bar',
+              'x-qux': 'baz',
+            },
+          },
+        },
+      });
+      await dbv2.add('requests', {
+        queueName: 'b',
+        metadata: {three: '3', four: '4'},
+        storableRequest: {
+          url: `${location.origin}/two`,
+          timestamp: 234,
+          requestInit: {
+            mode: 'cors',
+          },
+        },
+      });
+
+      const dbv3 = await openDB('workbox-background-sync-from-v2', 3, {
+        upgrade: QueueDb.prototype._upgradeDb,
+        blocked() {
+          dbv2.close();
+        },
+      });
+
+      let entries = await dbv3.getAll('requests');
+      expect(entries.length).to.equal(0);
+
+      await dbv3.add('requests', v3Entry);
+
+      entries = await dbv3.getAll('requests');
+      expect(entries[0].id).to.equal(1);
+      expect(entries[0].timestamp).to.equal(v3Entry.timestamp);
+      expect(entries[0].metadata).to.deep.equal(v3Entry.metadata);
+      expect(entries[0].queueName).to.equal(v3Entry.queueName);
+      expect(entries[0].requestData).to.deep.equal(v3Entry.requestData);
+
+      await deleteDB('workbox-background-sync-from-v2', {
+        blocked() {
+          dbv3.close();
+        },
+      });
+    });
+  });
+
+  describe('getFirstEntry', () => {
+    it(`should return the first entry in the IBDObjectStore`, async () => {
+      const queueDb = new QueueDb();
+
+      await queueDb.addEntry(entry1);
+
+      const entries = await db.getAll('requests');
+      const firstId = entries[0].id;
+
+      await queueDb.addEntry(entry2);
+      await queueDb.addEntry(entry3);
+
+      const result = await queueDb.getFirstEntry();
+      expect(result).to.deep.equal({
+        id: firstId,
+        queueName: 'a',
+        requestData: requestData1,
+        timestamp: 1000,
+        metadata: {name: 'meta1'},
+      });
+    });
+  });
+
+  describe('getAllEntriesFromIndex', () => {
+    it(`should return all entries in IDB filtered by index`, async () => {
+      const queueDb = new QueueDb();
+
+      await queueDb.addEntry(entry1);
+
+      const entries = await db.getAll('requests');
+      const firstId = entries[0].id;
+
+      await queueDb.addEntry(entry2);
+      await queueDb.addEntry(entry3);
+      await queueDb.addEntry(entry4);
+      await queueDb.addEntry(entry5);
+
+      let results = await queueDb.getAllEntriesFromIndex(IDBKeyRange.only('b'));
+      expect(results).to.deep.equal([
+        {
+          id: firstId + 3,
+          queueName: 'b',
+          requestData: requestData4,
+          timestamp: 4000,
+          metadata: {name: 'meta4'},
+        },
+        {
+          id: firstId + 4,
+          queueName: 'b',
+          requestData: requestData5,
+          timestamp: 5000,
+          metadata: {name: 'meta5'},
+        },
+      ]);
+
+      results = await queueDb.getAllEntriesFromIndex(IDBKeyRange.only('a'));
+      expect(results).to.deep.equal([
+        {
+          id: firstId,
+          queueName: 'a',
+          requestData: requestData1,
+          timestamp: 1000,
+          metadata: {name: 'meta1'},
+        },
+        {
+          id: firstId + 1,
+          queueName: 'a',
+          requestData: requestData2,
+          timestamp: 2000,
+          metadata: {name: 'meta2'},
+        },
+        {
+          id: firstId + 2,
+          queueName: 'a',
+          requestData: requestData3,
+          timestamp: 3000,
+          metadata: {name: 'meta3'},
+        },
+      ]);
+
+      await db.clear('requests');
+
+      expect(await queueDb.getAllEntriesFromIndex(IDBKeyRange.only('a'))).to.deep.equal([]);
+      expect(await queueDb.getAllEntriesFromIndex(IDBKeyRange.only('b'))).to.deep.equal([]);
+    });
+  });
+
+  describe('deleteEntry', () => {
+    it(`should delete an entry for the given ID`, async () => {
+      const queueDb = new QueueDb();
+
+      await queueDb.addEntry(entry1);
+
+      const entries = await db.getAll('requests');
+      const firstId = entries[0].id;
+
+      await queueDb.addEntry(entry2);
+      await queueDb.addEntry(entry3);
+
+      await queueDb.deleteEntry(firstId + 1);
+
+      expect(await db.getAll('requests')).to.deep.equal([
+        {
+          id: firstId,
+          queueName: 'a',
+          requestData: requestData1,
+          timestamp: 1000,
+          metadata: {name: 'meta1'},
+        },
+        {
+          id: firstId + 2,
+          queueName: 'a',
+          requestData: requestData3,
+          timestamp: 3000,
+          metadata: {name: 'meta3'},
+        },
+      ]);
+    });
+  });
+
+
+  describe('deleteEntry', () => {
+    it(`should delete an entry for the given ID`, async () => {
+      const queueDb = new QueueDb();
+
+      await queueDb.addEntry(entry1);
+
+      const entries = await db.getAll('requests');
+      const firstId = entries[0].id;
+
+      await queueDb.addEntry(entry2);
+      await queueDb.addEntry(entry3);
+
+      await queueDb.deleteEntry(firstId + 1);
+
+      expect(await db.getAll('requests')).to.deep.equal([
+        {
+          id: firstId,
+          queueName: 'a',
+          requestData: requestData1,
+          timestamp: 1000,
+          metadata: {name: 'meta1'},
+        },
+        {
+          id: firstId + 2,
+          queueName: 'a',
+          requestData: requestData3,
+          timestamp: 3000,
+          metadata: {name: 'meta3'},
+        },
+      ]);
+    });
+  });
+
+  describe('addEntry', () => {
+    it(`Should add new entries`, async () => {
+      const queueDb = new QueueDb();
+
+      await queueDb.addEntry(entry1);
+
+      const entries = await db.getAll('requests');
+      const firstId = entries[0].id;
+
+      await queueDb.addEntry(entry3);
+
+      expect(await db.getAll('requests')).to.deep.equal([
+        {
+          id: firstId,
+          queueName: 'a',
+          requestData: requestData1,
+          timestamp: 1000,
+          metadata: {name: 'meta1'},
+        },
+        {
+          id: firstId + 1,
+          queueName: 'a',
+          requestData: requestData3,
+          timestamp: 3000,
+          metadata: {name: 'meta3'},
+        },
+      ]);
+    });
+  });
+
+  describe('getEndEntryFromIndex', () => {
+    it(`should return first entry in IDB filtered by index`, async () => {
+      const queueDb = new QueueDb();
+
+      await queueDb.addEntry(entry1);
+
+      const entries = await db.getAll('requests');
+      const firstId = entries[0].id;
+
+      await queueDb.addEntry(entry2);
+      await queueDb.addEntry(entry3);
+      await queueDb.addEntry(entry4);
+      await queueDb.addEntry(entry5);
+
+      let result = await queueDb.getEndEntryFromIndex({direction: 'next'}, IDBKeyRange.only('b'));
+      expect(result).to.deep.equal({
+        id: firstId + 3,
+        queueName: 'b',
+        requestData: requestData4,
+        timestamp: 4000,
+        metadata: {name: 'meta4'},
+      });
+
+      result = await queueDb.getEndEntryFromIndex({direction: 'next'}, IDBKeyRange.only('a'));
+      expect(result).to.deep.equal({
+        id: firstId,
+        queueName: 'a',
+        requestData: requestData1,
+        timestamp: 1000,
+        metadata: {name: 'meta1'},
+      });
+    });
+
+    it(`should return last entry in IDB filtered by index`, async () => {
+      const queueDb = new QueueDb();
+
+      await queueDb.addEntry(entry1);
+
+      const entries = await db.getAll('requests');
+      const firstId = entries[0].id;
+
+      await queueDb.addEntry(entry2);
+      await queueDb.addEntry(entry3);
+      await queueDb.addEntry(entry4);
+      await queueDb.addEntry(entry5);
+
+      let result = await queueDb.getEndEntryFromIndex({direction: 'prev'}, IDBKeyRange.only('b'));
+      expect(result).to.deep.equal({
+        id: firstId + 4,
+        queueName: 'b',
+        requestData: requestData5,
+        timestamp: 5000,
+        metadata: {name: 'meta5'},
+      });
+
+      result = await queueDb.getEndEntryFromIndex({direction: 'prev'}, IDBKeyRange.only('a'));
+      expect(result).to.deep.equal({
+        id: firstId + 2,
+        queueName: 'a',
+        requestData: requestData3,
+        timestamp: 3000,
+        metadata: {name: 'meta3'},
+      });
+
+      await db.clear('requests');
+
+      expect(await queueDb.getAllEntriesFromIndex(IDBKeyRange.only('a'))).to.deep.equal([]);
+      expect(await queueDb.getAllEntriesFromIndex(IDBKeyRange.only('b'))).to.deep.equal([]);
+    });
+  });
+});

--- a/test/workbox-background-sync/sw/lib/test-QueueStore.mjs
+++ b/test/workbox-background-sync/sw/lib/test-QueueStore.mjs
@@ -6,18 +6,18 @@
   https://opensource.org/licenses/MIT.
 */
 
-import {DBWrapper} from 'workbox-core/_private/DBWrapper.mjs';
-import {deleteDatabase} from 'workbox-core/_private/deleteDatabase.mjs';
 import {QueueStore} from 'workbox-background-sync/lib/QueueStore.mjs';
 import {StorableRequest} from 'workbox-background-sync/lib/StorableRequest.mjs';
-
+import {QueueDb} from 'workbox-background-sync/lib/QueueDb.mjs';
+import {openDB} from 'idb';
 
 describe(`QueueStore`, function() {
-  const db = new DBWrapper('workbox-background-sync', 3, {
-    onupgradeneeded: QueueStore.prototype._upgradeDb,
-  });
+  let db = null;
 
   beforeEach(async function() {
+    db = await openDB('workbox-background-sync', 3, {
+      upgrade: QueueDb.prototype._upgradeDb,
+    });
     await db.clear('requests');
   });
 
@@ -25,171 +25,6 @@ describe(`QueueStore`, function() {
     it(`should associate the queue name with a Queue instance`, function() {
       const queueStore = new QueueStore('foo');
       expect(queueStore._queueName).to.equal('foo');
-    });
-
-    it(`should create a DBWrapper instance that references the _upgradeDb method`, function() {
-      const queueStore = new QueueStore('foo');
-      expect(queueStore._db._onupgradeneeded).to.equal(queueStore._upgradeDb);
-    });
-  });
-
-  describe(`_upgradeDb`, function() {
-    const v3Entry = {
-      queueName: 'a',
-      metadata: {
-        one: '1',
-        two: '2',
-      },
-      timestamp: 123,
-      requestData: {
-        url: `${location.origin}/one`,
-        requestInit: {
-          mode: 'cors',
-        },
-      },
-    };
-
-    it(`should handle upgrading from no previous version`, async function() {
-      const dbv3 = new DBWrapper('workbox-background-sync-from-v3', 3, {
-        onupgradeneeded: QueueStore.prototype._upgradeDb,
-      });
-
-      let entries = await dbv3.getAll('requests');
-      expect(entries.length).to.equal(0);
-
-      await dbv3.add('requests', v3Entry);
-
-      entries = await dbv3.getAll('requests');
-      expect(entries[0].id).to.equal(1);
-      expect(entries[0].timestamp).to.equal(v3Entry.timestamp);
-      expect(entries[0].metadata).to.deep.equal(v3Entry.metadata);
-      expect(entries[0].queueName).to.equal(v3Entry.queueName);
-      expect(entries[0].requestData).to.deep.equal(v3Entry.requestData);
-
-      await deleteDatabase('workbox-background-sync-from-v3');
-    });
-
-    it(`should handle upgrading from version 1`, async function() {
-      await deleteDatabase('workbox-background-sync-from-v1');
-
-      const dbv1 = new DBWrapper('workbox-background-sync-from-v1', 1, {
-        onupgradeneeded: (event) => event.target.result
-            .createObjectStore('requests', {autoIncrement: true})
-            .createIndex('queueName', 'queueName', {unique: false}),
-      });
-
-      // Add entries in v1 format.
-      await dbv1.add('requests', {
-        queueName: 'a',
-        storableRequest: {
-          url: `${location.origin}/one`,
-          timestamp: 123,
-          requestInit: {
-            method: 'POST',
-            mode: 'cors',
-            headers: {
-              'x-foo': 'bar',
-              'x-qux': 'baz',
-            },
-          },
-        },
-      });
-      await dbv1.add('requests', {
-        queueName: 'b',
-        storableRequest: {
-          url: `${location.origin}/two`,
-          timestamp: 234,
-          requestInit: {
-            mode: 'cors',
-          },
-        },
-      });
-      await dbv1.add('requests', {
-        queueName: 'a',
-        storableRequest: {
-          url: `${location.origin}/three`,
-          timestamp: 345,
-          requestInit: {},
-        },
-      });
-
-      const dbv3 = new DBWrapper('workbox-background-sync-from-v1', 3, {
-        onupgradeneeded: QueueStore.prototype._upgradeDb,
-      });
-
-      let entries = await dbv3.getAll('requests');
-      expect(entries.length).to.equal(0);
-
-      await dbv3.add('requests', v3Entry);
-
-      entries = await dbv3.getAll('requests');
-      expect(entries[0].id).to.equal(1);
-      expect(entries[0].timestamp).to.equal(v3Entry.timestamp);
-      expect(entries[0].metadata).to.deep.equal(v3Entry.metadata);
-      expect(entries[0].queueName).to.equal(v3Entry.queueName);
-      expect(entries[0].requestData).to.deep.equal(v3Entry.requestData);
-
-      await deleteDatabase('workbox-background-sync-from-v2');
-    });
-
-    it(`should handle upgrading from version 2`, async function() {
-      await deleteDatabase('workbox-background-sync-from-v2');
-
-      const dbv2 = new DBWrapper('workbox-background-sync-from-v2', 2, {
-        onupgradeneeded: (event) => event.target.result
-            .createObjectStore('requests', {
-              autoIncrement: true,
-              keyPath: 'id',
-            })
-            .createIndex('queueName', 'queueName', {unique: false}),
-      });
-
-      // Add entries in v2 format.
-      await dbv2.add('requests', {
-        queueName: 'a',
-        metadata: {one: '1', two: '2'},
-        storableRequest: {
-          url: `${location.origin}/one`,
-          timestamp: 123,
-          requestInit: {
-            method: 'POST',
-            mode: 'cors',
-            headers: {
-              'x-foo': 'bar',
-              'x-qux': 'baz',
-            },
-          },
-        },
-      });
-      await dbv2.add('requests', {
-        queueName: 'b',
-        metadata: {three: '3', four: '4'},
-        storableRequest: {
-          url: `${location.origin}/two`,
-          timestamp: 234,
-          requestInit: {
-            mode: 'cors',
-          },
-        },
-      });
-
-      const dbv3 = new DBWrapper('workbox-background-sync-from-v2', 3, {
-        onupgradeneeded: QueueStore.prototype._upgradeDb,
-      });
-
-      let entries = await dbv3.getAll('requests');
-      expect(entries.length).to.equal(0);
-
-      await dbv3.add('requests', v3Entry);
-
-      entries = await dbv3.getAll('requests');
-      expect(entries[0].id).to.equal(1);
-      expect(entries[0].timestamp).to.equal(v3Entry.timestamp);
-      expect(entries[0].metadata).to.deep.equal(v3Entry.metadata);
-      expect(entries[0].queueName).to.equal(v3Entry.queueName);
-      expect(entries[0].requestData).to.deep.equal(v3Entry.requestData);
-
-      await deleteDatabase('workbox-background-sync-from-v2');
     });
   });
 
@@ -611,55 +446,6 @@ describe(`QueueStore`, function() {
 
       expect(await queueStore1.getAll()).to.deep.equal([]);
       expect(await queueStore2.getAll()).to.deep.equal([]);
-    });
-  });
-
-  describe(`delete`, function() {
-    it(`should delete an entry for the given ID`, async function() {
-      const queueStore = new QueueStore('a');
-
-      const sr1 = await StorableRequest.fromRequest(new Request('/one'));
-      const sr2 = await StorableRequest.fromRequest(new Request('/two'));
-      const sr3 = await StorableRequest.fromRequest(new Request('/three'));
-
-      await queueStore.pushEntry({
-        requestData: sr1.toObject(),
-        timestamp: 1000,
-        metadata: {name: 'meta1'},
-      });
-
-      const entries = await db.getAll('requests');
-      const firstId = entries[0].id;
-
-      await queueStore.pushEntry({
-        requestData: sr2.toObject(),
-        timestamp: 2000,
-        metadata: {name: 'meta2'},
-      });
-      await queueStore.pushEntry({
-        requestData: sr3.toObject(),
-        timestamp: 3000,
-        metadata: {name: 'meta3'},
-      });
-
-      await queueStore.deleteEntry(firstId + 1);
-
-      expect(await db.getAll('requests')).to.deep.equal([
-        {
-          id: firstId,
-          queueName: 'a',
-          requestData: sr1.toObject(),
-          timestamp: 1000,
-          metadata: {name: 'meta1'},
-        },
-        {
-          id: firstId + 2,
-          queueName: 'a',
-          requestData: sr3.toObject(),
-          timestamp: 3000,
-          metadata: {name: 'meta3'},
-        },
-      ]);
     });
   });
 });

--- a/test/workbox-background-sync/sw/test-Queue.mjs
+++ b/test/workbox-background-sync/sw/test-Queue.mjs
@@ -7,23 +7,23 @@
 */
 
 import {Queue} from 'workbox-background-sync/Queue.mjs';
+import {QueueDb} from 'workbox-background-sync/lib/QueueDb.mjs';
+import {openDB} from 'idb';
 import {QueueStore} from 'workbox-background-sync/lib/QueueStore.mjs';
-import {DBWrapper} from 'workbox-core/_private/DBWrapper.mjs';
 import {logger} from 'workbox-core/_private/logger.mjs';
 import {dispatchAndWaitUntilDone} from '../../../infra/testing/helpers/extendable-event-utils.mjs';
 
-
 const MINUTES = 60 * 1000;
-
 
 describe(`Queue`, function() {
   const sandbox = sinon.createSandbox();
-  const db = new DBWrapper('workbox-background-sync', 3, {
-    onupgradeneeded: QueueStore.prototype._upgradeDb,
-  });
+  let db = null;
 
   beforeEach(async function() {
     Queue._queueNames.clear();
+    db = await openDB('workbox-background-sync', 3, {
+      upgrade: QueueDb.prototype._upgradeDb,
+    });
     await db.clear('requests');
     sandbox.restore();
 


### PR DESCRIPTION
This is the first part of #2801 
I created a new class to interact with IDB, to manage the queues in workbox-background-sync. This new class encapsulates details like the object store name and index, as well as the types the DB should manage.
