### PR TITLE
Update demos from 5.1.2 to 6.1.5

### DIFF
--- a/demos/src/workbox-background-sync-demo/sw.js
+++ b/demos/src/workbox-background-sync-demo/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 // Note: Ignore the error that Glitch raises about workbox being undefined.
 workbox.setConfig({

--- a/demos/src/workbox-broadcast-update-demo/sw.js
+++ b/demos/src/workbox-broadcast-update-demo/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 workbox.setConfig({
   debug: true,

--- a/demos/src/workbox-cacheable-response/sw.js
+++ b/demos/src/workbox-cacheable-response/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 workbox.setConfig({
   debug: true,

--- a/demos/src/workbox-core/sw.js
+++ b/demos/src/workbox-core/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 // Note: Ignore the error that Glitch raises about workbox being undefined.
 workbox.setConfig({

--- a/demos/src/workbox-expiration/sw.js
+++ b/demos/src/workbox-expiration/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 // Note: Ignore the error that Glitch raises about workbox being undefined.
 workbox.setConfig({

--- a/demos/src/workbox-google-analytics/sw.js
+++ b/demos/src/workbox-google-analytics/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 workbox.setConfig({
   debug: true,

--- a/demos/src/workbox-navigation-preload/sw.js
+++ b/demos/src/workbox-navigation-preload/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 workbox.setConfig({
   debug: true,

--- a/demos/src/workbox-precaching/sw-1.js
+++ b/demos/src/workbox-precaching/sw-1.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 workbox.setConfig({
   debug: true,

--- a/demos/src/workbox-precaching/sw-2.js
+++ b/demos/src/workbox-precaching/sw-2.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 workbox.setConfig({
   debug: true,

--- a/demos/src/workbox-range-requests/sw.js
+++ b/demos/src/workbox-range-requests/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 workbox.setConfig({
   debug: true,

--- a/demos/src/workbox-routing/sw.js
+++ b/demos/src/workbox-routing/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 workbox.setConfig({
   debug: true,

--- a/demos/src/workbox-strategies/sw.js
+++ b/demos/src/workbox-strategies/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 // To avoid async issues, we load strategies before we call it in the event listener
 workbox.loadModule('workbox-strategies');
 // Note: Ignore the error that Glitch raises about workbox being undefined.

--- a/demos/src/workbox-streams/sw.js
+++ b/demos/src/workbox-streams/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 workbox.setConfig({
   debug: true,

--- a/demos/src/workbox-sw/sw.js
+++ b/demos/src/workbox-sw/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 // Note: Ignore the error that Glitch raises about workbox being undefined.
 workbox.setConfig({

--- a/demos/src/workbox-window/sw.js
+++ b/demos/src/workbox-window/sw.js
@@ -1,4 +1,4 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.1.5/workbox-sw.js');
 
 workbox.setConfig({
   debug: true,


### PR DESCRIPTION
R: @tropicadri

Fixes #2701

There's a [deployment script](https://github.com/GoogleChrome/workbox/blob/v6/gulp-tasks/publish-glitch.js) to update the Glitch projects following this change.