### PR TITLE
Modify ajv function validation

### DIFF
--- a/gulp-tasks/build-node-packages.js
+++ b/gulp-tasks/build-node-packages.js
@@ -50,7 +50,7 @@ async function generateWorkboxBuildJSONSchema(packagePath) {
     if (schema.properties.manifestTransforms) {
       schema.properties.manifestTransforms.items = {};
     }
-  
+
     if (schema.properties.exclude) {
       schema.properties.exclude.items = {};
     }

--- a/gulp-tasks/build-node-packages.js
+++ b/gulp-tasks/build-node-packages.js
@@ -46,31 +46,23 @@ async function generateWorkboxBuildJSONSchema(packagePath) {
   ];
   for (const optionType of optionTypes) {
     const schema = generator.getSchemaForSymbol(optionType);
-    // Ideally, we'd set typeOfKeyword so that functions could be represented.
-    // Instead, we need to hardcode a few overrides to deal with functions.
-    // See https://github.com/YousefED/typescript-json-schema/issues/424
+
     if (schema.properties.manifestTransforms) {
-      schema.properties.manifestTransforms.items = {typeof: 'function'};
+      schema.properties.manifestTransforms.items = {};
     }
+  
     if (schema.properties.exclude) {
-      schema.properties.exclude.items.anyOf = [
-        {'$ref': '#/definitions/RegExp'},
-        {type: 'string'},
-        {typeof: 'function'},
-      ];
+      schema.properties.exclude.items = {};
     }
+
     if (schema.properties.include) {
-      schema.properties.include.items.anyOf = [
-        {'$ref': '#/definitions/RegExp'},
-        {type: 'string'},
-        {typeof: 'function'},
-      ];
+      schema.properties.include.items = {};
     }
+
     if (schema.definitions.RouteMatchCallback) {
-      delete schema.definitions.RouteMatchCallback.type;
-      delete schema.definitions.RouteMatchCallback.additionalProperties;
-      schema.definitions.RouteMatchCallback.typeof = 'function';
+      schema.definitions.RouteMatchCallback = {};
     }
+
     await fse.writeJSON(upath.join(packagePath, 'src', 'schema',
         `${optionType}.json`), schema, {spaces: 2});
   }

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -29,7 +29,6 @@
     "@rollup/plugin-replace": "^2.4.1",
     "@surma/rollup-plugin-off-main-thread": "^1.4.1",
     "ajv": "^8.6.0",
-    "ajv-keywords": "^5.0.0",
     "common-tags": "^1.8.0",
     "fast-json-stable-stringify": "^2.1.0",
     "fs-extra": "^9.0.1",

--- a/packages/workbox-build/src/lib/errors.ts
+++ b/packages/workbox-build/src/lib/errors.ts
@@ -118,4 +118,6 @@ export const errors = {
     configure a runtimeCaching route that will use the preloaded response.`,
   'cache-name-required': ol`When using cache expiration, you must also
     configure a custom cacheName.`,
+  'manifest-transforms': ol`When using manifestTransforms, you must provide
+    an array of functions.`,
 };

--- a/packages/workbox-build/src/schema/GenerateSWOptions.json
+++ b/packages/workbox-build/src/schema/GenerateSWOptions.json
@@ -20,9 +20,7 @@
     },
     "manifestTransforms": {
       "type": "array",
-      "items": {
-        "typeof": "function"
-      }
+      "items": {}
     },
     "maximumFileSizeToCacheInBytes": {
       "default": 2097152,
@@ -861,10 +859,7 @@
         "onabort"
       ]
     },
-    "RouteMatchCallback": {
-      "description": "The \"match\" callback is used to determine if a `Route` should apply for a\nparticular URL and request. When matching occurs in response to a fetch\nevent from the client, the `event` object is also supplied. However, since\nthe match callback can be invoked outside of a fetch event, matching logic\nshould not assume the `event` object will always be available.\nIf the match callback returns a truthy value, the matching route's\n`RouteHandlerCallback` will be invoked immediately. If the value returned\nis a non-empty array or object, that value will be set on the handler's\n`options.params` argument.",
-      "typeof": "function"
-    }
+    "RouteMatchCallback": {}
   },
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/packages/workbox-build/src/schema/GetManifestOptions.json
+++ b/packages/workbox-build/src/schema/GetManifestOptions.json
@@ -20,9 +20,7 @@
     },
     "manifestTransforms": {
       "type": "array",
-      "items": {
-        "typeof": "function"
-      }
+      "items": {}
     },
     "maximumFileSizeToCacheInBytes": {
       "default": 2097152,
@@ -753,10 +751,7 @@
         "onabort"
       ]
     },
-    "RouteMatchCallback": {
-      "description": "The \"match\" callback is used to determine if a `Route` should apply for a\nparticular URL and request. When matching occurs in response to a fetch\nevent from the client, the `event` object is also supplied. However, since\nthe match callback can be invoked outside of a fetch event, matching logic\nshould not assume the `event` object will always be available.\nIf the match callback returns a truthy value, the matching route's\n`RouteHandlerCallback` will be invoked immediately. If the value returned\nis a non-empty array or object, that value will be set on the handler's\n`options.params` argument.",
-      "typeof": "function"
-    }
+    "RouteMatchCallback": {}
   },
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/packages/workbox-build/src/schema/InjectManifestOptions.json
+++ b/packages/workbox-build/src/schema/InjectManifestOptions.json
@@ -20,9 +20,7 @@
     },
     "manifestTransforms": {
       "type": "array",
-      "items": {
-        "typeof": "function"
-      }
+      "items": {}
     },
     "maximumFileSizeToCacheInBytes": {
       "default": 2097152,
@@ -765,10 +763,7 @@
         "onabort"
       ]
     },
-    "RouteMatchCallback": {
-      "description": "The \"match\" callback is used to determine if a `Route` should apply for a\nparticular URL and request. When matching occurs in response to a fetch\nevent from the client, the `event` object is also supplied. However, since\nthe match callback can be invoked outside of a fetch event, matching logic\nshould not assume the `event` object will always be available.\nIf the match callback returns a truthy value, the matching route's\n`RouteHandlerCallback` will be invoked immediately. If the value returned\nis a non-empty array or object, that value will be set on the handler's\n`options.params` argument.",
-      "typeof": "function"
-    }
+    "RouteMatchCallback": {}
   },
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/packages/workbox-build/src/schema/WebpackGenerateSWOptions.json
+++ b/packages/workbox-build/src/schema/WebpackGenerateSWOptions.json
@@ -20,9 +20,7 @@
     },
     "manifestTransforms": {
       "type": "array",
-      "items": {
-        "typeof": "function"
-      }
+      "items": {}
     },
     "maximumFileSizeToCacheInBytes": {
       "default": 2097152,
@@ -42,19 +40,7 @@
     },
     "exclude": {
       "type": "array",
-      "items": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/RegExp"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "typeof": "function"
-          }
-        ]
-      }
+      "items": {}
     },
     "excludeChunks": {
       "type": "array",
@@ -64,19 +50,7 @@
     },
     "include": {
       "type": "array",
-      "items": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/RegExp"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "typeof": "function"
-          }
-        ]
-      }
+      "items": {}
     },
     "mode": {
       "default": "production",
@@ -864,10 +838,7 @@
         "onabort"
       ]
     },
-    "RouteMatchCallback": {
-      "description": "The \"match\" callback is used to determine if a `Route` should apply for a\nparticular URL and request. When matching occurs in response to a fetch\nevent from the client, the `event` object is also supplied. However, since\nthe match callback can be invoked outside of a fetch event, matching logic\nshould not assume the `event` object will always be available.\nIf the match callback returns a truthy value, the matching route's\n`RouteHandlerCallback` will be invoked immediately. If the value returned\nis a non-empty array or object, that value will be set on the handler's\n`options.params` argument.",
-      "typeof": "function"
-    }
+    "RouteMatchCallback": {}
   },
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/packages/workbox-build/src/schema/WebpackInjectManifestOptions.json
+++ b/packages/workbox-build/src/schema/WebpackInjectManifestOptions.json
@@ -20,9 +20,7 @@
     },
     "manifestTransforms": {
       "type": "array",
-      "items": {
-        "typeof": "function"
-      }
+      "items": {}
     },
     "maximumFileSizeToCacheInBytes": {
       "default": 2097152,
@@ -42,19 +40,7 @@
     },
     "exclude": {
       "type": "array",
-      "items": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/RegExp"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "typeof": "function"
-          }
-        ]
-      }
+      "items": {}
     },
     "excludeChunks": {
       "type": "array",
@@ -64,19 +50,7 @@
     },
     "include": {
       "type": "array",
-      "items": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/RegExp"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "typeof": "function"
-          }
-        ]
-      }
+      "items": {}
     },
     "mode": {
       "type": [
@@ -776,10 +750,7 @@
         "onabort"
       ]
     },
-    "RouteMatchCallback": {
-      "description": "The \"match\" callback is used to determine if a `Route` should apply for a\nparticular URL and request. When matching occurs in response to a fetch\nevent from the client, the `event` object is also supplied. However, since\nthe match callback can be invoked outside of a fetch event, matching logic\nshould not assume the `event` object will always be available.\nIf the match callback returns a truthy value, the matching route's\n`RouteHandlerCallback` will be invoked immediately. If the value returned\nis a non-empty array or object, that value will be set on the handler's\n`options.params` argument.",
-      "typeof": "function"
-    }
+    "RouteMatchCallback": {}
   },
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  arrowParens: 'always',
+  bracketSpacing: false,
+  printWidth: 80,
+  quoteProps: 'consistent',
+  semi: true,
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: 'all',
+};


### PR DESCRIPTION
Using `ajv-keywords` triggered buggy behavior in `npm` related to hoisting and `peerDependencies`, along the lines of https://github.com/eslint/eslint/issues/11018#issuecomment-433248374

The v6.x version of `ajv` could end up hoisted to the top-level `node_modules/`, and `ajv-keywords` might be hoisted there too, but `ajv-keywords` needs `ajv` v8.x, which only gets installed in `node_modules/workbox-build/node_modules/ajv/`.

This PR attempts to work around the fact that we can't validate that a given option is set to a `function` without `ajv-keywords` by relaxing the JSON schema and adding in some manual validation logic.

(I also added a basic `prettier` config to this PR as well, as I've gotten tired of manually formatting everything... we should hold off on updating the entire codebase, but we can use it for one-offs until then.)