### PR TITLE
upgrade to @surma/rollup-plugin-off-main-thread dependencies from 1.4.1 to 2.2.2 (#2927)

### DIFF
--- a/infra/testing/validator/service-worker-runtime.js
+++ b/infra/testing/validator/service-worker-runtime.js
@@ -136,7 +136,7 @@ function setupSpiesAndContextForGenerateSW() {
   const context = Object.assign(
     {
       importScripts,
-      define: (_, scripts, callback) => {
+      define: (scripts, callback) => {
         importScripts(...scripts);
         callback(workboxContext);
       },

--- a/packages/workbox-background-sync/package-lock.json
+++ b/packages/workbox-background-sync/package-lock.json
@@ -8,11 +8,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.4.tgz",
       "integrity": "sha512-DshI5yxIB3NYc47cPpfipYX8MSIgQPqVR+WoaGI9EDq6cnLGgGYR1fp6z8/Bq9vMS8Jq1bS3eWUgXpFO5+ypSA=="
-    },
-    "workbox-core": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.3.0.tgz",
-      "integrity": "sha512-SufToEV3SOLwwz3j+P4pgkfpzLRUlR17sX3p/LrMHP/brYKvJQqjTwtSvaCkkAX0RPHX2TFHmN8xhPP1bpmomg=="
     }
   }
 }

--- a/packages/workbox-build/package-lock.json
+++ b/packages/workbox-build/package-lock.json
@@ -999,13 +999,14 @@
 			}
 		},
 		"@surma/rollup-plugin-off-main-thread": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.2.tgz",
-			"integrity": "sha512-dOD6nGZ79RmWKDRQuC7SOGXMvDkkLwBogu+epfVFMKiy2kOUtLZkb8wV/ettuMt37YJAJKYCKUmxSbZL2LkUQg==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
+			"integrity": "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==",
 			"requires": {
 				"ejs": "^3.1.6",
 				"json5": "^2.2.0",
-				"magic-string": "^0.25.0"
+				"magic-string": "^0.25.0",
+				"string.prototype.matchall": "^4.0.6"
 			},
 			"dependencies": {
 				"json5": {
@@ -1035,6 +1036,11 @@
 			"requires": {
 				"@types/node": "*"
 			}
+		},
+		"@types/trusted-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+			"integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
 		},
 		"ajv": {
 			"version": "8.6.0",
@@ -1107,6 +1113,15 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
 			"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA=="
+		},
+		"call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			}
 		},
 		"caniuse-lite": {
 			"version": "1.0.30001114",
@@ -1214,6 +1229,61 @@
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.533.tgz",
 			"integrity": "sha512-YqAL+NXOzjBnpY+dcOKDlZybJDCOzgsq4koW3fvyty/ldTmsb4QazZpOWmVvZ2m0t5jbBf7L0lIGU3BUipwG+A=="
 		},
+		"es-abstract": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+			"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"es-to-primitive": "^1.2.1",
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.1.1",
+				"get-symbol-description": "^1.0.0",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.2",
+				"internal-slot": "^1.0.3",
+				"is-callable": "^1.2.4",
+				"is-negative-zero": "^2.0.1",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.1",
+				"is-string": "^1.0.7",
+				"is-weakref": "^1.0.1",
+				"object-inspect": "^1.11.0",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.2",
+				"string.prototype.trimend": "^1.0.4",
+				"string.prototype.trimstart": "^1.0.4",
+				"unbox-primitive": "^1.0.1"
+			},
+			"dependencies": {
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
 		"escalade": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
@@ -1284,10 +1354,29 @@
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
 			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
 		},
+		"get-intrinsic": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
+		},
 		"get-own-enumerable-property-symbols": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
 			"integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
+		},
+		"get-symbol-description": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+			"integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.1"
+			}
 		},
 		"glob": {
 			"version": "7.1.6",
@@ -1320,6 +1409,11 @@
 				"function-bind": "^1.1.1"
 			}
 		},
+		"has-bigints": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1329,6 +1423,26 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+		},
+		"has-tostringtag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"requires": {
+				"has-symbols": "^1.0.2"
+			},
+			"dependencies": {
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+				}
+			}
+		},
+		"idb": {
+			"version": "6.1.5",
+			"resolved": "https://registry.npmjs.org/idb/-/idb-6.1.5.tgz",
+			"integrity": "sha512-IJtugpKkiVXQn5Y+LteyBCNk1N8xpGV3wWZk9EVtZWH8DYkjBn0bX1XnGP9RkyZF0sAcywa6unHqSWKe7q4LGw=="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -1344,6 +1458,16 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
+		"internal-slot": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+			"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+			"requires": {
+				"get-intrinsic": "^1.1.0",
+				"has": "^1.0.3",
+				"side-channel": "^1.0.4"
+			}
+		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -1351,6 +1475,28 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
+		},
+		"is-bigint": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"requires": {
+				"has-bigints": "^1.0.1"
+			}
+		},
+		"is-boolean-object": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-callable": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
 		},
 		"is-core-module": {
 			"version": "2.2.0",
@@ -1360,25 +1506,91 @@
 				"has": "^1.0.3"
 			}
 		},
