### PR TITLE
Skip ignoreURLParametersMatching in workbox wizard --injectManifest

### DIFF
--- a/packages/workbox-cli/src/lib/questions/ask-questions.ts
+++ b/packages/workbox-cli/src/lib/questions/ask-questions.ts
@@ -23,21 +23,30 @@ interface ConfigWithConfigLocation {
 export async function askQuestions(
   options = {},
 ): Promise<ConfigWithConfigLocation> {
+  const isInjectManifest = 'injectManifest' in options;
+
   const globDirectory = await askRootOfWebApp();
   const globPatterns = await askExtensionsToCache(globDirectory);
-  const swSrc = 'injectManifest' in options ? await askSWSrc() : undefined;
+  const swSrc = isInjectManifest ? await askSWSrc() : undefined;
   const swDest = await askSWDest(globDirectory);
   const configLocation = await askConfigLocation();
-  const ignoreURLParametersMatching = await askQueryParametersInStartUrl();
+  // See https://github.com/GoogleChrome/workbox/issues/2985
+  const ignoreURLParametersMatching = isInjectManifest
+    ? undefined
+    : await askQueryParametersInStartUrl();
+
   const config: {[key: string]: any} = {
     globDirectory,
     globPatterns,
-    ignoreURLParametersMatching,
     swDest,
   };
 
   if (swSrc) {
     config.swSrc = swSrc;
+  }
+
+  if (ignoreURLParametersMatching) {
+    config.ignoreURLParametersMatching = ignoreURLParametersMatching;
   }
 
   return {

--- a/test/workbox-cli/node/lib/questions/ask-questions.js
+++ b/test/workbox-cli/node/lib/questions/ask-questions.js
@@ -93,10 +93,9 @@ describe(`[workbox-cli] lib/questions/ask-questions.js`, function () {
         globPatterns: 1,
         swSrc: 2,
         swDest: 3,
-        ignoreURLParametersMatching: 5,
       },
       configLocation: 4,
     });
-    expect(stub.callCount).to.eql(6);
+    expect(stub.callCount).to.eql(5);
   });
 });


### PR DESCRIPTION
R: @tropicadri

Fixes #2985

This is an issue that I came across while using `workbox wizard` recently.
