### PR TITLE
Fix quotation chars when eval-cheap-source-map is used

### DIFF
--- a/infra/testing/validator/service-worker-runtime.js
+++ b/infra/testing/validator/service-worker-runtime.js
@@ -198,7 +198,9 @@ module.exports = async ({
 
   vm.runInNewContext(swString, context);
 
-  validateMethodCalls({methodsToSpies, expectedMethodCalls, context});
+  if (expectedMethodCalls) {
+    validateMethodCalls({methodsToSpies, expectedMethodCalls, context});
+  }
 
   // Optionally check the usage of addEventListener().
   if (addEventListenerValidation) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10867,7 +10867,8 @@
     "idb": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/idb/-/idb-6.0.0.tgz",
-      "integrity": "sha512-+M367poGtpzAylX4pwcrZIa7cFQLfNkAOlMMLN2kw/2jGfJP6h+TB/unQNSVYwNtP8XqkLYrfuiVnxLQNP1tjA=="
+      "integrity": "sha512-+M367poGtpzAylX4pwcrZIa7cFQLfNkAOlMMLN2kw/2jGfJP6h+TB/unQNSVYwNtP8XqkLYrfuiVnxLQNP1tjA==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   },
   "scripts": {
     "version": "gulp build && git add -A packages",
-    "gulp": "gulp", 
+    "gulp": "gulp",
     "build": "gulp build",
     "lint": "gulp lint",
-    "test_server" : "gulp test_server",
+    "test_server": "gulp test_server",
     "test_node": "gulp test_node",
     "test_integration": "gulp test_integration"
   },

--- a/packages/workbox-expiration/package-lock.json
+++ b/packages/workbox-expiration/package-lock.json
@@ -8,11 +8,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/idb/-/idb-6.0.0.tgz",
       "integrity": "sha512-+M367poGtpzAylX4pwcrZIa7cFQLfNkAOlMMLN2kw/2jGfJP6h+TB/unQNSVYwNtP8XqkLYrfuiVnxLQNP1tjA=="
-    },
-    "workbox-core": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.1.5.tgz",
-      "integrity": "sha512-9SOEle7YcJzg3njC0xMSmrPIiFjfsFm9WjwGd5enXmI8Lwk8wLdy63B0nzu5LXoibEmS9k+aWF8EzaKtOWjNSA=="
     }
   }
 }

