### PR TITLE
notifyAllClients option to BroadcastUpdates

### DIFF
--- a/packages/workbox-broadcast-update/src/utils/constants.ts
+++ b/packages/workbox-broadcast-update/src/utils/constants.ts
@@ -10,6 +10,7 @@ import '../_version.js';
 
 export const CACHE_UPDATED_MESSAGE_TYPE = 'CACHE_UPDATED';
 export const CACHE_UPDATED_MESSAGE_META = 'workbox-broadcast-update';
+export const NOTIFY_ALL_CLIENTS = true;
 export const DEFAULT_HEADERS_TO_CHECK: string[] = [
   'content-length',
   'etag',

--- a/packages/workbox-build/src/schema/GenerateSWOptions.json
+++ b/packages/workbox-build/src/schema/GenerateSWOptions.json
@@ -446,6 +446,9 @@
         "generatePayload": {
           "type": "object",
           "additionalProperties": false
+        },
+        "notifyAllClients": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/packages/workbox-build/src/schema/GetManifestOptions.json
+++ b/packages/workbox-build/src/schema/GetManifestOptions.json
@@ -338,6 +338,9 @@
         "generatePayload": {
           "type": "object",
           "additionalProperties": false
+        },
+        "notifyAllClients": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/packages/workbox-build/src/schema/InjectManifestOptions.json
+++ b/packages/workbox-build/src/schema/InjectManifestOptions.json
@@ -350,6 +350,9 @@
         "generatePayload": {
           "type": "object",
           "additionalProperties": false
+        },
+        "notifyAllClients": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/packages/workbox-build/src/schema/WebpackGenerateSWOptions.json
+++ b/packages/workbox-build/src/schema/WebpackGenerateSWOptions.json
@@ -425,6 +425,9 @@
         "generatePayload": {
           "type": "object",
           "additionalProperties": false
+        },
+        "notifyAllClients": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/packages/workbox-build/src/schema/WebpackInjectManifestOptions.json
+++ b/packages/workbox-build/src/schema/WebpackInjectManifestOptions.json
@@ -337,6 +337,9 @@
         "generatePayload": {
           "type": "object",
           "additionalProperties": false
+        },
+        "notifyAllClients": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/test/workbox-broadcast-update/static/sw.js
+++ b/test/workbox-broadcast-update/static/sw.js
@@ -14,6 +14,18 @@ importScripts('/__WORKBOX/buildFile/workbox-strategies');
 const cacheName = 'bcu-integration-test';
 
 workbox.routing.registerRoute(
+    ({url}) => url.searchParams.has('notifyAllClientsTest'),
+    new workbox.strategies.NetworkFirst({
+      cacheName,
+      plugins: [
+        new workbox.broadcastUpdate.BroadcastUpdatePlugin({
+          notifyAllClients: false,
+        }),
+      ],
+    }),
+);
+
+workbox.routing.registerRoute(
     new RegExp('/__WORKBOX/uniqueETag$'),
     new workbox.strategies.StaleWhileRevalidate({
       cacheName,


### PR DESCRIPTION
R: @tropicadri

Fixes #2895

This adds an option that will cause `BroadcastCacheUpdate` to only `postMessage()` to the client page that was associated with the `fetch` that updated the cache, instead of sending the same message to all open clients.

The default for `notifyAllClients` is `true`, matching the current behavior, so this should be backwards compatible.