### PR TITLE
Move @types/trusted-types to dependencies

### DIFF
--- a/packages/workbox-window/package-lock.json
+++ b/packages/workbox-window/package-lock.json
@@ -5,10 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/trusted-types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.1.tgz",
-      "integrity": "sha512-TmhE+/eI8PP7EwT9EbK8i74F1ryNn0LToCyEaLpN+X+A3LS1j4CpsCk9Jwq6Y2Uu7w9wdrKl6bujdj5LSsDKKA==",
-      "dev": true
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     }
   }
 }

--- a/packages/workbox-window/package.json
+++ b/packages/workbox-window/package.json
@@ -24,9 +24,7 @@
   "module": "build/workbox-window.prod.es5.mjs",
   "types": "index.d.ts",
   "dependencies": {
+    "@types/trusted-types": "^2.0.2",
     "workbox-core": "6.2.2"
-  },
-  "devDependencies": {
-    "@types/trusted-types": "^2.0.1"
   }
 }


### PR DESCRIPTION
See https://github.com/GoogleChrome/workbox/pull/2872#issuecomment-894775401

Third-party types need to be added as `dependencies`, not `devDependencies`, or else they won't be available at compile-time when developers try to compile our TypeScript source installed from the `npm` package.