+		"is-date-object": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
 			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
+		},
+		"is-negative-zero": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+		},
+		"is-number-object": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+			"integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
 		},
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 		},
+		"is-regex": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			}
+		},
 		"is-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
 			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
 		},
+		"is-shared-array-buffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+		},
 		"is-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
 			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+		},
+		"is-string": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-symbol": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+			"requires": {
+				"has-symbols": "^1.0.2"
+			},
+			"dependencies": {
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+				}
+			}
+		},
+		"is-weakref": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+			"requires": {
+				"call-bind": "^1.0.0"
+			}
 		},
 		"jake": {
 			"version": "10.8.2",
@@ -1525,6 +1737,11 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
 			"integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA=="
 		},
+		"object-inspect": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -1606,6 +1823,15 @@
 			"integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
 			"requires": {
 				"@babel/runtime": "^7.8.4"
+			}
+		},
+		"regexp.prototype.flags": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+			"integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
 			}
 		},
 		"regexpu-core": {
@@ -1691,6 +1917,16 @@
 				"randombytes": "^2.1.0"
 			}
 		},
+		"side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"requires": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			}
+		},
 		"source-map": {
 			"version": "0.8.0-beta.0",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
@@ -1724,6 +1960,46 @@
 			"version": "1.4.8",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
 			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+		},
+		"string.prototype.matchall": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
+			"integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.1",
+				"get-intrinsic": "^1.1.1",
+				"has-symbols": "^1.0.2",
+				"internal-slot": "^1.0.3",
+				"regexp.prototype.flags": "^1.3.1",
+				"side-channel": "^1.0.4"
+			},
+			"dependencies": {
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+				}
+			}
+		},
+		"string.prototype.trimend": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
+			}
+		},
+		"string.prototype.trimstart": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
+			}
 		},
 		"stringify-object": {
 			"version": "3.3.0",
@@ -1799,6 +2075,24 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
 			"integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg=="
 		},
+		"unbox-primitive": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has-bigints": "^1.0.1",
+				"has-symbols": "^1.0.2",
+				"which-boxed-primitive": "^1.0.2"
+			},
+			"dependencies": {
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+				}
+			}
+		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -1862,6 +2156,146 @@
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^1.0.1",
 				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"requires": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			}
