### PR TITLE
Update GitHub Actions to use cache@v2

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,16 +9,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/cache@v1
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - uses: actions/setup-node@v1
         with:
           node-version: 10.x
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Setup
         run: |
@@ -33,21 +37,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/cache@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.selenium-assistant
           key: ${{ runner.os }}
-
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
 
       - name: Setup
         run: |


### PR DESCRIPTION
R: @tropicadri 

Based on the info at https://github.com/actions/cache/blob/main/examples.md#node---npm, this updates our GitHub Actions build to use the latest caching action.