### PR TITLE
Fix WorkboxPlugins schema validation

### DIFF
--- a/gulp-tasks/build-node-packages.js
+++ b/gulp-tasks/build-node-packages.js
@@ -17,33 +17,33 @@ const packageRunner = require('./utils/package-runner');
 
 async function buildNodePackage(packagePath) {
   const outputDirectory = upath.join(
-    packagePath,
-    constants.PACKAGE_BUILD_DIRNAME,
+      packagePath,
+      constants.PACKAGE_BUILD_DIRNAME,
   );
 
   const configFile = upath.join(
-    __dirname,
-    'utils',
-    'node-projects-babel.config.json',
+      __dirname,
+      'utils',
+      'node-projects-babel.config.json',
   );
 
   await execa(
-    'babel',
-    [
-      '--config-file',
-      configFile,
-      `${packagePath}/src`,
-      '--out-dir',
-      outputDirectory,
-      '--copy-files',
-    ],
-    {preferLocal: true},
+      'babel',
+      [
+        '--config-file',
+        configFile,
+        `${packagePath}/src`,
+        '--out-dir',
+        outputDirectory,
+        '--copy-files',
+      ],
+      {preferLocal: true},
   );
 }
 
 async function generateWorkboxBuildJSONSchema(packagePath) {
   const program = TJS.programFromConfig(
-    upath.join(packagePath, 'tsconfig.json'),
+      upath.join(packagePath, 'tsconfig.json'),
   );
   const generator = TJS.buildGenerator(program, {
     noExtraProps: true,
@@ -78,16 +78,16 @@ async function generateWorkboxBuildJSONSchema(packagePath) {
     // See https://github.com/GoogleChrome/workbox/issues/2901
     if (schema.definitions.WorkboxPlugin) {
       for (const plugin of Object.keys(
-        schema.definitions.WorkboxPlugin.properties,
+          schema.definitions.WorkboxPlugin.properties,
       )) {
         schema.definitions.WorkboxPlugin.properties[plugin] = {};
       }
     }
 
     await fse.writeJSON(
-      upath.join(packagePath, 'src', 'schema', `${optionType}.json`),
-      schema,
-      {spaces: 2},
+        upath.join(packagePath, 'src', 'schema', `${optionType}.json`),
+        schema,
+        {spaces: 2},
     );
   }
 }
@@ -104,9 +104,9 @@ async function buildNodeTSPackage(packagePath) {
 
 module.exports = {
   build_node_packages: parallel(
-    packageRunner('build_node_packages', 'node', buildNodePackage),
+      packageRunner('build_node_packages', 'node', buildNodePackage),
   ),
   build_node_ts_packages: parallel(
-    packageRunner('build_node_ts_packages', 'node_ts', buildNodeTSPackage),
+      packageRunner('build_node_ts_packages', 'node_ts', buildNodeTSPackage),
   ),
 };

--- a/gulp-tasks/build-node-packages.js
+++ b/gulp-tasks/build-node-packages.js
@@ -16,23 +16,35 @@ const constants = require('./utils/constants');
 const packageRunner = require('./utils/package-runner');
 
 async function buildNodePackage(packagePath) {
-  const outputDirectory = upath.join(packagePath,
-      constants.PACKAGE_BUILD_DIRNAME);
+  const outputDirectory = upath.join(
+    packagePath,
+    constants.PACKAGE_BUILD_DIRNAME,
+  );
 
-  const configFile = upath.join(__dirname, 'utils',
-      'node-projects-babel.config.json');
+  const configFile = upath.join(
+    __dirname,
+    'utils',
+    'node-projects-babel.config.json',
+  );
 
-  await execa('babel', [
-    '--config-file', configFile,
-    `${packagePath}/src`,
-    '--out-dir', outputDirectory,
-    '--copy-files',
-  ], {preferLocal: true});
+  await execa(
+    'babel',
+    [
+      '--config-file',
+      configFile,
+      `${packagePath}/src`,
+      '--out-dir',
+      outputDirectory,
+      '--copy-files',
+    ],
+    {preferLocal: true},
+  );
 }
 
 async function generateWorkboxBuildJSONSchema(packagePath) {
-  const program = TJS.programFromConfig(upath.join(packagePath,
-      'tsconfig.json'));
+  const program = TJS.programFromConfig(
+    upath.join(packagePath, 'tsconfig.json'),
+  );
   const generator = TJS.buildGenerator(program, {
     noExtraProps: true,
     required: true,
@@ -63,8 +75,20 @@ async function generateWorkboxBuildJSONSchema(packagePath) {
       schema.definitions.RouteMatchCallback = {};
     }
 
-    await fse.writeJSON(upath.join(packagePath, 'src', 'schema',
-        `${optionType}.json`), schema, {spaces: 2});
+    // See https://github.com/GoogleChrome/workbox/issues/2901
+    if (schema.definitions.WorkboxPlugin) {
+      for (const plugin of Object.keys(
+        schema.definitions.WorkboxPlugin.properties,
+      )) {
+        schema.definitions.WorkboxPlugin.properties[plugin] = {};
+      }
+    }
+
+    await fse.writeJSON(
+      upath.join(packagePath, 'src', 'schema', `${optionType}.json`),
+      schema,
+      {spaces: 2},
+    );
   }
 }
 
@@ -79,8 +103,10 @@ async function buildNodeTSPackage(packagePath) {
 }
 
 module.exports = {
-  build_node_packages: parallel(packageRunner('build_node_packages', 'node',
-      buildNodePackage)),
-  build_node_ts_packages: parallel(packageRunner('build_node_ts_packages',
-      'node_ts', buildNodeTSPackage)),
+  build_node_packages: parallel(
+    packageRunner('build_node_packages', 'node', buildNodePackage),
+  ),
+  build_node_ts_packages: parallel(
+    packageRunner('build_node_ts_packages', 'node_ts', buildNodeTSPackage),
+  ),
 };

--- a/packages/workbox-build/src/schema/GenerateSWOptions.json
+++ b/packages/workbox-build/src/schema/GenerateSWOptions.json
@@ -512,42 +512,18 @@
       "description": "An object with optional lifecycle callback properties for the fetch and\ncache operations.",
       "type": "object",
       "properties": {
-        "cacheDidUpdate": {
-          "$ref": "#/definitions/CacheDidUpdateCallback"
-        },
-        "cachedResponseWillBeUsed": {
-          "$ref": "#/definitions/CachedResponseWillBeUsedCallback"
-        },
-        "cacheKeyWillBeUsed": {
-          "$ref": "#/definitions/CacheKeyWillBeUsedCallback"
-        },
-        "cacheWillUpdate": {
-          "$ref": "#/definitions/CacheWillUpdateCallback"
-        },
-        "fetchDidFail": {
-          "$ref": "#/definitions/FetchDidFailCallback"
-        },
-        "fetchDidSucceed": {
-          "$ref": "#/definitions/FetchDidSucceedCallback"
-        },
-        "handlerDidComplete": {
-          "$ref": "#/definitions/HandlerDidCompleteCallback"
-        },
-        "handlerDidError": {
-          "$ref": "#/definitions/HandlerDidErrorCallback"
-        },
-        "handlerDidRespond": {
-          "$ref": "#/definitions/HandlerDidRespondCallback"
-        },
-        "handlerWillRespond": {
-          "$ref": "#/definitions/HandlerWillRespondCallback"
-        },
-        "handlerWillStart": {
-          "$ref": "#/definitions/HandlerWillStartCallback"
-        },
-        "requestWillFetch": {
-          "$ref": "#/definitions/RequestWillFetchCallback"
-        }
+        "cacheDidUpdate": {},
+        "cachedResponseWillBeUsed": {},
+        "cacheKeyWillBeUsed": {},
+        "cacheWillUpdate": {},
+        "fetchDidFail": {},
+        "fetchDidSucceed": {},
+        "handlerDidComplete": {},
+        "handlerDidError": {},
+        "handlerDidRespond": {},
+        "handlerWillRespond": {},
+        "handlerWillStart": {},
+        "requestWillFetch": {}
       },
       "additionalProperties": false
     },

--- a/packages/workbox-build/src/schema/GetManifestOptions.json
+++ b/packages/workbox-build/src/schema/GetManifestOptions.json
@@ -404,42 +404,18 @@
       "description": "An object with optional lifecycle callback properties for the fetch and\ncache operations.",
       "type": "object",
       "properties": {
-        "cacheDidUpdate": {
-          "$ref": "#/definitions/CacheDidUpdateCallback"
-        },
-        "cachedResponseWillBeUsed": {
-          "$ref": "#/definitions/CachedResponseWillBeUsedCallback"
-        },
-        "cacheKeyWillBeUsed": {
-          "$ref": "#/definitions/CacheKeyWillBeUsedCallback"
-        },
-        "cacheWillUpdate": {
-          "$ref": "#/definitions/CacheWillUpdateCallback"
-        },
-        "fetchDidFail": {
-          "$ref": "#/definitions/FetchDidFailCallback"
-        },
-        "fetchDidSucceed": {
-          "$ref": "#/definitions/FetchDidSucceedCallback"
-        },
-        "handlerDidComplete": {
-          "$ref": "#/definitions/HandlerDidCompleteCallback"
-        },
-        "handlerDidError": {
-          "$ref": "#/definitions/HandlerDidErrorCallback"
-        },
-        "handlerDidRespond": {
-          "$ref": "#/definitions/HandlerDidRespondCallback"
-        },
-        "handlerWillRespond": {
-          "$ref": "#/definitions/HandlerWillRespondCallback"
-        },
-        "handlerWillStart": {
-          "$ref": "#/definitions/HandlerWillStartCallback"
-        },
-        "requestWillFetch": {
-          "$ref": "#/definitions/RequestWillFetchCallback"
-        }
+        "cacheDidUpdate": {},
+        "cachedResponseWillBeUsed": {},
+        "cacheKeyWillBeUsed": {},
+        "cacheWillUpdate": {},
+        "fetchDidFail": {},
+        "fetchDidSucceed": {},
+        "handlerDidComplete": {},
+        "handlerDidError": {},
+        "handlerDidRespond": {},
+        "handlerWillRespond": {},
+        "handlerWillStart": {},
+        "requestWillFetch": {}
       },
       "additionalProperties": false
     },

--- a/packages/workbox-build/src/schema/InjectManifestOptions.json
+++ b/packages/workbox-build/src/schema/InjectManifestOptions.json
@@ -416,42 +416,18 @@
       "description": "An object with optional lifecycle callback properties for the fetch and\ncache operations.",
       "type": "object",
       "properties": {
-        "cacheDidUpdate": {
-          "$ref": "#/definitions/CacheDidUpdateCallback"
-        },
-        "cachedResponseWillBeUsed": {
-          "$ref": "#/definitions/CachedResponseWillBeUsedCallback"
-        },
-        "cacheKeyWillBeUsed": {
-          "$ref": "#/definitions/CacheKeyWillBeUsedCallback"
-        },
-        "cacheWillUpdate": {
-          "$ref": "#/definitions/CacheWillUpdateCallback"
-        },
-        "fetchDidFail": {
-          "$ref": "#/definitions/FetchDidFailCallback"
-        },
-        "fetchDidSucceed": {
-          "$ref": "#/definitions/FetchDidSucceedCallback"
-        },
-        "handlerDidComplete": {
-          "$ref": "#/definitions/HandlerDidCompleteCallback"
-        },
-        "handlerDidError": {
-          "$ref": "#/definitions/HandlerDidErrorCallback"
-        },
-        "handlerDidRespond": {
-          "$ref": "#/definitions/HandlerDidRespondCallback"
-        },
-        "handlerWillRespond": {
-          "$ref": "#/definitions/HandlerWillRespondCallback"
-        },
-        "handlerWillStart": {
-          "$ref": "#/definitions/HandlerWillStartCallback"
-        },
-        "requestWillFetch": {
-          "$ref": "#/definitions/RequestWillFetchCallback"
-        }
+        "cacheDidUpdate": {},
+        "cachedResponseWillBeUsed": {},
+        "cacheKeyWillBeUsed": {},
+        "cacheWillUpdate": {},
+        "fetchDidFail": {},
+        "fetchDidSucceed": {},
+        "handlerDidComplete": {},
+        "handlerDidError": {},
+        "handlerDidRespond": {},
+        "handlerWillRespond": {},
+        "handlerWillStart": {},
+        "requestWillFetch": {}
       },
       "additionalProperties": false
     },

--- a/packages/workbox-build/src/schema/WebpackGenerateSWOptions.json
+++ b/packages/workbox-build/src/schema/WebpackGenerateSWOptions.json
@@ -491,42 +491,18 @@
       "description": "An object with optional lifecycle callback properties for the fetch and\ncache operations.",
       "type": "object",
       "properties": {
-        "cacheDidUpdate": {
-          "$ref": "#/definitions/CacheDidUpdateCallback"
-        },
-        "cachedResponseWillBeUsed": {
-          "$ref": "#/definitions/CachedResponseWillBeUsedCallback"
-        },
-        "cacheKeyWillBeUsed": {
-          "$ref": "#/definitions/CacheKeyWillBeUsedCallback"
-        },
-        "cacheWillUpdate": {
-          "$ref": "#/definitions/CacheWillUpdateCallback"
-        },
-        "fetchDidFail": {
-          "$ref": "#/definitions/FetchDidFailCallback"
-        },
-        "fetchDidSucceed": {
-          "$ref": "#/definitions/FetchDidSucceedCallback"
-        },
-        "handlerDidComplete": {
-          "$ref": "#/definitions/HandlerDidCompleteCallback"
-        },
-        "handlerDidError": {
-          "$ref": "#/definitions/HandlerDidErrorCallback"
-        },
-        "handlerDidRespond": {
-          "$ref": "#/definitions/HandlerDidRespondCallback"
-        },
-        "handlerWillRespond": {
-          "$ref": "#/definitions/HandlerWillRespondCallback"
-        },
-        "handlerWillStart": {
-          "$ref": "#/definitions/HandlerWillStartCallback"
-        },
-        "requestWillFetch": {
-          "$ref": "#/definitions/RequestWillFetchCallback"
-        }
+        "cacheDidUpdate": {},
+        "cachedResponseWillBeUsed": {},
+        "cacheKeyWillBeUsed": {},
+        "cacheWillUpdate": {},
+        "fetchDidFail": {},
+        "fetchDidSucceed": {},
+        "handlerDidComplete": {},
+        "handlerDidError": {},
+        "handlerDidRespond": {},
+        "handlerWillRespond": {},
+        "handlerWillStart": {},
+        "requestWillFetch": {}
       },
       "additionalProperties": false
     },

