### PR TITLE
Fire controlling event more than once (#2817)

### DIFF
--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -189,7 +189,7 @@ class Workbox extends WorkboxEventTarget {
 
     this._registration.addEventListener('updatefound', this._onUpdateFound);
     navigator.serviceWorker.addEventListener(
-        'controllerchange', this._onControllerChange, {once: true});
+        'controllerchange', this._onControllerChange);
 
     return this._registration;
   }

--- a/test/workbox-window/integration/test-all.js
+++ b/test/workbox-window/integration/test-all.js
@@ -250,7 +250,7 @@ describe(`[workbox-window] Workbox`, function() {
 
       expect(installedSpyArgs[0][0].isExternal).to.eql(false);
       expect(activatedSpyArgs[0][0].isExternal).to.eql(false);
-      expect(controllingSpyArgs[1][0].isExternal).to.eql(true);
+      expect(controllingSpyArgs[0][0].isExternal).to.eql(false);
       expect(installedSpyArgs[1][0].isExternal).to.eql(true);
       expect(activatedSpyArgs[1][0].isExternal).to.eql(true);
       expect(controllingSpyArgs[1][0].isExternal).to.eql(true);

--- a/test/workbox-window/integration/test-all.js
+++ b/test/workbox-window/integration/test-all.js
@@ -246,12 +246,14 @@ describe(`[workbox-window] Workbox`, function() {
       expect(installedSpyArgs.length, 'installedSpy').to.eql(2);
       expect(waitingSpyArgs.length, 'waitingSpy').to.eql(0);
       expect(activatedSpyArgs.length, 'activatedSpy').to.eql(2);
-      expect(controllingSpyArgs.length, 'controllingSpy').to.eql(1);
+      expect(controllingSpyArgs.length, 'controllingSpy').to.eql(2);
 
       expect(installedSpyArgs[0][0].isExternal).to.eql(false);
       expect(activatedSpyArgs[0][0].isExternal).to.eql(false);
+      expect(controllingSpyArgs[1][0].isExternal).to.eql(true);
       expect(installedSpyArgs[1][0].isExternal).to.eql(true);
       expect(activatedSpyArgs[1][0].isExternal).to.eql(true);
+      expect(controllingSpyArgs[1][0].isExternal).to.eql(true);
     });
   });
 });

--- a/test/workbox-window/window/test-Workbox.mjs
+++ b/test/workbox-window/window/test-Workbox.mjs
@@ -844,9 +844,17 @@ describe(`[workbox-window] Workbox`, function() {
         // the first time a page registers a SW). This case is tested in the
         // integration tests.
 
-        expect(controlling1Spy.callCount).to.equal(1);
+        expect(controlling1Spy.callCount).to.equal(2);
         assertMatchesWorkboxEvent(controlling1Spy.args[0][0], {
           isExternal: false,
+          isUpdate: true,
+          originalEvent: {type: 'controllerchange'},
+          sw: await wb1.getSW(),
+          target: wb1,
+          type: 'controlling',
+        });
+        assertMatchesWorkboxEvent(controlling1Spy.args[1][0], {
+          isExternal: true,
           isUpdate: true,
           originalEvent: {type: 'controllerchange'},
           sw: await wb1.getSW(),
@@ -869,6 +877,51 @@ describe(`[workbox-window] Workbox`, function() {
           originalEvent: {type: 'controllerchange'},
           sw: await wb3.getSW(),
           target: wb3,
+          type: 'controlling',
+        });
+      });
+
+      it(`runs every time the registered SW is updated`, async function() {
+        const scriptURL = uniq('sw-skip-waiting.js.njk');
+        const wb1 = new Workbox(scriptURL);
+        const controlling1Spy = sandbox.spy();
+        wb1.addEventListener('controlling', controlling1Spy);
+        await wb1.register();
+        await nextEvent(wb1, 'controlling');
+
+        await updateVersion('2.0.0', scriptURL);
+
+        wb1.update();
+        await nextEvent(wb1, 'controlling');
+
+        await updateVersion('3.0.0', scriptURL);
+
+        wb1.update();
+        await nextEvent(wb1, 'controlling');
+
+        expect(controlling1Spy.callCount).to.equal(3);
+        assertMatchesWorkboxEvent(controlling1Spy.args[0][0], {
+          isExternal: false,
+          isUpdate: true,
+          originalEvent: {type: 'controllerchange'},
+          sw: await wb1.getSW(),
+          target: wb1,
+          type: 'controlling',
+        });
+        assertMatchesWorkboxEvent(controlling1Spy.args[1][0], {
+          isExternal: true,
+          isUpdate: true,
+          originalEvent: {type: 'controllerchange'},
+          sw: await wb1.getSW(),
+          target: wb1,
+          type: 'controlling',
+        });
+        assertMatchesWorkboxEvent(controlling1Spy.args[2][0], {
+          isExternal: true,
+          isUpdate: true,
+          originalEvent: {type: 'controllerchange'},
+          sw: await wb1.getSW(),
+          target: wb1,
           type: 'controlling',
         });
       });


### PR DESCRIPTION
R: @jeffposnick @tropicadri

Fixes #2817

*Description of what's changed/fixed.*
Dispatches the `controlling` event every time the documentation specifies that it should.