### PR TITLE
Take request.url into account in StrategyHandler.getCacheKey()

### DIFF
--- a/packages/workbox-strategies/src/StrategyHandler.ts
+++ b/packages/workbox-strategies/src/StrategyHandler.ts
@@ -43,7 +43,7 @@ class StrategyHandler {
   public event: ExtendableEvent;
   public params?: any;
 
-  private _cacheKeys: {read?: Request; write?: Request} = {};
+  private _cacheKeys: Record<string, Request> = {};
 
   private readonly _strategy: Strategy;
   private readonly _extendLifetimePromises: Promise<any>[];
@@ -437,7 +437,8 @@ class StrategyHandler {
     request: Request,
     mode: 'read' | 'write',
   ): Promise<Request> {
-    if (!this._cacheKeys[mode]) {
+    const key = `${request.url} | ${mode}`;
+    if (!this._cacheKeys[key]) {
       let effectiveRequest = request;
 
       for (const callback of this.iterateCallbacks('cacheKeyWillBeUsed')) {
@@ -452,9 +453,9 @@ class StrategyHandler {
         );
       }
 
-      this._cacheKeys[mode] = effectiveRequest;
+      this._cacheKeys[key] = effectiveRequest;
     }
-    return this._cacheKeys[mode]!;
+    return this._cacheKeys[key];
   }
 
   /**

--- a/test/workbox-strategies/sw/test-StrategyHandler.mjs
+++ b/test/workbox-strategies/sw/test-StrategyHandler.mjs
@@ -1295,7 +1295,7 @@ describe(`StrategyHandler`, function () {
       expect(writeCacheKey.url).to.equal(location.origin + '/test+1+write');
     });
 
-    it(`caches the key per mode to avoid repeat invocations`, async function () {
+    it(`caches the key using request + mode avoid repeat invocations`, async function () {
       const request = new Request('/test');
       const plugin = {
         cacheKeyWillBeUsed({mode, request}) {
@@ -1323,6 +1323,16 @@ describe(`StrategyHandler`, function () {
       await handler.getCacheKey(request, 'write');
       await handler.getCacheKey(request, 'write');
       expect(plugin.cacheKeyWillBeUsed.callCount).to.equal(2);
+
+      // See https://github.com/GoogleChrome/workbox/issues/2972
+      const secondRequest = new Request('/test2');
+
+      await handler.getCacheKey(secondRequest, 'read');
+      expect(plugin.cacheKeyWillBeUsed.callCount).to.equal(3);
+
+      await handler.getCacheKey(secondRequest, 'write');
+      await handler.getCacheKey(secondRequest, 'write');
+      expect(plugin.cacheKeyWillBeUsed.callCount).to.equal(4);
     });
   });
 });


### PR DESCRIPTION
R: @tropicadri

Fixes #2972

Longer-term we might want to get rid of this in-memory cache entirely (since it's not entirely obvious that the `cacheKeyWillBeUsed` callback is only executed once), but for the time being, this seemed like the safest, backwards-compatible approach that fixed the issue.