### PR TITLE
Export WorkboxEventMap from workbox-window

### DIFF
--- a/packages/workbox-window/src/index.ts
+++ b/packages/workbox-window/src/index.ts
@@ -8,13 +8,15 @@
 
 import {messageSW} from './messageSW.js';
 import {Workbox} from './Workbox.js';
-import './_version.js';
+import {WorkboxEventMap} from './utils/WorkboxEvent.js';
 
+import './_version.js';
 
 /**
  * @module workbox-window
  */
 export {
-  Workbox,
   messageSW,
+  Workbox,
+  WorkboxEventMap,
 };


### PR DESCRIPTION
R: @tropicadri
CC: @ivandotv

Fixes #2860

Exporting the existing event mapping seemed cleaner than exporting a bunch of events directly alongside the other symbols.

This should allow for use cases like:

```
import {Workbox, WorkboxEventMap} from 'workbox-window';

const handleWaiting = (event: WorkboxEventMap['waiting']) => {
  // ...
};

const wb = new Workbox('sw.js');
wb.addEventListener('waiting', handleWaiting);
```