### PR TITLE
fix: update @apideck/better-ajv-errors to ^0.3.1

### DIFF
--- a/packages/workbox-build/package-lock.json
+++ b/packages/workbox-build/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "dependencies": {
     "@apideck/better-ajv-errors": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.2.7.tgz",
-      "integrity": "sha512-J2dW+EHYudbwI7MGovcHWLBrxasl21uuroc2zT8bH2RxYuv2g5GqsO5jcKUZz4LaMST45xhKjVuyRYkhcWyMhA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.1.tgz",
+      "integrity": "sha512-6RMV31esAxqlDIvVCG/CJxY/s8dFNVOI5w8RWIfDMhjg/iwqnawko9tJXau/leqC4+T1Bu8et99QVWCwU5wk+g==",
       "requires": {
-        "json-schema": "^0.3.0",
+        "json-schema": "^0.4.0",
         "jsonpointer": "^5.0.0",
         "leven": "^3.1.0"
       }
@@ -1037,6 +1037,11 @@
         "@types/node": "*"
       }
     },
+    "@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
     "ajv": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
@@ -1434,6 +1439,11 @@
         }
       }
     },
+    "idb": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.5.tgz",
+      "integrity": "sha512-IJtugpKkiVXQn5Y+LteyBCNk1N8xpGV3wWZk9EVtZWH8DYkjBn0bX1XnGP9RkyZF0sAcywa6unHqSWKe7q4LGw=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1629,9 +1639,9 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-schema": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
-      "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "1.0.0",
@@ -2161,330 +2171,131 @@
       }
     },
     "workbox-background-sync": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.4.1.tgz",
+      "integrity": "sha512-GiDklRhDF/oJ+WJhb6jO00wA+fjOZlY4SomqpumXP6OXp1WodmKu7xv75hpum0Kx4Fh3MZrj+9Ae+dIYlq21dA==",
       "requires": {
         "idb": "^6.1.4",
-        "workbox-core": "6.4.0"
-      },
-      "dependencies": {
-        "idb": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.4.tgz",
-          "integrity": "sha512-DshI5yxIB3NYc47cPpfipYX8MSIgQPqVR+WoaGI9EDq6cnLGgGYR1fp6z8/Bq9vMS8Jq1bS3eWUgXpFO5+ypSA=="
-        },
-        "workbox-core": {
-          "version": "6.4.0"
-        }
+        "workbox-core": "6.4.1"
       }
     },
     "workbox-broadcast-update": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-6.4.1.tgz",
+      "integrity": "sha512-oz1WAEppIatucgIc49zXPsyQG6004eoKsyiJVGDyN94LIFpUDfGa+cykN32X0PaqOC9bdlj+4EjVBi0OuwkIHA==",
       "requires": {
-        "workbox-core": "6.4.0"
-      },
-      "dependencies": {
-        "workbox-core": {
-          "version": "6.4.0"
-        }
+        "workbox-core": "6.4.1"
       }
     },
     "workbox-cacheable-response": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.4.1.tgz",
+      "integrity": "sha512-omXplP3miJhQwx+jfFnqO9xWgNc8CLG6EWRvTyc8R81cA/4zhqh87yj9UVH+fGUmuIXOUBPAuulSazXUsvKFWg==",
       "requires": {
-        "workbox-core": "6.4.0"
-      },
-      "dependencies": {
-        "workbox-core": {
-          "version": "6.4.0"
-        }
+        "workbox-core": "6.4.1"
       }
     },
     "workbox-core": {
-      "version": "6.4.0"
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.4.1.tgz",
+      "integrity": "sha512-5hosqpSK+48jHlj+5EHN5dtH1Ade4fqTe4+xX3U9wWK1SDaXEqXpVxdHuBqYfg75UE1PUINA0rhMZWTqeGoLFg=="
     },
     "workbox-expiration": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-6.4.1.tgz",
