### PR TITLE
Switch tsc target to es2017

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "noUnusedParameters": true,
     "preserveConstEnums": true,
     "strict": true,
-    "target": "esnext",
+    "target": "es2017",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "files": [


### PR DESCRIPTION
Fixes #2902

This ensures that the generated JS files that `tsc` produces all use ES2017 syntax. (This is separate from our `rollup`-produced bundles.)