### PR TITLE
fetch() stubs in Google Analytics tests

### DIFF
--- a/test/workbox-google-analytics/sw/test-initialize.mjs
+++ b/test/workbox-google-analytics/sw/test-initialize.mjs
@@ -149,7 +149,6 @@ describe(`initialize`, function() {
   it(`should register GET/POST routes for collect endpoints`, async function() {
     // Stub out fetch(), since this test is about routing, and doesn't need to
     // contact the production Google Analytics endpoints.
-    // (This also works around some unresolved issues in Chrome 90+.)
     sandbox.stub(self, 'fetch').callsFake(() => new Response('ignored'));
 
     sandbox.spy(NetworkOnly.prototype, 'handle');
@@ -227,7 +226,6 @@ describe(`initialize`, function() {
   it(`should not alter hit paths`, async function() {
     // Stub out fetch(), since this test is about routing, and doesn't need to
     // contact the production Google Analytics endpoints.
-    // (This also works around some unresolved issues in Chrome 90+.)
     sandbox.stub(self, 'fetch').callsFake(() => new Response('ignored'));
 
     initialize();

--- a/test/workbox-google-analytics/sw/test-initialize.mjs
+++ b/test/workbox-google-analytics/sw/test-initialize.mjs
@@ -195,7 +195,9 @@ describe(`initialize`, function() {
   });
 
   it(`should not alter successful hit payloads`, async function() {
-    sandbox.spy(self, 'fetch');
+    // Stub out fetch(), since this test is about routing, and doesn't need to
+    // contact the production Google Analytics endpoints.
+    sandbox.stub(self, 'fetch').callsFake(() => new Response('ignored'));
 
     initialize();
 

--- a/test/workbox-google-analytics/sw/test-initialize.mjs
+++ b/test/workbox-google-analytics/sw/test-initialize.mjs
@@ -147,6 +147,11 @@ describe(`initialize`, function() {
   });
 
   it(`should register GET/POST routes for collect endpoints`, async function() {
+    // Stub out fetch(), since this test is about routing, and doesn't need to
+    // contact the production Google Analytics endpoints.
+    // (This also works around some unresolved issues in Chrome 90+.)
+    sandbox.stub(self, 'fetch').callsFake(() => new Response('ignored'));
+
     sandbox.spy(NetworkOnly.prototype, 'handle');
 
     initialize();
@@ -220,7 +225,10 @@ describe(`initialize`, function() {
   });
 
   it(`should not alter hit paths`, async function() {
-    sandbox.spy(self, 'fetch');
+    // Stub out fetch(), since this test is about routing, and doesn't need to
+    // contact the production Google Analytics endpoints.
+    // (This also works around some unresolved issues in Chrome 90+.)
+    sandbox.stub(self, 'fetch').callsFake(() => new Response('ignored'));
 
     initialize();
 


### PR DESCRIPTION
R: @tropicadri

This kind of papers over the issue we were seeing with the `workbox-google-analytics` tests in Chrome, but at the same time, making real requests to Google Analytics URLs in order to test routing isn't necessary.
