### PR TITLE
Initialize StaleWhileRevalidate's options to {} when unset

### DIFF
--- a/packages/workbox-strategies/src/StaleWhileRevalidate.ts
+++ b/packages/workbox-strategies/src/StaleWhileRevalidate.ts
@@ -52,7 +52,7 @@ class StaleWhileRevalidate extends Strategy {
    * `fetch()` requests made by this strategy.
    * @param {Object} [options.matchOptions] [`CacheQueryOptions`](https://w3c.github.io/ServiceWorker/#dictdef-cachequeryoptions)
    */
-  constructor(options: StrategyOptions) {
+  constructor(options: StrategyOptions = {}) {
     super(options);
 
     // If this instance contains no plugins with a 'cacheWillUpdate' callback,


### PR DESCRIPTION
R: @tropicadri
CC: @SimonSiefke

Fixes #2844

This should be functionally equivalent to the current codebase (where `{}` is used as the default value in the [`Strategy` base class](https://github.com/GoogleChrome/workbox/blob/bbaa0bb5bc7830543be4f170d108842dd1f19e01/packages/workbox-strategies/src/Strategy.ts#L65)) and is an alternative to just marking `options` as optional. Given that the other `Strategy` subclasses all [follow the pattern](https://github.com/GoogleChrome/workbox/blob/bbaa0bb5bc7830543be4f170d108842dd1f19e01/packages/workbox-strategies/src/NetworkFirst.ts#L62) of providing a default initialization to `{}` within their own constructors, I'm going with this approach to match.
