### PR TITLE
Use the exact flag

### DIFF
--- a/gulp-tasks/publish-lerna.js
+++ b/gulp-tasks/publish-lerna.js
@@ -12,7 +12,8 @@ const ol = require('common-tags').oneLine;
 const logHelper = require('../infra/utils/log-helper');
 
 async function publish_lerna() {
-  const options = ['publish', '--force-publish'];
+  // See https://github.com/GoogleChrome/workbox/issues/2904#issuecomment-894452253
+  const options = ['publish', '--force-publish', '--exact'];
 
   // gulp publish --distTag=latest would be the most common.
   if (global.cliOptions.distTag) {


### PR DESCRIPTION
The [`--exact` flag](https://github.com/lerna/lerna/tree/main/commands/version#--exact) will give us the intended dependent module versioning, which is for each Workbox module in the monorepo to explicitly depend on the same version of each other module.

See https://github.com/GoogleChrome/workbox/issues/2904#issuecomment-894452253