### PR TITLE
Export more classes/types publicly

### DIFF
--- a/packages/workbox-background-sync/src/QueueStore.ts
+++ b/packages/workbox-background-sync/src/QueueStore.ts
@@ -1,0 +1,14 @@
+/*
+  Copyright 2018 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import './_version.js';
+
+// This is a temporary workaround to expose something from ./lib/ via our
+// top-level public API.
+// TODO: In Workbox v7, move the actual code from ./lib/ to this file.
+export {QueueStore} from './lib/QueueStore';

--- a/packages/workbox-background-sync/src/QueueStore.ts
+++ b/packages/workbox-background-sync/src/QueueStore.ts
@@ -1,5 +1,5 @@
 /*
-  Copyright 2018 Google LLC
+  Copyright 2021 Google LLC
 
   Use of this source code is governed by an MIT-style
   license that can be found in the LICENSE file or at

--- a/packages/workbox-background-sync/src/StorableRequest.ts
+++ b/packages/workbox-background-sync/src/StorableRequest.ts
@@ -1,0 +1,14 @@
+/*
+  Copyright 2018 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+import './_version.js';
+
+// This is a temporary workaround to expose something from ./lib/ via our
+// top-level public API.
+// TODO: In Workbox v7, move the actual code from ./lib/ to this file.
+export {StorableRequest} from './lib/StorableRequest';

--- a/packages/workbox-background-sync/src/StorableRequest.ts
+++ b/packages/workbox-background-sync/src/StorableRequest.ts
@@ -1,5 +1,5 @@
 /*
-  Copyright 2018 Google LLC
+  Copyright 2021 Google LLC
 
   Use of this source code is governed by an MIT-style
   license that can be found in the LICENSE file or at

--- a/packages/workbox-background-sync/src/index.ts
+++ b/packages/workbox-background-sync/src/index.ts
@@ -6,6 +6,8 @@
   https://opensource.org/licenses/MIT.
 */
 
+import {QueueStore} from './lib/QueueStore.js';
+import {StorableRequest} from './lib/StorableRequest.js';
 import {Queue, QueueOptions} from './Queue.js';
 import {BackgroundSyncPlugin} from './BackgroundSyncPlugin.js';
 
@@ -14,4 +16,4 @@ import './_version.js';
 /**
  * @module workbox-background-sync
  */
-export {BackgroundSyncPlugin, Queue, QueueOptions};
+export {BackgroundSyncPlugin, Queue, QueueOptions, QueueStore, StorableRequest};

--- a/packages/workbox-background-sync/src/index.ts
+++ b/packages/workbox-background-sync/src/index.ts
@@ -6,10 +6,10 @@
   https://opensource.org/licenses/MIT.
 */
 
-import {QueueStore} from './lib/QueueStore.js';
-import {StorableRequest} from './lib/StorableRequest.js';
-import {Queue, QueueOptions} from './Queue.js';
 import {BackgroundSyncPlugin} from './BackgroundSyncPlugin.js';
+import {Queue, QueueOptions} from './Queue.js';
+import {QueueStore} from './QueueStore.js';
+import {StorableRequest} from './StorableRequest.js';
 
 import './_version.js';
 

--- a/packages/workbox-background-sync/src/lib/QueueStore.ts
+++ b/packages/workbox-background-sync/src/lib/QueueStore.ts
@@ -7,18 +7,19 @@
 */
 
 import {assert} from 'workbox-core/_private/assert.js';
-import '../_version.js';
 import {
   UnidentifiedQueueStoreEntry,
   QueueStoreEntry,
   QueueDb,
 } from './QueueDb.js';