+      "integrity": "sha512-N912AGhi95vhf2vebE3wPhnGjnR+t5W4yALDY7Pl6bcuhySNbwkkp2RjQcBB+dxrdiX2rOvavvdcf/q1LSnEyg==",
       "requires": {
         "idb": "^6.1.4",
-        "workbox-core": "6.4.0"
-      },
-      "dependencies": {
-        "idb": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.4.tgz",
-          "integrity": "sha512-DshI5yxIB3NYc47cPpfipYX8MSIgQPqVR+WoaGI9EDq6cnLGgGYR1fp6z8/Bq9vMS8Jq1bS3eWUgXpFO5+ypSA=="
-        },
-        "workbox-core": {
-          "version": "6.4.0"
-        }
+        "workbox-core": "6.4.1"
       }
     },
     "workbox-google-analytics": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-6.4.1.tgz",
+      "integrity": "sha512-L1JQISg1CxMAlqw3HXpWB2gRYsmJ9F9OgC2/UNAZLyOJTFk1faZziPS4eXe+UaHevZ+Ma66Z2zfYxPUTr5znjQ==",
       "requires": {
-        "workbox-background-sync": "6.4.0",
-        "workbox-core": "6.4.0",
-        "workbox-routing": "6.4.0",
-        "workbox-strategies": "6.4.0"
-      },
-      "dependencies": {
-        "workbox-background-sync": {
-          "version": "6.4.0",
-          "requires": {
-            "idb": "^6.1.4",
-            "workbox-core": "6.4.0"
-          },
-          "dependencies": {
-            "idb": {
-              "version": "6.1.4",
-              "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.4.tgz",
-              "integrity": "sha512-DshI5yxIB3NYc47cPpfipYX8MSIgQPqVR+WoaGI9EDq6cnLGgGYR1fp6z8/Bq9vMS8Jq1bS3eWUgXpFO5+ypSA=="
-            },
-            "workbox-core": {
-              "version": "6.4.0"
-            }
-          }
-        },
-        "workbox-core": {
-          "version": "6.4.0"
-        },
-        "workbox-routing": {
-          "version": "6.4.0",
-          "requires": {
-            "workbox-core": "6.4.0"
-          },
-          "dependencies": {
-            "workbox-core": {
-              "version": "6.4.0"
-            }
-          }
-        },
-        "workbox-strategies": {
-          "version": "6.4.0",
-          "requires": {
-            "workbox-core": "6.4.0"
-          },
-          "dependencies": {
-            "workbox-core": {
-              "version": "6.4.0"
-            }
-          }
-        }
+        "workbox-background-sync": "6.4.1",
+        "workbox-core": "6.4.1",
+        "workbox-routing": "6.4.1",
+        "workbox-strategies": "6.4.1"
       }
     },
     "workbox-navigation-preload": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-6.4.1.tgz",
+      "integrity": "sha512-npgZYoeaE+teQvpWqZLgJDJ6I3qxwqAfnSIa8yrNQ2sLR1A88uWGGsiRzfUsIdKjVCLPQVZ+clwb6XU1vyW9Lw==",
       "requires": {
-        "workbox-core": "6.4.0"
-      },
-      "dependencies": {
-        "workbox-core": {
-          "version": "6.4.0"
-        }
+        "workbox-core": "6.4.1"
       }
     },
     "workbox-precaching": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-6.4.1.tgz",
+      "integrity": "sha512-Sq8d+/wfcXFjwuVwKe2VxD4QddRBgkO6pJVgpHbk5WFynR8dc8Zj3BlJ38e4nMlRuBZ8996TIgAmk/U6Rr5YHQ==",
       "requires": {
-        "workbox-core": "6.4.0",
-        "workbox-routing": "6.4.0",
-        "workbox-strategies": "6.4.0"
-      },
-      "dependencies": {
-        "workbox-core": {
-          "version": "6.4.0"
-        },
-        "workbox-routing": {
-          "version": "6.4.0",
-          "requires": {
-            "workbox-core": "6.4.0"
-          },
-          "dependencies": {
-            "workbox-core": {
-              "version": "6.4.0"
-            }
-          }
-        },
-        "workbox-strategies": {
-          "version": "6.4.0",
-          "requires": {
-            "workbox-core": "6.4.0"
-          },
-          "dependencies": {
-            "workbox-core": {
-              "version": "6.4.0"
-            }
-          }
-        }
+        "workbox-core": "6.4.1",
+        "workbox-routing": "6.4.1",
+        "workbox-strategies": "6.4.1"
       }
     },
     "workbox-range-requests": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-6.4.1.tgz",