+		},
+		"workbox-background-sync": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.3.0.tgz",
+			"integrity": "sha512-79Wznt6oO8xMmLiErRS4zENUEldFHj1/5IiuHsY3NgGRN5rJdvGW6hz+RERhWzoB7rd/vXyAQdKYahGdsiYG1A==",
+			"requires": {
+				"idb": "^6.0.0",
+				"workbox-core": "6.3.0"
+			}
+		},
+		"workbox-broadcast-update": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-6.3.0.tgz",
+			"integrity": "sha512-hp7Du6GJzK99wak5cQFhcSBxvcS+2fkFcxiMmz/RsQ5GQNxVcbiovq74w5aNCzuv3muQvICyC1XELZhZ4GYRTQ==",
+			"requires": {
+				"workbox-core": "6.3.0"
+			}
+		},
+		"workbox-cacheable-response": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.3.0.tgz",
+			"integrity": "sha512-oYCRGF6PFEmJJkktdxYw/tcrU8N5u/2ihxVSHd+9sNqjNMDiXLqsewcEG544f1yx7gq5/u6VcvUA5N62KzN1GQ==",
+			"requires": {
+				"workbox-core": "6.3.0"
+			}
+		},
+		"workbox-core": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.3.0.tgz",
+			"integrity": "sha512-SufToEV3SOLwwz3j+P4pgkfpzLRUlR17sX3p/LrMHP/brYKvJQqjTwtSvaCkkAX0RPHX2TFHmN8xhPP1bpmomg=="
+		},
+		"workbox-expiration": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-6.3.0.tgz",
+			"integrity": "sha512-teYuYfM3HFbwAD/nlZDw/dCMOrCKjsAiMRhz0uOy9IkfBb7vBynO3xf118lY62X6BfqjZdeahiHh10N0/aYICg==",
+			"requires": {
+				"idb": "^6.0.0",
+				"workbox-core": "6.3.0"
+			}
+		},
+		"workbox-google-analytics": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-6.3.0.tgz",
+			"integrity": "sha512-6u0y21rtimnrCKpvayTkwh9y4Y5Xdn6X87x895WzwcOcWA2j/Nl7nmCpB0wjjhqU9pMj7B2lChqfypP+xUs5IA==",
+			"requires": {
+				"workbox-background-sync": "6.3.0",
+				"workbox-core": "6.3.0",
+				"workbox-routing": "6.3.0",
+				"workbox-strategies": "6.3.0"
+			}
+		},
+		"workbox-navigation-preload": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-6.3.0.tgz",
+			"integrity": "sha512-D7bomh9SCn1u6n32FqAWfyHe2dkK6mWbwcTsoeBnFSD0p8Gr9Zq1Mpt/DitEfGIQHck90Zd024xcTFLkjczS/Q==",
+			"requires": {
+				"workbox-core": "6.3.0"
+			}
+		},
+		"workbox-precaching": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-6.3.0.tgz",
+			"integrity": "sha512-bND3rUxiuzFmDfeKywdvOqK0LQ5LLbOPk0eX22PlMQNOOduHRxzglMpgHo/MR6h+8cPJ3GpxT8hZ895/7bHMqQ==",
+			"requires": {
+				"workbox-core": "6.3.0",
+				"workbox-routing": "6.3.0",
+				"workbox-strategies": "6.3.0"
+			}
+		},
+		"workbox-range-requests": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-6.3.0.tgz",
+			"integrity": "sha512-AHnGtfSvc/fBt+8NCVT6jVcshv7oFkiuS94YsedQu2sIN1jKHkxLaj7qMBl818FoY6x7r0jw1WLmG/QDmI1/oA==",
+			"requires": {
+				"workbox-core": "6.3.0"
+			}
+		},
+		"workbox-recipes": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-6.3.0.tgz",
+			"integrity": "sha512-f0AZyxd48E4t+PV+ifgIf8WodfJqRj8/E0t+PwppDIdTPyD59cIh0HZBtgPKFdIMVnltodpMz4zioxym1H3GjQ==",
+			"requires": {
+				"workbox-cacheable-response": "6.3.0",
+				"workbox-core": "6.3.0",
+				"workbox-expiration": "6.3.0",
+				"workbox-precaching": "6.3.0",
+				"workbox-routing": "6.3.0",
+				"workbox-strategies": "6.3.0"
+			}
+		},
+		"workbox-routing": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.3.0.tgz",
+			"integrity": "sha512-asajX5UPkaoU4PB9pEpxKWKkcpA+KJQUEeYU6NlK0rXTCpdWQ6iieMRDoBTZBjTzUdL3j3s1Zo2qCOSvtXSYGg==",
+			"requires": {
+				"workbox-core": "6.3.0"
+			}
+		},
+		"workbox-strategies": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.3.0.tgz",
+			"integrity": "sha512-SYZt40y+Iu5nA+UEPQOrAuAMMNTxtUBPLCIaMMb4lcADpBYrNP1CD+/s2QsrxzS651a8hfi06REKt+uTp1tqfw==",
+			"requires": {
+				"workbox-core": "6.3.0"
+			}
+		},
+		"workbox-streams": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-6.3.0.tgz",
+			"integrity": "sha512-CiRsuoXJOytA7IQriRu6kVCa0L4OdNi0DdniiSageu/EZuxTswNXpgVzkGE4IDArU/5jlzgRtwqrqIWCJX+OMA==",
+			"requires": {
+				"workbox-core": "6.3.0",
+				"workbox-routing": "6.3.0"
+			}
+		},
+		"workbox-sw": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-6.3.0.tgz",
+			"integrity": "sha512-xwrXRBzw5jwJ7VdAQkTSNTbNZ4S6VhXtbZZ0vY6XKNQARO5nuGphNdif+hJFIejHUgtV6ESpQnixPj5hYB2jKQ=="
+		},
+		"workbox-window": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-6.3.0.tgz",
+			"integrity": "sha512-CFP84assX9srH/TOx4OD8z4EBPO/Cq4WKdV2YLcJIFJmVTS/cB63XKeidKl2KJk8qOOLVIKnaO7BLmb0MxGFtA==",
+			"requires": {
+				"@types/trusted-types": "^2.0.2",
+				"workbox-core": "6.3.0"
 			}
 		},
 		"wrappy": {

--- a/packages/workbox-build/package-lock.json
+++ b/packages/workbox-build/package-lock.json
@@ -999,12 +999,23 @@
 			}
 		},
 		"@surma/rollup-plugin-off-main-thread": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-1.4.1.tgz",
