### PR TITLE
Remove WorkboxError.name definition

### DIFF
--- a/packages/workbox-core/src/_private/WorkboxError.ts
+++ b/packages/workbox-core/src/_private/WorkboxError.ts
@@ -21,7 +21,6 @@ import '../_version.js';
  * @private
  */
 class WorkboxError extends Error {
-  name: string;
   details?: MapLikeObject;
 
   /**


### PR DESCRIPTION
R: @tropicadri

Small change to account for the fact that `Error.name` already exists and should work for our use case, without having to implicitly override.