### PR TITLE
Fix preloadResponse type

### DIFF
--- a/packages/workbox-strategies/src/StrategyHandler.ts
+++ b/packages/workbox-strategies/src/StrategyHandler.ts
@@ -155,7 +155,9 @@ class StrategyHandler {
       event instanceof FetchEvent &&
       event.preloadResponse
     ) {
-      const possiblePreloadResponse = await event.preloadResponse;
+      const possiblePreloadResponse = (await event.preloadResponse) as
+        | Response
+        | undefined;
       if (possiblePreloadResponse) {
         if (process.env.NODE_ENV !== 'production') {
           logger.log(

--- a/packages/workbox-strategies/src/index.ts
+++ b/packages/workbox-strategies/src/index.ts
@@ -18,7 +18,8 @@ import './_version.js';
 // See https://github.com/GoogleChrome/workbox/issues/2946
 declare global {
   interface FetchEvent {
-    readonly preloadResponse: Promise<Response | undefined>;
+    // See https://github.com/GoogleChrome/workbox/issues/2974
+    readonly preloadResponse: Promise<any>;
   }
 }
 


### PR DESCRIPTION
R: @tropicadri

Fixes #2974

This fixes the type for `preloadResponse` that we're explicitly assigning for post TypeScript v4.4.0 compatibility, to match what the pre-TypeScript v4.4.0 type was.