--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -316,7 +316,7 @@ class InjectManifest {
     const {size, sortedEntries} = await getManifestEntriesFromCompilation(
         compilation, config);
 
-    let manifestString = stringify(sortedEntries);  
+    let manifestString = stringify(sortedEntries);
     if (this.config.compileSrc &&
       // See https://github.com/GoogleChrome/workbox/issues/2729
       // (TODO: Switch to ?. once our linter supports it.)

--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -319,8 +319,11 @@ class InjectManifest {
     let manifestString = stringify(sortedEntries);  
     if (this.config.compileSrc &&
       // See https://github.com/GoogleChrome/workbox/issues/2729
-      !(compilation.options?.devtool === 'eval-cheap-source-map' &&
-        compilation.options?.optimization?.minimize)
+      // (TODO: Switch to ?. once our linter supports it.)
+      !(compilation.options &&
+        compilation.options.devtool === 'eval-cheap-source-map' &&
+        compilation.options.optimization &&
+        compilation.options.optimization.minimize)
     ) {
       // See https://github.com/GoogleChrome/workbox/issues/2263
       manifestString = manifestString.replace(/"/g, `'`);

--- a/packages/workbox-webpack-plugin/src/inject-manifest.js
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.js
@@ -316,8 +316,12 @@ class InjectManifest {
     const {size, sortedEntries} = await getManifestEntriesFromCompilation(
         compilation, config);
 
-    let manifestString = stringify(sortedEntries);
-    if (this.config.compileSrc) {
+    let manifestString = stringify(sortedEntries);  
+    if (this.config.compileSrc &&
+      // See https://github.com/GoogleChrome/workbox/issues/2729
+      !(compilation.options?.devtool === 'eval-cheap-source-map' &&
+        compilation.options?.optimization?.minimize)
+    ) {
       // See https://github.com/GoogleChrome/workbox/issues/2263
       manifestString = manifestString.replace(/"/g, `'`);
     }

--- a/test/workbox-webpack-plugin/node/v5/inject-manifest.js
+++ b/test/workbox-webpack-plugin/node/v5/inject-manifest.js
@@ -694,6 +694,100 @@ describe(`[workbox-webpack-plugin] InjectManifest with webpack v5`, function() {
         }
       });
     });
+
+    // See https://github.com/GoogleChrome/workbox/issues/2729
+    it(`should produce valid JavaScript when eval-cheap-source-map and minimization are used`, function(done) {
+      const outputDir = tempy.directory();
+
+      const config = {
+        mode: 'development',
+        entry: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        output: {
+          filename: WEBPACK_ENTRY_FILENAME,
+          path: outputDir,
+        },
+        devtool: 'eval-cheap-source-map',
+        optimization: {
+          minimize: true,
+        },
+        plugins: [
+          new InjectManifest({
+            swSrc: upath.join(__dirname, '..', '..', 'static', 'module-import-sw.js'),
+            swDest: 'service-worker.js',
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError, stats) => {
+        const swFile = upath.join(outputDir, 'service-worker.js');
+        try {
+          webpackBuildCheck(webpackError, stats);
+
+          const files = await globby('**', {cwd: outputDir});
+          expect(files).to.have.length(4);
+
+          await validateServiceWorkerRuntime({
+            swFile,
+            entryPoint: 'injectManifest',
+            // We can't verify expectedMethodCalls here, since we're using
+            // a compiled ES module import, not the workbox-sw interfaces.
+            // This test just confirms that the compilation produces valid JS.
+          });
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+
+    // See https://github.com/GoogleChrome/workbox/issues/2729
+    it(`should produce valid JavaScript when eval-cheap-source-map is used without minimization`, function(done) {
+      const outputDir = tempy.directory();
+
+      const config = {
+        mode: 'development',
+        entry: upath.join(SRC_DIR, WEBPACK_ENTRY_FILENAME),
+        output: {
+          filename: WEBPACK_ENTRY_FILENAME,
+          path: outputDir,
+        },
+        devtool: 'eval-cheap-source-map',
+        optimization: {
+          minimize: false,
+        },
+        plugins: [
+          new InjectManifest({
+            swSrc: upath.join(__dirname, '..', '..', 'static', 'module-import-sw.js'),
+            swDest: 'service-worker.js',
+          }),
+        ],
+      };
+
+      const compiler = webpack(config);
+      compiler.run(async (webpackError, stats) => {
+        const swFile = upath.join(outputDir, 'service-worker.js');
+        try {
+          webpackBuildCheck(webpackError, stats);
+
+          const files = await globby('**', {cwd: outputDir});
+          expect(files).to.have.length(2);
+
+          await validateServiceWorkerRuntime({
+            swFile,
+            entryPoint: 'injectManifest',
+            // We can't verify expectedMethodCalls here, since we're using
+            // a compiled ES module import, not the workbox-sw interfaces.
+            // This test just confirms that the compilation produces valid JS.
+          });
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
   });
 
   describe(`[workbox-webpack-plugin] Filtering via include/exclude`, function() {

--- a/test/workbox-webpack-plugin/static/module-import-sw.js
+++ b/test/workbox-webpack-plugin/static/module-import-sw.js
@@ -1,0 +1,11 @@
+/*
+  Copyright 2018 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import {precacheAndRoute} from '../../../packages/workbox-precaching';
+
+precacheAndRoute(self.__WB_MANIFEST);


### PR DESCRIPTION
R: @tropicadri

Fixes #2729

Because `InjectManifest` adds JSON serialized data to compiled JavaScript files, it can sometimes lead to invalid JavaScript if the compiled JS is itself wrapped in a string—that's what can happen in various `webpack` sourcemap modes.

In some modes, the string that it's wrapped in is terminated with `"` characters, so the serialized JSON needs to use `'`. In other modes, apparently, the string it's wrapped in is terminated with `'` characters, so the serialized JSON needs to use `"`. This PR accounts for one of those modes, which only happens when `eval-cheap-source-map` and minimization are used.

(This PR also picked up a few changes to `package.json` and `package-lock.json` files that appear not to have been committed following the previous PR.)