-			"integrity": "sha512-ZPBWYQDdO4JZiTmTP3DABsHhIPA7bEJk9Znk7tZsrbPGanoGo8YxMv//WLx5Cvb+lRgS42+6yiOIYYHCKDmkpQ==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.2.tgz",
+			"integrity": "sha512-dOD6nGZ79RmWKDRQuC7SOGXMvDkkLwBogu+epfVFMKiy2kOUtLZkb8wV/ettuMt37YJAJKYCKUmxSbZL2LkUQg==",
 			"requires": {
-				"ejs": "^2.6.1",
+				"ejs": "^3.1.6",
+				"json5": "^2.2.0",
 				"magic-string": "^0.25.0"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+					"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				}
 			}
 		},
 		"@types/estree": {
@@ -1043,6 +1054,11 @@
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
+		},
+		"async": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+			"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
 		},
 		"at-least-node": {
 			"version": "1.0.0",
@@ -1186,9 +1202,12 @@
 			}
 		},
 		"ejs": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-			"integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+			"integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+			"requires": {
+				"jake": "^10.6.1"
+			}
 		},
 		"electron-to-chromium": {
 			"version": "1.3.533",
@@ -1224,6 +1243,14 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+		},
+		"filelist": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
+			"integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+			"requires": {
+				"minimatch": "^3.0.4"
+			}
 		},
 		"fs-extra": {
 			"version": "9.0.1",
@@ -1352,6 +1379,17 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
 			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+		},
+		"jake": {
+			"version": "10.8.2",
+			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
+			"integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+			"requires": {
+				"async": "0.9.x",
+				"chalk": "^2.4.2",
+				"filelist": "^1.0.1",
+				"minimatch": "^3.0.4"
+			}
 		},
 		"jest-worker": {
 			"version": "26.3.0",

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -27,7 +27,7 @@
     "@rollup/plugin-babel": "^5.2.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-replace": "^2.4.1",
-    "@surma/rollup-plugin-off-main-thread": "^2.2.2",
+    "@surma/rollup-plugin-off-main-thread": "^2.2.3",
     "ajv": "^8.6.0",
     "common-tags": "^1.8.0",
     "fast-json-stable-stringify": "^2.1.0",

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -27,7 +27,7 @@
     "@rollup/plugin-babel": "^5.2.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-replace": "^2.4.1",
-    "@surma/rollup-plugin-off-main-thread": "^1.4.1",
+    "@surma/rollup-plugin-off-main-thread": "^2.2.2",
     "ajv": "^8.6.0",
     "common-tags": "^1.8.0",
     "fast-json-stable-stringify": "^2.1.0",

--- a/packages/workbox-cli/package-lock.json
+++ b/packages/workbox-cli/package-lock.json
@@ -112,15 +112,6 @@
         "@types/node": "*"
       }
     },
-    "@types/glob-watcher": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/glob-watcher/-/glob-watcher-5.0.0.tgz",
-      "integrity": "sha512-UZRHIRfTpcymeWQM6knz7SIHkYNNFZGn+3ybomdEyuEO0RpUHjRm5ro7ALL7MjYWI+W5Xn3VgVEl7atzlavVpw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/inquirer": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.0.tgz",
@@ -1331,11 +1322,6 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
-    },
-    "sents": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/sents/-/sents-0.3.2.tgz",
-      "integrity": "sha512-/4pT+XHLA1NF7v5PUBKueaq92ovmuUJugFxKo9Hw3vJenY5zkTW5dQjnzIu9enFoFLF/9IKWN2KeNq9ko9udYQ=="
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/packages/workbox-expiration/package-lock.json
+++ b/packages/workbox-expiration/package-lock.json
@@ -8,11 +8,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.4.tgz",
       "integrity": "sha512-DshI5yxIB3NYc47cPpfipYX8MSIgQPqVR+WoaGI9EDq6cnLGgGYR1fp6z8/Bq9vMS8Jq1bS3eWUgXpFO5+ypSA=="
-    },
-    "workbox-core": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.3.0.tgz",
-      "integrity": "sha512-SufToEV3SOLwwz3j+P4pgkfpzLRUlR17sX3p/LrMHP/brYKvJQqjTwtSvaCkkAX0RPHX2TFHmN8xhPP1bpmomg=="
     }
   }
 }


### PR DESCRIPTION
upgrade to @surma/rollup-plugin-off-main-thread dependencies from 1.4.1 to 2.2.2 (#2927)

Fixes #2927 
updated @surma/rollup-plugin-off-main-thread to use the new ejs version 3.1.6