+      "integrity": "sha512-X/asYHeuWIKg5Tk+dfmiEOo9hlkQ1K737dnENj8zL97kZDdcfokPT5CuXgM2xqX7NMoahONq1Eo2UoFfJNjZzg==",
       "requires": {
-        "workbox-core": "6.4.0"
-      },
-      "dependencies": {
-        "workbox-core": {
-          "version": "6.4.0"
-        }
+        "workbox-core": "6.4.1"
       }
     },
     "workbox-recipes": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-6.4.1.tgz",
+      "integrity": "sha512-Yu9tLmgD25NorZPO3FHJUii/Y2ghrx2jD2QKMaWBBplshw1MFokqlmr3Dz3O6NI8jBBUnK5Dtbl0+SCwVGSCqg==",
       "requires": {
-        "workbox-cacheable-response": "6.4.0",
-        "workbox-core": "6.4.0",
-        "workbox-expiration": "6.4.0",
-        "workbox-precaching": "6.4.0",
-        "workbox-routing": "6.4.0",
-        "workbox-strategies": "6.4.0"
-      },
-      "dependencies": {
-        "workbox-cacheable-response": {
-          "version": "6.4.0",
-          "requires": {
-            "workbox-core": "6.4.0"
-          },
-          "dependencies": {
-            "workbox-core": {
-              "version": "6.4.0"
-            }
-          }
-        },
-        "workbox-core": {
-          "version": "6.4.0"
-        },
-        "workbox-expiration": {
-          "version": "6.4.0",
-          "requires": {
-            "idb": "^6.1.4",
-            "workbox-core": "6.4.0"
-          },
-          "dependencies": {
-            "idb": {
-              "version": "6.1.4",
-              "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.4.tgz",
-              "integrity": "sha512-DshI5yxIB3NYc47cPpfipYX8MSIgQPqVR+WoaGI9EDq6cnLGgGYR1fp6z8/Bq9vMS8Jq1bS3eWUgXpFO5+ypSA=="
-            },
-            "workbox-core": {
-              "version": "6.4.0"
-            }
-          }
-        },
-        "workbox-precaching": {
-          "version": "6.4.0",
-          "requires": {
-            "workbox-core": "6.4.0",
-            "workbox-routing": "6.4.0",
-            "workbox-strategies": "6.4.0"
-          },
-          "dependencies": {
-            "workbox-core": {
-              "version": "6.4.0"
-            },
-            "workbox-routing": {
-              "version": "6.4.0",
-              "requires": {
-                "workbox-core": "6.4.0"
-              },
-              "dependencies": {}
-            },
-            "workbox-strategies": {
-              "version": "6.4.0",
-              "requires": {
-                "workbox-core": "6.4.0"
-              },
-              "dependencies": {}
-            }
-          }
-        },
-        "workbox-routing": {
-          "version": "6.4.0",
-          "requires": {
-            "workbox-core": "6.4.0"
-          },
-          "dependencies": {
-            "workbox-core": {
-              "version": "6.4.0"
-            }
-          }
-        },
-        "workbox-strategies": {
-          "version": "6.4.0",
-          "requires": {
-            "workbox-core": "6.4.0"
-          },
-          "dependencies": {
-            "workbox-core": {
-              "version": "6.4.0"
-            }
-          }
-        }
+        "workbox-cacheable-response": "6.4.1",
+        "workbox-core": "6.4.1",
+        "workbox-expiration": "6.4.1",
+        "workbox-precaching": "6.4.1",
+        "workbox-routing": "6.4.1",
+        "workbox-strategies": "6.4.1"
       }
     },
     "workbox-routing": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.4.1.tgz",
