### PR TITLE
Export all TypeScript types in WorkboxEvents

### DIFF
--- a/packages/workbox-window/src/index.ts
+++ b/packages/workbox-window/src/index.ts
@@ -8,7 +8,6 @@
 
 import {messageSW} from './messageSW.js';
 import {Workbox} from './Workbox.js';
-import {WorkboxEventMap} from './utils/WorkboxEvent.js';
 
 import './_version.js';
 
@@ -18,5 +17,7 @@ import './_version.js';
 export {
   messageSW,
   Workbox,
-  WorkboxEventMap,
 };
+
+// See https://github.com/GoogleChrome/workbox/issues/2770
+export * from './utils/WorkboxEvent.js';


### PR DESCRIPTION
R: @tropicadri

Fixes #2770

I think we're fine committing them all to our public interface, and this improves developer experience.

See #2255 for precedent.