### PR TITLE
Add size() to expose amount of requests in queue

### DIFF
--- a/packages/workbox-background-sync/src/Queue.ts
+++ b/packages/workbox-background-sync/src/Queue.ts
@@ -243,6 +243,16 @@ class Queue {
   }
 
   /**
+   * Returns the number of entries present in the queue.
+   * Note that expired entries (per `maxRetentionTime`) are also included in this count.
+   *
+   * @return {Promise<number>}
+   */
+  async size(): Promise<number> {
+    return await this._queueStore.size();
+  }
+
+  /**
    * Adds the entry to the QueueStore and registers for a sync event.
    *
    * @param {Object} entry

--- a/packages/workbox-background-sync/src/lib/QueueDb.ts
+++ b/packages/workbox-background-sync/src/lib/QueueDb.ts
@@ -87,6 +87,19 @@ export class QueueDb {
   }
 
   /**
+   * Returns the number of entries filtered by index
+   *
+   * @param queueName
+   * @return {Promise<number>}
+   */
+  async getEntryCountByQueueName(
+      queueName: string,
+  ): Promise<number> {
+    const db = await this.getDb();
+    return db.countFromIndex(REQUEST_OBJECT_STORE_NAME, QUEUE_NAME_INDEX, IDBKeyRange.only(queueName));
+  }
+
+  /**
    * Deletes a single entry by id.
    *
    * @param {number} id the id of the entry to be deleted

--- a/packages/workbox-background-sync/src/lib/QueueStore.ts
+++ b/packages/workbox-background-sync/src/lib/QueueStore.ts
@@ -135,6 +135,17 @@ export class QueueStore {
   }
 
   /**
+   * Returns the number of entries in the store matching the `queueName`.
+   *
+   * @param {Object} options See {@link module:workbox-background-sync.Queue~size}
+   * @return {Promise<number>}
+   * @private
+   */
+  async size(): Promise<number> {
+    return await this._queueDb.getEntryCountByQueueName(this._queueName);
+  }
+
+  /**
    * Deletes the entry for the given ID.
    *
    * WARNING: this method does not ensure the deleted entry belongs to this

--- a/test/workbox-background-sync/sw/lib/test-QueueDb.mjs
+++ b/test/workbox-background-sync/sw/lib/test-QueueDb.mjs
@@ -350,6 +350,26 @@ describe(`QueueDb`, () => {
     });
   });
 
+  describe('getEntryCountByQueueName', () => {
+    it(`should return the number of entries in IDB filtered by index`, async () => {
+      const queueDb = new QueueDb();
+
+      await queueDb.addEntry(entry1);
+      await queueDb.addEntry(entry2);
+      await queueDb.addEntry(entry3);
+      await queueDb.addEntry(entry4);
+      await queueDb.addEntry(entry5);
+
+      expect(await queueDb.getEntryCountByQueueName('a')).to.equal(3);
+      expect(await queueDb.getEntryCountByQueueName('b')).to.equal(2);
+
+      await db.clear('requests');
+
+      expect(await queueDb.getEntryCountByQueueName('a')).to.equal(0);
+      expect(await queueDb.getEntryCountByQueueName('b')).to.equal(0);
+    });
+  });
+
   describe('deleteEntry', () => {
     it(`should delete an entry for the given ID`, async () => {
       const queueDb = new QueueDb();

--- a/test/workbox-background-sync/sw/lib/test-QueueStore.mjs
+++ b/test/workbox-background-sync/sw/lib/test-QueueStore.mjs
@@ -449,6 +449,53 @@ describe(`QueueStore`, function () {
     });
   });
 
+  describe(`size`, function () {
+    it(`should return the number of entries in IDB with the right queue name`, async function () {
+      const queueStore1 = new QueueStore('a');
+      const queueStore2 = new QueueStore('b');
+
+      const sr1 = await StorableRequest.fromRequest(new Request('/one'));
+      const sr2 = await StorableRequest.fromRequest(new Request('/two'));
+      const sr3 = await StorableRequest.fromRequest(new Request('/three'));
+      const sr4 = await StorableRequest.fromRequest(new Request('/four'));
+      const sr5 = await StorableRequest.fromRequest(new Request('/five'));
+
+      await queueStore1.pushEntry({
+        requestData: sr1.toObject(),
+        timestamp: 1000,
+        metadata: {name: 'meta1'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr2.toObject(),
+        timestamp: 2000,
+        metadata: {name: 'meta2'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr3.toObject(),
+        timestamp: 3000,
+        metadata: {name: 'meta3'},
+      });
+      await queueStore2.pushEntry({
+        requestData: sr4.toObject(),
+        timestamp: 4000,
+        metadata: {name: 'meta4'},
+      });
+      await queueStore1.pushEntry({
+        requestData: sr5.toObject(),
+        timestamp: 5000,
+        metadata: {name: 'meta5'},
+      });
+
+      expect(await queueStore1.size()).to.equal(2);
+      expect(await queueStore2.size()).to.equal(3);
+
+      await db.clear('requests');
+
+      expect(await queueStore1.size()).to.deep.equal(0);
+      expect(await queueStore2.size()).to.deep.equal(0);
+    });
+  });
+
   describe(`delete`, function () {
     it(`should delete an entry for the given ID`, async function () {
       const queueStore = new QueueStore('a');

--- a/test/workbox-background-sync/sw/test-Queue.mjs
+++ b/test/workbox-background-sync/sw/test-Queue.mjs
@@ -811,4 +811,23 @@ describe(`Queue`, function () {
       expect(await db.getAll('requests')).to.have.lengthOf(2);
     });
   });
+
+  describe(`size()`, function () {
+    it(`returns the number of requests in the QueueStore instance`, async function () {
+      const queue = new Queue('a');
+
+      const request1 = new Request('/one', {method: 'POST', body: '...'});
+      const request2 = new Request('/two', {method: 'POST', body: '...'});
+      const request3 = new Request('/three', {method: 'POST', body: '...'});
+
+      await queue.pushRequest({request: request1});
+      await queue.pushRequest({request: request2});
+      await queue.pushRequest({
+        request: request3,
+        metadata: {meta: 'data'},
+      });
+
+      expect(await queue.size()).to.equal(3);
+    });
+  });
 });


### PR DESCRIPTION
R: @jeffposnick @tropicadri

Fixes  GoogleChrome/workbox#2940

In short, this allows a developer to perform a quick count of what's left in the queue, so that a number could be displayed in a status indicator... or whatever else the developer wants to do with the number.

It's not as heavy as `(await queue.getAll()).length` and doesn't modify the queue

>- ensure that `gulp build && gulp lint test` passes locally.

Well, I tried... but Windows doesn't very much like the npm scripts and as such I had to bypass the git hooks as well, it just wouldn't run.. Hopefully I managed to keep everything consistent with the surrounding code :-)