### PR TITLE
Remove default from the export statement

### DIFF
--- a/packages/workbox-build/src/index.ts
+++ b/packages/workbox-build/src/index.ts
@@ -16,7 +16,7 @@ import {injectManifest} from './inject-manifest';
 /**
  * @module workbox-build
  */
-export default {
+export {
   copyWorkboxLibraries,
   generateSW,
   getManifest,

--- a/packages/workbox-cli/src/app.ts
+++ b/packages/workbox-cli/src/app.ts
@@ -12,7 +12,7 @@ import GlobWatcher from 'glob-watcher';
 import meow from 'meow';
 import prettyBytes from 'pretty-bytes';
 import upath from 'upath';
-import workboxBuild from 'workbox-build';
+import * as workboxBuild from 'workbox-build';
 
 import {constants} from './lib/constants.js';
 import {errors} from './lib/errors.js';

--- a/test/workbox-cli/node/app.js
+++ b/test/workbox-cli/node/app.js
@@ -135,11 +135,9 @@ describe(`[workbox-cli] app.js`, function() {
             },
           },
           'workbox-build': {
-            default: {
-              [command]: (config) => {
-                expect(config).to.eql(PROXIED_CONFIG);
-                throw PROXIED_ERROR;
-              },
+            [command]: (config) => {
+              expect(config).to.eql(PROXIED_CONFIG);
+              throw PROXIED_ERROR;
             },
           },
         });
@@ -167,10 +165,8 @@ describe(`[workbox-cli] app.js`, function() {
             },
           },
           'workbox-build': {
-            default: {
-              [command]: () => {
-                return WORKBOX_BUILD_NO_WARNINGS_RETURN_VALUE;
-              },
+            [command]: () => {
+              return WORKBOX_BUILD_NO_WARNINGS_RETURN_VALUE;
             },
           },
         });
@@ -195,11 +191,9 @@ describe(`[workbox-cli] app.js`, function() {
               warn: loggerWarningStub,
             },
           },
-          'workbox-build': {
-            default: {
-              [command]: () => {
-                return WORKBOX_BUILD_WITH_WARNINGS_RETURN_VALUE;
-              },
+          'workbox-build': {      
+            [command]: () => {
+              return WORKBOX_BUILD_WITH_WARNINGS_RETURN_VALUE;
             },
           },
         });
@@ -226,10 +220,8 @@ describe(`[workbox-cli] app.js`, function() {
             },
           },
           'workbox-build': {
-            default: {
-              [command]: () => {
-                return WORKBOX_BUILD_NO_WARNINGS_RETURN_VALUE;
-              },
+            [command]: () => {
+              return WORKBOX_BUILD_NO_WARNINGS_RETURN_VALUE;
             },
           },
         });
@@ -248,11 +240,9 @@ describe(`[workbox-cli] app.js`, function() {
           },
         },
         'workbox-build': {
-          default: {
-            copyWorkboxLibraries: (destDir) => {
-              expect(destDir).to.eql(PROXIED_DEST_DIR);
-              return upath.join(destDir, 'workbox');
-            },
+          copyWorkboxLibraries: (destDir) => {
+            expect(destDir).to.eql(PROXIED_DEST_DIR);
+            return upath.join(destDir, 'workbox');
           },
         },
       });


### PR DESCRIPTION
R: @tropicadri

We actually want all those properties to be exported directly by name, not wrapped by `default`.