### PR TITLE
fix: Add `matchOptions` to `runtimeCaching.options.expiration` scheme

### DIFF
--- a/packages/workbox-build/src/options/partials/generate.js
+++ b/packages/workbox-build/src/options/partials/generate.js
@@ -70,6 +70,7 @@ module.exports = {
         maxEntries: joi.number().min(1),
         maxAgeSeconds: joi.number().min(1),
         purgeOnQuotaError: joi.boolean().default(defaults.purgeOnQuotaError),
+        matchOptions: joi.object(),
       }).or('maxEntries', 'maxAgeSeconds'),
       networkTimeoutSeconds: joi.number().min(1),
       plugins: joi.array().items(joi.object()),


### PR DESCRIPTION
**Prior to filing a PR, please:**
- [open an issue](https://github.com/GoogleChrome/workbox/issues/new) to discuss your proposed change.
- ensure that `gulp build && gulp lint test` passes locally.

R: @jeffposnick @tropicadri

Fixes #2864

*Description of what's changed/fixed.*
Add `matchOptions` to `runtimeCaching.options.expiration` scheme