### PR TITLE
changing durability to relaxed

### DIFF
--- a/packages/workbox-background-sync/src/lib/QueueDb.ts
+++ b/packages/workbox-background-sync/src/lib/QueueDb.ts
@@ -56,7 +56,9 @@ export class QueueDb {
    */
   async addEntry(entry: UnidentifiedQueueStoreEntry): Promise<void> {
     const db = await this.getDb();
-    await db.add(REQUEST_OBJECT_STORE_NAME, entry as QueueStoreEntry);
+    const tx = db.transaction(REQUEST_OBJECT_STORE_NAME, 'readwrite', { durability: 'relaxed' });
+    await tx.store.add(entry as QueueStoreEntry);
+    await tx.done;
   }
 
   /**

--- a/packages/workbox-expiration/src/models/CacheTimestampsModel.ts
+++ b/packages/workbox-expiration/src/models/CacheTimestampsModel.ts
@@ -111,7 +111,9 @@ class CacheTimestampsModel {
       id: this._getId(url),
     };
     const db = await this.getDb();
-    await db.put(CACHE_OBJECT_STORE, entry);
+    const tx = db.transaction(CACHE_OBJECT_STORE, 'readwrite', {durability: 'relaxed'});
+    await tx.store.put(CACHE_OBJECT_STORE, entry);
+    await tx.done;
   }
 
   /**

--- a/packages/workbox-expiration/src/models/CacheTimestampsModel.ts
+++ b/packages/workbox-expiration/src/models/CacheTimestampsModel.ts
@@ -112,7 +112,7 @@ class CacheTimestampsModel {
     };
     const db = await this.getDb();
     const tx = db.transaction(CACHE_OBJECT_STORE, 'readwrite', {durability: 'relaxed'});
-    await tx.store.put(CACHE_OBJECT_STORE, entry);
+    await tx.store.put(entry);
     await tx.done;
   }
 


### PR DESCRIPTION
After reading #2854 and this [article]( https://nolanlawson.com/2021/08/22/speeding-up-indexeddb-reads-and-writes/), seeing it is the default behavior in FF that seems to improve the performance, that is supported in Chrome and seems to be soon supported in Safari, I think it is a good idea to change the durability.

Fixes #2854 