+import '../_version.js';
 
 /**
  * A class to manage storing requests from a Queue in IndexedDB,
  * indexed by their queue name for easier access.
  *
- * @private
+ * Most developers will not need to access this class directly;
+ * it is exposed for advanced use cases.
  */
 export class QueueStore {
   private readonly _queueName: string;
@@ -29,7 +30,6 @@ export class QueueStore {
    * identified by their queue name.
    *
    * @param {string} queueName
-   * @private
    */
   constructor(queueName: string) {
     this._queueName = queueName;
@@ -43,7 +43,6 @@ export class QueueStore {
    * @param {Object} entry.requestData
    * @param {number} [entry.timestamp]
    * @param {Object} [entry.metadata]
-   * @private
    */
   async pushEntry(entry: UnidentifiedQueueStoreEntry): Promise<void> {
     if (process.env.NODE_ENV !== 'production') {
@@ -75,7 +74,6 @@ export class QueueStore {
    * @param {Object} entry.requestData
    * @param {number} [entry.timestamp]
    * @param {Object} [entry.metadata]
-   * @private
    */
   async unshiftEntry(entry: UnidentifiedQueueStoreEntry): Promise<void> {
     if (process.env.NODE_ENV !== 'production') {
@@ -111,7 +109,6 @@ export class QueueStore {
    * Removes and returns the last entry in the queue matching the `queueName`.
    *
    * @return {Promise<QueueStoreEntry|undefined>}
-   * @private
    */
   async popEntry(): Promise<QueueStoreEntry | undefined> {
     return this._removeEntry(
@@ -123,7 +120,6 @@ export class QueueStore {
    * Removes and returns the first entry in the queue matching the `queueName`.
    *
    * @return {Promise<QueueStoreEntry|undefined>}
-   * @private
    */
   async shiftEntry(): Promise<QueueStoreEntry | undefined> {
     return this._removeEntry(
@@ -136,7 +132,6 @@ export class QueueStore {
    *
    * @param {Object} options See {@link module:workbox-background-sync.Queue~getAll}
    * @return {Promise<Array<Object>>}
-   * @private
    */
   async getAll(): Promise<QueueStoreEntry[]> {
     return await this._queueDb.getAllEntriesByQueueName(this._queueName);
@@ -147,7 +142,6 @@ export class QueueStore {
    *
    * @param {Object} options See {@link module:workbox-background-sync.Queue~size}
    * @return {Promise<number>}
-   * @private
    */
   async size(): Promise<number> {
     return await this._queueDb.getEntryCountByQueueName(this._queueName);
@@ -161,7 +155,6 @@ export class QueueStore {
    * as this class is not publicly exposed. An additional check would make
    * this method slower than it needs to be.
    *
-   * @private
    * @param {number} id
    */
   async deleteEntry(id: number): Promise<void> {
@@ -173,7 +166,6 @@ export class QueueStore {
    * `direction` argument) matching the `queueName`.
    *
    * @return {Promise<QueueStoreEntry|undefined>}
-   * @private
    */
   async _removeEntry(
     entry?: QueueStoreEntry,

--- a/packages/workbox-background-sync/src/lib/QueueStore.ts
+++ b/packages/workbox-background-sync/src/lib/QueueStore.ts
@@ -166,6 +166,7 @@ export class QueueStore {
    * `direction` argument) matching the `queueName`.
    *
    * @return {Promise<QueueStoreEntry|undefined>}
+   * @private
    */
   async _removeEntry(
     entry?: QueueStoreEntry,

--- a/packages/workbox-background-sync/src/lib/StorableRequest.ts
+++ b/packages/workbox-background-sync/src/lib/StorableRequest.ts
@@ -43,7 +43,8 @@ export interface RequestData extends MapLikeObject {
  * A class to make it easier to serialize and de-serialize requests so they
  * can be stored in IndexedDB.
  *
- * @private
+ * Most developers will not need to access this class directly;
+ * it is exposed for advanced use cases.
  */
 class StorableRequest {
   private readonly _requestData: RequestData;
@@ -54,8 +55,6 @@ class StorableRequest {
    *
    * @param {Request} request
    * @return {Promise<StorableRequest>}
-   *
-   * @private
    */
   static async fromRequest(request: Request): Promise<StorableRequest> {
     const requestData: RequestData = {
@@ -94,7 +93,6 @@ class StorableRequest {
    * @param {Object} requestData An object of request data that includes the
    *     `url` plus any relevant properties of
    *     [requestInit]{@link https://fetch.spec.whatwg.org/#requestinit}.
-   * @private
    */
   constructor(requestData: RequestData) {
     if (process.env.NODE_ENV !== 'production') {
@@ -125,8 +123,6 @@ class StorableRequest {
    * Returns a deep clone of the instances `_requestData` object.
    *
    * @return {Object}
-   *
-   * @private
    */
   toObject(): RequestData {
     const requestData = Object.assign({}, this._requestData);
@@ -142,8 +138,6 @@ class StorableRequest {
    * Converts this instance to a Request.
    *
    * @return {Request}
-   *
-   * @private
    */
   toRequest(): Request {
     return new Request(this._requestData.url, this._requestData);
@@ -153,8 +147,6 @@ class StorableRequest {
    * Creates and returns a deep clone of the instance.
    *
    * @return {StorableRequest}
-   *
-   * @private
    */
   clone(): StorableRequest {
     return new StorableRequest(this.toObject());

--- a/packages/workbox-precaching/src/_types.ts
+++ b/packages/workbox-precaching/src/_types.ts
@@ -22,6 +22,7 @@ export declare interface PrecacheEntry {
   url: string;
   revision?: string | null;
 }
+
 export interface PrecacheRouteOptions {
   directoryIndex?: string;
   ignoreURLParametersMatching?: RegExp[];

--- a/packages/workbox-precaching/src/index.ts
+++ b/packages/workbox-precaching/src/index.ts
@@ -48,3 +48,5 @@ export {
   PrecacheStrategy,
   PrecacheFallbackPlugin,
 };
+
+export * from './_types.js';

--- a/packages/workbox-strategies/src/index.ts
+++ b/packages/workbox-strategies/src/index.ts
@@ -8,10 +8,10 @@
 
 import {CacheFirst} from './CacheFirst.js';
 import {CacheOnly} from './CacheOnly.js';
-import {NetworkFirst} from './NetworkFirst.js';
-import {NetworkOnly} from './NetworkOnly.js';
+import {NetworkFirst, NetworkFirstOptions} from './NetworkFirst.js';
+import {NetworkOnly, NetworkOnlyOptions} from './NetworkOnly.js';
 import {StaleWhileRevalidate} from './StaleWhileRevalidate.js';
-import {Strategy} from './Strategy.js';
+import {Strategy, StrategyOptions} from './Strategy.js';
 import {StrategyHandler} from './StrategyHandler.js';
 import './_version.js';
 
@@ -26,8 +26,11 @@ export {
   CacheFirst,
   CacheOnly,
   NetworkFirst,
+  NetworkFirstOptions,
   NetworkOnly,
+  NetworkOnlyOptions,
   StaleWhileRevalidate,
   Strategy,
   StrategyHandler,
+  StrategyOptions,
 };

--- a/packages/workbox-streams/src/index.ts
+++ b/packages/workbox-streams/src/index.ts
@@ -17,3 +17,5 @@ import './_version.js';
  */
 
 export {concatenate, concatenateToResponse, isSupported, strategy};
+
+export * from './_types.js';


### PR DESCRIPTION
R: @tropicadri

Fixes #1824, fixes #2952

The additional exports of TypeScript types that might be useful to some developers via the top-level `index.ts` is hopefully not controversial.

There are also two previously private, internal classes in the `workbox-background-sync` module that this PR makes public. Based on the initial issue request, there's a use for developers accessing these directly, but I've warned in the JSDoc that most developers shouldn't. You've touched the `workbox-background-sync` code most recently, @tropicadri, so I'll defer to whether you anticipate any problems with making those classes public.