### PR TITLE
TrustedScriptURL support for workbox-window

### DIFF
--- a/packages/workbox-window/package-lock.json
+++ b/packages/workbox-window/package-lock.json
@@ -4,8 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "workbox-core": {
-      "version": "5.0.0-alpha.0"
+    "@types/trusted-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.1.tgz",
+      "integrity": "sha512-TmhE+/eI8PP7EwT9EbK8i74F1ryNn0LToCyEaLpN+X+A3LS1j4CpsCk9Jwq6Y2Uu7w9wdrKl6bujdj5LSsDKKA==",
+      "dev": true
     }
   }
 }

--- a/packages/workbox-window/package.json
+++ b/packages/workbox-window/package.json
@@ -25,5 +25,8 @@
   "types": "index.d.ts",
   "dependencies": {
     "workbox-core": "^6.1.5"
+  },
+  "devDependencies": {
+    "@types/trusted-types": "^2.0.1"
   }
 }


### PR DESCRIPTION
R: @tropicadri
CC: @budarin

Fixes #2855

This should be backwards compatible. At some point, if `TrustedScriptURL` is added to the TypeScript `lib.dom` library, we can remove the dependency on `@types/trusted-types`.