+      "integrity": "sha512-FIy27mwM3WdDASOTMX10OZ8q3Un47ULeDtDrDAKfWYIP/oTF2xoA1/HtXpOjBlyg5VP/poPX5GDojXHXAXpfzQ==",
       "requires": {
-        "workbox-core": "6.4.0"
-      },
-      "dependencies": {
-        "workbox-core": {
-          "version": "6.4.0"
-        }
+        "workbox-core": "6.4.1"
       }
     },
     "workbox-strategies": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.4.1.tgz",
+      "integrity": "sha512-2UQ+7Siy4Z5QG2LebbVhDLmPG3M7bVo/tZqN4LNUGXS6fDlpbTTK6A3Hu0W8gCVwIX0tSg7U3mVhDntH4qt3Dg==",
       "requires": {
-        "workbox-core": "6.4.0"
-      },
-      "dependencies": {
-        "workbox-core": {
-          "version": "6.4.0"
-        }
+        "workbox-core": "6.4.1"
       }
     },
     "workbox-streams": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-6.4.1.tgz",
+      "integrity": "sha512-0t3QKBml3Qi37JniDfEn0FfN4JRgMK6sEcjGxvmMGwlHAyKukZr0Gj58ax1o1KYGGJr72RDBK+YXI9Sk9cKifw==",
       "requires": {
-        "workbox-core": "6.4.0",
-        "workbox-routing": "6.4.0"
-      },
-      "dependencies": {
-        "workbox-core": {
-          "version": "6.4.0"
-        },
-        "workbox-routing": {
-          "version": "6.4.0",
-          "requires": {
-            "workbox-core": "6.4.0"
-          },
-          "dependencies": {
-            "workbox-core": {
-              "version": "6.4.0"
-            }
-          }
-        }
+        "workbox-core": "6.4.1",
+        "workbox-routing": "6.4.1"
       }
     },
     "workbox-sw": {
-      "version": "6.4.0"
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-6.4.1.tgz",
+      "integrity": "sha512-IJNYcNbjugMB9v+Yx7uswohjOaYoimw5dI0Gcaj2zrJHKjV0bom+BPRCdijmttN/3uVbX57jhNe8SMzWMj7fHw=="
     },
     "workbox-window": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-6.4.1.tgz",
+      "integrity": "sha512-v5G1U+NN0sHErvE9fzHRA75FrfRFj/0dihFnvno5yqHZZIb9G4U2AarodSDRBC3t6CsnLO68l1Bj1gsHqsM9Qw==",
       "requires": {
         "@types/trusted-types": "^2.0.2",
-        "workbox-core": "6.4.0"
-      },
-      "dependencies": {
-        "@types/trusted-types": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-          "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
-        },
-        "workbox-core": {
-          "version": "6.4.0"
-        }
+        "workbox-core": "6.4.1"
       }
     },
     "wrappy": {

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -20,7 +20,7 @@
   "bugs": "https://github.com/GoogleChrome/workbox/issues",
   "homepage": "https://github.com/GoogleChrome/workbox",
   "dependencies": {
-    "@apideck/better-ajv-errors": "^0.2.7",
+    "@apideck/better-ajv-errors": "^0.3.1",
     "@babel/core": "^7.11.1",
     "@babel/preset-env": "^7.11.0",
     "@babel/runtime": "^7.11.2",


### PR DESCRIPTION
R: @jeffposnick @tropicadri

Closes #2981 

Fixes https://github.com/advisories/GHSA-896r-f27r-55mw (`json-schema`) that was fixed in `better-ajv-errors` with 0.3.1 [#9](https://github.com/apideck-libraries/better-ajv-errors/pull/9) that is outside of the current minor range specified in `workbox-build`