--- a/packages/workbox-build/src/schema/WebpackInjectManifestOptions.json
+++ b/packages/workbox-build/src/schema/WebpackInjectManifestOptions.json
@@ -403,42 +403,18 @@
       "description": "An object with optional lifecycle callback properties for the fetch and\ncache operations.",
       "type": "object",
       "properties": {
-        "cacheDidUpdate": {
-          "$ref": "#/definitions/CacheDidUpdateCallback"
-        },
-        "cachedResponseWillBeUsed": {
-          "$ref": "#/definitions/CachedResponseWillBeUsedCallback"
-        },
-        "cacheKeyWillBeUsed": {
-          "$ref": "#/definitions/CacheKeyWillBeUsedCallback"
-        },
-        "cacheWillUpdate": {
-          "$ref": "#/definitions/CacheWillUpdateCallback"
-        },
-        "fetchDidFail": {
-          "$ref": "#/definitions/FetchDidFailCallback"
-        },
-        "fetchDidSucceed": {
-          "$ref": "#/definitions/FetchDidSucceedCallback"
-        },
-        "handlerDidComplete": {
-          "$ref": "#/definitions/HandlerDidCompleteCallback"
-        },
-        "handlerDidError": {
-          "$ref": "#/definitions/HandlerDidErrorCallback"
-        },
-        "handlerDidRespond": {
-          "$ref": "#/definitions/HandlerDidRespondCallback"
-        },
-        "handlerWillRespond": {
-          "$ref": "#/definitions/HandlerWillRespondCallback"
-        },
-        "handlerWillStart": {
-          "$ref": "#/definitions/HandlerWillStartCallback"
-        },
-        "requestWillFetch": {
-          "$ref": "#/definitions/RequestWillFetchCallback"
-        }
+        "cacheDidUpdate": {},
+        "cachedResponseWillBeUsed": {},
+        "cacheKeyWillBeUsed": {},
+        "cacheWillUpdate": {},
+        "fetchDidFail": {},
+        "fetchDidSucceed": {},
+        "handlerDidComplete": {},
+        "handlerDidError": {},
+        "handlerDidRespond": {},
+        "handlerWillRespond": {},
+        "handlerWillStart": {},
+        "requestWillFetch": {}
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
Fixes #2901

Since `ajv` doesn't natively support `function` validation, we need to swap out `object` for `{}` (i.e. `any`) to allow anything that should be a function to validate in the generated JSON schema.