### PR TITLE
Temporarily disable lint_ts

### DIFF
--- a/gulp-tasks/lint.js
+++ b/gulp-tasks/lint.js
@@ -28,5 +28,6 @@ async function lint_ts() {
 module.exports = {
   lint_js,
   lint_ts,
-  lint: parallel(lint_js, lint_ts),
+  // Temporarily disable lint_ts until we upgrade our ESLint dependencies.
+  lint: parallel(lint_js /* , lint_ts */ ),
 };

--- a/test/workbox-cli/node/app.js
+++ b/test/workbox-cli/node/app.js
@@ -191,7 +191,7 @@ describe(`[workbox-cli] app.js`, function() {
               warn: loggerWarningStub,
             },
           },
-          'workbox-build': {      
+          'workbox-build': {
             [command]: () => {
               return WORKBOX_BUILD_WITH_WARNINGS_RETURN_VALUE;
             },


### PR DESCRIPTION
R: @tropicadri

Turns off `lint_ts` until we get the ESLint dependencies updated.