### PR TITLE
JSDoc link cleanup

### DIFF
--- a/packages/workbox-background-sync/src/BackgroundSyncPlugin.ts
+++ b/packages/workbox-background-sync/src/BackgroundSyncPlugin.ts
@@ -14,7 +14,7 @@ import './_version.js';
  * A class implementing the `fetchDidFail` lifecycle callback. This makes it
  * easier to add failed requests to a background sync Queue.
  *
- * @memberof module:workbox-background-sync
+ * @memberof workbox-background-sync
  */
 class BackgroundSyncPlugin implements WorkboxPlugin {
   private readonly _queue: Queue;

--- a/packages/workbox-background-sync/src/BackgroundSyncPlugin.ts
+++ b/packages/workbox-background-sync/src/BackgroundSyncPlugin.ts
@@ -20,10 +20,10 @@ class BackgroundSyncPlugin implements WorkboxPlugin {
   private readonly _queue: Queue;
 
   /**
-   * @param {string} name See the [Queue]{@link module:workbox-background-sync.Queue}
+   * @param {string} name See the {@link workbox-background-sync.Queue}
    *     documentation for parameter details.
    * @param {Object} [options] See the
-   *     [Queue]{@link module:workbox-background-sync.Queue} documentation for
+   *     {@link workbox-background-sync.Queue} documentation for
    *     parameter details.
    */
   constructor(name: string, options?: QueueOptions) {

--- a/packages/workbox-background-sync/src/Queue.ts
+++ b/packages/workbox-background-sync/src/Queue.ts
@@ -72,7 +72,7 @@ const convertEntry = (
  * later. All parts of the storing and replaying process are observable via
  * callbacks.
  *
- * @memberof module:workbox-background-sync
+ * @memberof workbox-background-sync
  */
 class Queue {
   private readonly _name: string;

--- a/packages/workbox-background-sync/src/lib/QueueStore.ts
+++ b/packages/workbox-background-sync/src/lib/QueueStore.ts
@@ -130,7 +130,7 @@ export class QueueStore {
   /**
    * Returns all entries in the store matching the `queueName`.
    *
-   * @param {Object} options See {@link module:workbox-background-sync.Queue~getAll}
+   * @param {Object} options See {@link workbox-background-sync.Queue~getAll}
    * @return {Promise<Array<Object>>}
    */
   async getAll(): Promise<QueueStoreEntry[]> {
@@ -140,7 +140,7 @@ export class QueueStore {
   /**
    * Returns the number of entries in the store matching the `queueName`.
    *
-   * @param {Object} options See {@link module:workbox-background-sync.Queue~size}
+   * @param {Object} options See {@link workbox-background-sync.Queue~size}
    * @return {Promise<number>}
    */
   async size(): Promise<number> {

--- a/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts
+++ b/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts
@@ -60,7 +60,7 @@ function defaultPayloadGenerator(
  * For efficiency's sake, the underlying response bodies are not compared;
  * only specific response headers are checked.
  *
- * @memberof module:workbox-broadcast-update
+ * @memberof workbox-broadcast-update
  */
 class BroadcastCacheUpdate {
   private readonly _headersToCheck: string[];

--- a/packages/workbox-broadcast-update/src/BroadcastUpdatePlugin.ts
+++ b/packages/workbox-broadcast-update/src/BroadcastUpdatePlugin.ts
@@ -20,7 +20,7 @@ import './_version.js';
  * This plugin will automatically broadcast a message whenever a cached response
  * is updated.
  *
- * @memberof module:workbox-broadcast-update
+ * @memberof workbox-broadcast-update
  */
 class BroadcastUpdatePlugin implements WorkboxPlugin {
   private readonly _broadcastUpdate: BroadcastCacheUpdate;

--- a/packages/workbox-broadcast-update/src/BroadcastUpdatePlugin.ts
+++ b/packages/workbox-broadcast-update/src/BroadcastUpdatePlugin.ts
@@ -27,7 +27,7 @@ class BroadcastUpdatePlugin implements WorkboxPlugin {
 
   /**
    * Construct a BroadcastCacheUpdate instance with the passed options and
-   * calls its [`notifyIfUpdated()`]{@link module:workbox-broadcast-update.BroadcastCacheUpdate~notifyIfUpdated}
+   * calls its {@link workbox-broadcast-update.BroadcastCacheUpdate~notifyIfUpdated}
    * method whenever the plugin's `cacheDidUpdate` callback is invoked.
    *
    * @param {Object} [options]

--- a/packages/workbox-broadcast-update/src/responsesAreSame.ts
+++ b/packages/workbox-broadcast-update/src/responsesAreSame.ts
@@ -19,7 +19,7 @@ import './_version.js';
  * @param {Array<string>} headersToCheck
  * @return {boolean}
  *
- * @memberof module:workbox-broadcast-update
+ * @memberof workbox-broadcast-update
  */
 const responsesAreSame = (
   firstResponse: Response,

--- a/packages/workbox-build/src/generate-sw.ts
+++ b/packages/workbox-build/src/generate-sw.ts
@@ -34,7 +34,7 @@ import {writeSWUsingDefaultTemplate} from './lib/write-sw-using-default-template
  * that will be created by the build process, relative to the current working
  * directory. It must end in '.js'.
  *
- * @param {Array<module:workbox-build.ManifestEntry>} [config.additionalManifestEntries]
+ * @param {Array<workbox-build.ManifestEntry>} [config.additionalManifestEntries]
  * A list of entries to be precached, in addition to any entries that are
  * generated as part of the build configuration.
  *
@@ -105,7 +105,7 @@ import {writeSWUsingDefaultTemplate} from './lib/write-sw-using-default-template
  * worker. Keeping the runtime separate means that users will not have to
  * re-download the Workbox code each time your top-level service worker changes.
  *
- * @param {Array<module:workbox-build.ManifestTransform>} [config.manifestTransforms] One or more
+ * @param {Array<workbox-build.ManifestTransform>} [config.manifestTransforms] One or more
  * functions which will be applied sequentially against the generated manifest.
  * If `modifyURLPrefix` or `dontCacheBustURLsMatching` are also specified, their
  * corresponding transformations will be applied first.

--- a/packages/workbox-build/src/generate-sw.ts
+++ b/packages/workbox-build/src/generate-sw.ts
@@ -168,7 +168,7 @@ import {writeSWUsingDefaultTemplate} from './lib/write-sw-using-default-template
  * @param {Array<RuntimeCachingEntry>} [config.runtimeCaching]
  *
  * @param {boolean} [config.skipWaiting=false] Whether to add an
- * unconditional call to [`skipWaiting()`]{@link module:workbox-core.skipWaiting}
+ * unconditional call to [`skipWaiting()`](https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#skip_the_waiting_phase)
  * to the generated service worker. If `false`, then a `message` listener will
  * be added instead, allowing you to conditionally call `skipWaiting()` by posting
  * a message containing {type: 'SKIP_WAITING'}.

--- a/packages/workbox-build/src/generate-sw.ts
+++ b/packages/workbox-build/src/generate-sw.ts
@@ -191,7 +191,7 @@ import {writeSWUsingDefaultTemplate} from './lib/write-sw-using-default-template
  * `count` property contains the total number of precached entries. Any
  * non-fatal warning messages will be returned via `warnings`.
  *
- * @memberof module:workbox-build
+ * @memberof workbox-build
  */
 export async function generateSW(config: unknown): Promise<BuildResult> {
   const options = validateGenerateSWOptions(config);

--- a/packages/workbox-build/src/get-manifest.ts
+++ b/packages/workbox-build/src/get-manifest.ts
@@ -21,7 +21,7 @@ import {validateGetManifestOptions} from './lib/validate-options';
  * @param {string} config.globDirectory The local directory you wish to match
  * `globPatterns` against. The path is relative to the current directory.
  *
- * @param {Array<module:workbox-build.ManifestEntry>} [config.additionalManifestEntries]
+ * @param {Array<workbox-build.ManifestEntry>} [config.additionalManifestEntries]
  * A list of entries to be precached, in addition to any entries that are
  * generated as part of the build configuration.
  *
@@ -53,7 +53,7 @@ import {validateGetManifestOptions} from './lib/validate-options';
  * definition of `strict` in the `glob`
  * [documentation](https://github.com/isaacs/node-glob#options).
  *
- * @param {Array<module:workbox-build.ManifestTransform>} [config.manifestTransforms] One or more
+ * @param {Array<workbox-build.ManifestTransform>} [config.manifestTransforms] One or more
  * functions which will be applied sequentially against the generated manifest.
  * If `modifyURLPrefix` or `dontCacheBustURLsMatching` are also specified, their
  * corresponding transformations will be applied first.
@@ -79,7 +79,7 @@ import {validateGetManifestOptions} from './lib/validate-options';
  * version the URL. If used with a single string, it will be interpreted as
  * unique versioning information that you've generated for a given URL.
  *
- * @return {Promise<{count: number, manifestEntries: Array<module:workbox-build.ManifestEntry>, size: number, warnings: Array<string>}>}
+ * @return {Promise<{count: number, manifestEntries: Array<workbox-build.ManifestEntry>, size: number, warnings: Array<string>}>}
  * A promise that resolves once the precache manifest (available in the
  * `manifestEntries` property) has been determined. The `size` property
  * contains the aggregate size of all the precached entries, in bytes, and the

--- a/packages/workbox-build/src/get-manifest.ts
+++ b/packages/workbox-build/src/get-manifest.ts
@@ -86,7 +86,7 @@ import {validateGetManifestOptions} from './lib/validate-options';
  * `count` property contains the total number of precached entries. Any
  * non-fatal warning messages will be returned via `warnings`.
  *
- * @memberof module:workbox-build
+ * @memberof workbox-build
  */
 export async function getManifest(config: unknown): Promise<GetManifestResult> {
   const options = validateGetManifestOptions(config);

--- a/packages/workbox-build/src/inject-manifest.ts
+++ b/packages/workbox-build/src/inject-manifest.ts
@@ -46,7 +46,7 @@ import {validateInjectManifestOptions} from './lib/validate-options';
  * that will be read during the build process, relative to the current working
  * directory.
  *
- * @param {Array<module:workbox-build.ManifestEntry>} [config.additionalManifestEntries]
+ * @param {Array<workbox-build.ManifestEntry>} [config.additionalManifestEntries]
  * A list of entries to be precached, in addition to any entries that are
  * generated as part of the build configuration.
  *
@@ -82,7 +82,7 @@ import {validateInjectManifestOptions} from './lib/validate-options';
  * find inside of the `swSrc` file. Once found, it will be replaced by the
  * generated precache manifest.
  *
- * @param {Array<module:workbox-build.ManifestTransform>} [config.manifestTransforms] One or more
+ * @param {Array<workbox-build.ManifestTransform>} [config.manifestTransforms] One or more
  * functions which will be applied sequentially against the generated manifest.
  * If `modifyURLPrefix` or `dontCacheBustURLsMatching` are also specified, their
  * corresponding transformations will be applied first.

--- a/packages/workbox-build/src/inject-manifest.ts
+++ b/packages/workbox-build/src/inject-manifest.ts
@@ -115,7 +115,7 @@ import {validateInjectManifestOptions} from './lib/validate-options';
  * `count` property contains the total number of precached entries. Any
  * non-fatal warning messages will be returned via `warnings`.
  *
- * @memberof module:workbox-build
+ * @memberof workbox-build
  */
 export async function injectManifest(config: unknown): Promise<BuildResult> {
   const options = validateInjectManifestOptions(config);

--- a/packages/workbox-build/src/lib/copy-workbox-libraries.ts
+++ b/packages/workbox-build/src/lib/copy-workbox-libraries.ts
@@ -26,16 +26,16 @@ const BUILD_DIR = 'build';
  * Workbox from its official CDN URL.
  *
  * This method is exposed for the benefit of developers using
- * [injectManifest()]{@link module:workbox-build.injectManifest} who would
+ * [injectManifest()]{@link workbox-build.injectManifest} who would
  * prefer not to use the CDN copies of Workbox. Developers using
- * [generateSW()]{@link module:workbox-build.generateSW} don't need to
+ * [generateSW()]{@link workbox-build.generateSW} don't need to
  * explicitly call this method.
  *
  * @param {string} destDirectory The path to the parent directory under which
  * the new directory of libraries will be created.
  * @return {Promise<string>} The name of the newly created directory.
  *
- * @alias module:workbox-build.copyWorkboxLibraries
+ * @alias workbox-build.copyWorkboxLibraries
  */
 export async function copyWorkboxLibraries(
   destDirectory: string,

--- a/packages/workbox-build/src/lib/transform-manifest.ts
+++ b/packages/workbox-build/src/lib/transform-manifest.ts
@@ -21,7 +21,7 @@ import {noRevisionForURLsMatchingTransform} from './no-revision-for-urls-matchin
 /**
  * A `ManifestTransform` function can be used to modify the modify the `url` or
  * `revision` properties of some or all of the
- * {@link module:workbox-build.ManifestEntry|ManifestEntries} in the manifest.
+ * {@link workbox-build.ManifestEntry|ManifestEntries} in the manifest.
  *
  * Deleting the `revision` property of an entry will cause
  * the corresponding `url` to be precached without cache-busting parameters
@@ -59,15 +59,15 @@ import {noRevisionForURLsMatchingTransform} from './no-revision-for-urls-matchin
  * };
  *
  * @callback ManifestTransform
- * @param {Array<module:workbox-build.ManifestEntry>} manifestEntries The full
+ * @param {Array<workbox-build.ManifestEntry>} manifestEntries The full
  * array of entries, prior to the current transformation.
  * @param {Object} [compilation] When used in the webpack plugins, this param
  * will be set to the current `compilation`.
- * @return {Promise<module:workbox-build.ManifestTransformResult>}
+ * @return {Promise<workbox-build.ManifestTransformResult>}
  * The array of entries with the transformation applied, and optionally, any
  * warnings that should be reported back to the build tool.
  *
- * @memberof module:workbox-build
+ * @memberof workbox-build
  */
 
 interface ManifestTransformResultWithWarnings {

--- a/packages/workbox-cacheable-response/src/CacheableResponse.ts
+++ b/packages/workbox-cacheable-response/src/CacheableResponse.ts
@@ -23,7 +23,7 @@ export interface CacheableResponseOptions {
  * [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
  * to be considered cacheable.
  *
- * @memberof module:workbox-cacheable-response
+ * @memberof workbox-cacheable-response
  */
 class CacheableResponse {
   private readonly _statuses?: CacheableResponseOptions['statuses'];

--- a/packages/workbox-cacheable-response/src/CacheableResponsePlugin.ts
+++ b/packages/workbox-cacheable-response/src/CacheableResponsePlugin.ts
@@ -18,7 +18,7 @@ import './_version.js';
  * easier to add in cacheability checks to requests made via Workbox's built-in
  * strategies.
  *
- * @memberof module:workbox-cacheable-response
+ * @memberof workbox-cacheable-response
  */
 class CacheableResponsePlugin implements WorkboxPlugin {
   private readonly _cacheableResponse: CacheableResponse;

--- a/packages/workbox-core/src/_private/executeQuotaErrorCallbacks.ts
+++ b/packages/workbox-core/src/_private/executeQuotaErrorCallbacks.ts
@@ -14,7 +14,7 @@ import '../_version.js';
  * Runs all of the callback functions, one at a time sequentially, in the order
  * in which they were registered.
  *
- * @memberof module:workbox-core
+ * @memberof workbox-core
  * @private
  */
 async function executeQuotaErrorCallbacks(): Promise<void> {

--- a/packages/workbox-core/src/cacheNames.ts
+++ b/packages/workbox-core/src/cacheNames.ts
@@ -22,7 +22,7 @@ import './_version.js';
  * @return {Object} An object with `precache`, `runtime`, `prefix`, and
  *     `googleAnalytics` properties.
  *
- * @memberof module:workbox-core
+ * @memberof workbox-core
  */
 const cacheNames = {
   get googleAnalytics(): string {

--- a/packages/workbox-core/src/clientsClaim.ts
+++ b/packages/workbox-core/src/clientsClaim.ts
@@ -15,7 +15,7 @@ declare let self: ServiceWorkerGlobalScope;
  * Claim any currently available clients once the service worker
  * becomes active. This is normally used in conjunction with `skipWaiting()`.
  *
- * @memberof module:workbox-core
+ * @memberof workbox-core
  */
 function clientsClaim(): void {
   self.addEventListener('activate', () => self.clients.claim());

--- a/packages/workbox-core/src/copyResponse.ts
+++ b/packages/workbox-core/src/copyResponse.ts
@@ -28,7 +28,7 @@ import './_version.js';
  *
  * @param {Response} response
  * @param {Function} modifier
- * @memberof module:workbox-core
+ * @memberof workbox-core
  */
 async function copyResponse(
   response: Response,

--- a/packages/workbox-core/src/registerQuotaErrorCallback.ts
+++ b/packages/workbox-core/src/registerQuotaErrorCallback.ts
@@ -16,7 +16,7 @@ import './_version.js';
  * there's a quota error.
  *
  * @param {Function} callback
- * @memberof module:workbox-core
+ * @memberof workbox-core
  */
 // Can't change Function type
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/workbox-core/src/setCacheNameDetails.ts
+++ b/packages/workbox-core/src/setCacheNameDetails.ts
@@ -26,7 +26,7 @@ import './_version.js';
  * @param {Object} [details.googleAnalytics] The cache name to use for
  *     `workbox-google-analytics` caching.
  *
- * @memberof module:workbox-core
+ * @memberof workbox-core
  */
 function setCacheNameDetails(details: PartialCacheNameDetails): void {
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/workbox-core/src/skipWaiting.ts
+++ b/packages/workbox-core/src/skipWaiting.ts
@@ -18,7 +18,7 @@ declare let self: ServiceWorkerGlobalScope;
  *
  * Calling self.skipWaiting() is equivalent, and should be used instead.
  *
- * @memberof module:workbox-core
+ * @memberof workbox-core
  */
 function skipWaiting(): void {
   // Just call self.skipWaiting() directly.

--- a/packages/workbox-expiration/src/CacheExpiration.ts
+++ b/packages/workbox-expiration/src/CacheExpiration.ts
@@ -26,7 +26,7 @@ interface CacheExpirationConfig {
  * limit on the number of responses stored in a
  * [`Cache`](https://developer.mozilla.org/en-US/docs/Web/API/Cache).
  *
- * @memberof module:workbox-expiration
+ * @memberof workbox-expiration
  */
 class CacheExpiration {
   private _isRunning = false;

--- a/packages/workbox-expiration/src/ExpirationPlugin.ts
+++ b/packages/workbox-expiration/src/ExpirationPlugin.ts
@@ -47,7 +47,7 @@ export interface ExpirationPluginOptions {
  * When using `maxEntries`, the entry least-recently requested will be removed
  * from the cache first.
  *
- * @memberof module:workbox-expiration
+ * @memberof workbox-expiration
  */
 class ExpirationPlugin implements WorkboxPlugin {
   private readonly _config: ExpirationPluginOptions;

--- a/packages/workbox-google-analytics/src/initialize.ts
+++ b/packages/workbox-google-analytics/src/initialize.ts
@@ -205,7 +205,7 @@ const createGtmJsRoute = (cacheName: string) => {
  *     the hit. The function is invoked with the original hit's URLSearchParams
  *     object as its only argument.
  *
- * @memberof module:workbox-google-analytics
+ * @memberof workbox-google-analytics
  */
 const initialize = (options: GoogleAnalyticsInitializeOptions = {}): void => {
   const cacheName = cacheNames.getGoogleAnalyticsName(options.cacheName);

--- a/packages/workbox-google-analytics/src/initialize.ts
+++ b/packages/workbox-google-analytics/src/initialize.ts
@@ -40,7 +40,7 @@ export interface GoogleAnalyticsInitializeOptions {
  * `qt` param based on the current time, as well as applies any other
  * user-defined hit modifications.
  *
- * @param {Object} config See {@link module:workbox-google-analytics.initialize}.
+ * @param {Object} config See {@link workbox-google-analytics.initialize}.
  * @return {Function} The requestWillDequeue callback function.
  *
  * @private

--- a/packages/workbox-navigation-preload/src/disable.ts
+++ b/packages/workbox-navigation-preload/src/disable.ts
@@ -16,7 +16,7 @@ declare let self: ServiceWorkerGlobalScope;
 /**
  * If the browser supports Navigation Preload, then this will disable it.
  *
- * @memberof module:workbox-navigation-preload
+ * @memberof workbox-navigation-preload
  */
 function disable(): void {
   if (isSupported()) {

--- a/packages/workbox-navigation-preload/src/enable.ts
+++ b/packages/workbox-navigation-preload/src/enable.ts
@@ -21,7 +21,7 @@ declare let self: ServiceWorkerGlobalScope;
  * the value of the `Service-Worker-Navigation-Preload` header which will be
  * sent to the server when making the navigation request.
  *
- * @memberof module:workbox-navigation-preload
+ * @memberof workbox-navigation-preload
  */
 function enable(headerValue?: string): void {
   if (isSupported()) {

--- a/packages/workbox-navigation-preload/src/isSupported.ts
+++ b/packages/workbox-navigation-preload/src/isSupported.ts
@@ -15,7 +15,7 @@ declare let self: ServiceWorkerGlobalScope;
  * @return {boolean} Whether or not the current browser supports enabling
  * navigation preload.
  *
- * @memberof module:workbox-navigation-preload
+ * @memberof workbox-navigation-preload
  */
 function isSupported(): boolean {
   return Boolean(self.registration && self.registration.navigationPreload);

--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -88,7 +88,7 @@ class PrecacheController {
   }
 
   /**
-   * @type {module:workbox-precaching.PrecacheStrategy} The strategy created by this controller and
+   * @type {workbox-precaching.PrecacheStrategy} The strategy created by this controller and
    * used to cache assets and respond to fetch events.
    */
   get strategy(): Strategy {
@@ -119,7 +119,7 @@ class PrecacheController {
    * This method will add items to the precache list, removing duplicates
    * and ensuring the information is valid.
    *
-   * @param {Array<module:workbox-precaching.PrecacheController.PrecacheEntry|string>} entries
+   * @param {Array<workbox-precaching.PrecacheController.PrecacheEntry|string>} entries
    *     Array of entries to precache.
    */
   addToCacheList(entries: Array<PrecacheEntry | string>): void {
@@ -194,7 +194,7 @@ class PrecacheController {
    * to call it yourself in your event handlers.
    *
    * @param {ExtendableEvent} event
-   * @return {Promise<module:workbox-precaching.InstallResult>}
+   * @return {Promise<workbox-precaching.InstallResult>}
    */
   install(event: ExtendableEvent): Promise<InstallResult> {
     // waitUntil returns Promise<any>
@@ -242,7 +242,7 @@ class PrecacheController {
    * to call it yourself in your event handlers.
    *
    * @param {ExtendableEvent} event
-   * @return {Promise<module:workbox-precaching.CleanupResult>}
+   * @return {Promise<workbox-precaching.CleanupResult>}
    */
   activate(event: ExtendableEvent): Promise<CleanupResult> {
     // waitUntil returns Promise<any>
@@ -347,7 +347,7 @@ class PrecacheController {
    *
    * @param {string} url The precached URL which will be used to lookup the
    * `Response`.
-   * @return {module:workbox-routing~handlerCallback}
+   * @return {workbox-routing~handlerCallback}
    */
   createHandlerBoundToURL(url: string): RouteHandlerCallback {
     const cacheKey = this.getCacheKeyForURL(url);

--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -98,7 +98,7 @@ class PrecacheController {
   /**
    * Adds items to the precache list, removing any duplicates and
    * stores the files in the
-   * ["precache cache"]{@link module:workbox-core.cacheNames} when the service
+   * {@link workbox-core.cacheNames|"precache cache"} when the service
    * worker installs.
    *
    * This method can be called multiple times.

--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -41,7 +41,7 @@ interface PrecacheControllerOptions {
 /**
  * Performs efficient precaching of assets.
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 class PrecacheController {
   private _installAndActiveListenersAdded?: boolean;

--- a/packages/workbox-precaching/src/PrecacheFallbackPlugin.ts
+++ b/packages/workbox-precaching/src/PrecacheFallbackPlugin.ts
@@ -25,7 +25,7 @@ import './_version.js';
  * constructor, the default instance will be used. Generally speaking, most
  * developers will end up using the default.
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 class PrecacheFallbackPlugin implements WorkboxPlugin {
   private readonly _fallbackURL: string;

--- a/packages/workbox-precaching/src/PrecacheRoute.ts
+++ b/packages/workbox-precaching/src/PrecacheRoute.ts
@@ -42,7 +42,7 @@ class PrecacheRoute extends Route {
    * array of regex's to remove search params when looking for a cache match.
    * @param {boolean} [options.cleanURLs=true] The `cleanURLs` option will
    * check the cache for the URL with a `.html` added to the end of the end.
-   * @param {module:workbox-precaching~urlManipulation} [options.urlManipulation]
+   * @param {workbox-precaching~urlManipulation} [options.urlManipulation]
    * This is a function that should take a URL and return an array of
    * alternative URLs that should be checked for precache matches.
    */

--- a/packages/workbox-precaching/src/PrecacheRoute.ts
+++ b/packages/workbox-precaching/src/PrecacheRoute.ts
@@ -26,8 +26,8 @@ import './_version.js';
  * instance and uses it to match incoming requests and handle fetching
  * responses from the precache.
  *
- * @memberof module:workbox-precaching
- * @extends module:workbox-routing.Route
+ * @memberof workbox-precaching
+ * @extends workbox-routing.Route
  */
 class PrecacheRoute extends Route {
   /**

--- a/packages/workbox-precaching/src/PrecacheRoute.ts
+++ b/packages/workbox-precaching/src/PrecacheRoute.ts
@@ -21,8 +21,8 @@ import {generateURLVariations} from './utils/generateURLVariations.js';
 import './_version.js';
 
 /**
- * A subclass of [Route]{@link module:workbox-routing.Route} that takes a
- * [PrecacheController]{@link module:workbox-precaching.PrecacheController}
+ * A subclass of {@link workbox-routing.Route} that takes a
+ * {@link workbox-precaching.PrecacheController}
  * instance and uses it to match incoming requests and handle fetching
  * responses from the precache.
  *

--- a/packages/workbox-precaching/src/PrecacheStrategy.ts
+++ b/packages/workbox-precaching/src/PrecacheStrategy.ts
@@ -86,7 +86,7 @@ class PrecacheStrategy extends Strategy {
   /**
    * @private
    * @param {Request|string} request A request to run this strategy for.
-   * @param {module:workbox-strategies.StrategyHandler} handler The event that
+   * @param {workbox-strategies.StrategyHandler} handler The event that
    *     triggered the request.
    * @return {Promise<Response>}
    */

--- a/packages/workbox-precaching/src/PrecacheStrategy.ts
+++ b/packages/workbox-precaching/src/PrecacheStrategy.ts
@@ -30,8 +30,8 @@ interface PrecacheStrategyOptions extends StrategyOptions {
  * Note: an instance of this class is created automatically when creating a
  * `PrecacheController`; it's generally not necessary to create this yourself.
  *
- * @extends module:workbox-strategies.Strategy
- * @memberof module:workbox-precaching
+ * @extends workbox-strategies.Strategy
+ * @memberof workbox-precaching
  */
 class PrecacheStrategy extends Strategy {
   private readonly _fallbackToNetwork: boolean;

--- a/packages/workbox-precaching/src/PrecacheStrategy.ts
+++ b/packages/workbox-precaching/src/PrecacheStrategy.ts
@@ -22,9 +22,9 @@ interface PrecacheStrategyOptions extends StrategyOptions {
 }
 
 /**
- * A [Strategy]{@link module:workbox-strategies.Strategy} implementation
+ * A {@link workbox-strategies.Strategy} implementation
  * specifically designed to work with
- * [PrecacheController]{@link module:workbox-precaching.PrecacheController}
+ * {@link workbox-precaching.PrecacheController}
  * to both cache and fetch precached assets.
  *
  * Note: an instance of this class is created automatically when creating a
@@ -57,14 +57,14 @@ class PrecacheStrategy extends Strategy {
    * @param {Object} [options]
    * @param {string} [options.cacheName] Cache name to store and retrieve
    * requests. Defaults to the cache names provided by
-   * [workbox-core]{@link module:workbox-core.cacheNames}.
-   * @param {Array<Object>} [options.plugins] [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
+   * {@link workbox-core.cacheNames}.
+   * @param {Array<Object>} [options.plugins] {@link https://developers.google.com/web/tools/workbox/guides/using-plugins|Plugins}
    * to use in conjunction with this caching strategy.
    * @param {Object} [options.fetchOptions] Values passed along to the
-   * [`init`]{@link https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters}
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters|init}
    * of all fetch() requests made by this strategy.
    * @param {Object} [options.matchOptions] The
-   * [`CacheQueryOptions`]{@link https://w3c.github.io/ServiceWorker/#dictdef-cachequeryoptions}
+   * {@link https://w3c.github.io/ServiceWorker/#dictdef-cachequeryoptions|CacheQueryOptions}
    * for any `cache.match()` or `cache.put()` calls made by this strategy.
    * @param {boolean} [options.fallbackToNetwork=true] Whether to attempt to
    * get the response from the network if there's a precache miss.

--- a/packages/workbox-precaching/src/_types.ts
+++ b/packages/workbox-precaching/src/_types.ts
@@ -46,7 +46,7 @@ export type urlManipulation = ({url}: {url: URL}) => URL[];
  * @property {Array<string>} notUpdatedURLs List of URLs that were already up to
  * date.
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 
 /**
@@ -54,7 +54,7 @@ export type urlManipulation = ({url}: {url: URL}) => URL[];
  * @property {Array<string>} deletedCacheRequests List of URLs that were deleted
  * while cleaning up the cache.
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 
 /**
@@ -64,7 +64,7 @@ export type urlManipulation = ({url}: {url: URL}) => URL[];
  * @property {string} [integrity] Integrity metadata that will be used when
  * making the network request for the URL.
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 
 /**
@@ -81,5 +81,5 @@ export type urlManipulation = ({url}: {url: URL}) => URL[];
  * @return {Array<URL>} To add additional urls to test, return an Array of
  * URLs. Please note that these **should not be strings**, but URL objects.
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */

--- a/packages/workbox-precaching/src/addPlugins.ts
+++ b/packages/workbox-precaching/src/addPlugins.ts
@@ -15,7 +15,7 @@ import './_version.js';
  *
  * @param {Array<Object>} plugins
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 function addPlugins(plugins: WorkboxPlugin[]): void {
   const precacheController = getOrCreatePrecacheController();

--- a/packages/workbox-precaching/src/addRoute.ts
+++ b/packages/workbox-precaching/src/addRoute.ts
@@ -26,7 +26,7 @@ import './_version.js';
  * @param {Object} [options] See the {@link workbox-precaching.PrecacheRoute}
  * options.
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 function addRoute(options?: PrecacheRouteOptions): void {
   const precacheController = getOrCreatePrecacheController();

--- a/packages/workbox-precaching/src/addRoute.ts
+++ b/packages/workbox-precaching/src/addRoute.ts
@@ -23,8 +23,8 @@ import './_version.js';
  * responded to, allowing the event to fall through to other `fetch` event
  * listeners.
  *
- * @param {Object} [options] See
- * [PrecacheRoute options]{@link module:workbox-precaching.PrecacheRoute}.
+ * @param {Object} [options] See the {@link workbox-precaching.PrecacheRoute}
+ * options.
  *
  * @memberof module:workbox-precaching
  */

--- a/packages/workbox-precaching/src/cleanupOutdatedCaches.ts
+++ b/packages/workbox-precaching/src/cleanupOutdatedCaches.ts
@@ -15,7 +15,7 @@ import './_version.js';
  * Adds an `activate` event listener which will clean up incompatible
  * precaches that were created by older versions of Workbox.
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 function cleanupOutdatedCaches(): void {
   // See https://github.com/Microsoft/TypeScript/issues/28357#issuecomment-436484705

--- a/packages/workbox-precaching/src/createHandlerBoundToURL.ts
+++ b/packages/workbox-precaching/src/createHandlerBoundToURL.ts
@@ -23,7 +23,7 @@ import './_version.js';
  * `Response`.
  * @param {boolean} [fallbackToNetwork=true] Whether to attempt to get the
  * response from the network if there's a precache miss.
- * @return {module:workbox-routing~handlerCallback}
+ * @return {workbox-routing~handlerCallback}
  *
  * @memberof workbox-precaching
  */

--- a/packages/workbox-precaching/src/createHandlerBoundToURL.ts
+++ b/packages/workbox-precaching/src/createHandlerBoundToURL.ts
@@ -25,7 +25,7 @@ import './_version.js';
  * response from the network if there's a precache miss.
  * @return {module:workbox-routing~handlerCallback}
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 function createHandlerBoundToURL(url: string): RouteHandlerCallback {
   const precacheController = getOrCreatePrecacheController();

--- a/packages/workbox-precaching/src/getCacheKeyForURL.ts
+++ b/packages/workbox-precaching/src/getCacheKeyForURL.ts
@@ -26,7 +26,7 @@ import './_version.js';
  * @param {string} url The URL whose cache key to look up.
  * @return {string} The cache key that corresponds to that URL.
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 function getCacheKeyForURL(url: string): string | undefined {
   const precacheController = getOrCreatePrecacheController();

--- a/packages/workbox-precaching/src/index.ts
+++ b/packages/workbox-precaching/src/index.ts
@@ -23,12 +23,12 @@ import './_version.js';
 
 /**
  * Most consumers of this module will want to use the
- * [precacheAndRoute()]{@link module:workbox-precaching.precacheAndRoute}
+ * {@link workbox-precaching.precacheAndRoute}
  * method to add assets to the cache and respond to network requests with these
  * cached assets.
  *
  * If you require more control over caching and routing, you can use the
- * [PrecacheController]{@link module:workbox-precaching.PrecacheController}
+ * {@link workbox-precaching.PrecacheController}
  * interface.
  *
  * @module workbox-precaching

--- a/packages/workbox-precaching/src/matchPrecache.ts
+++ b/packages/workbox-precaching/src/matchPrecache.ts
@@ -23,7 +23,7 @@ import './_version.js';
  * to look up in the precache.
  * @return {Promise<Response|undefined>}
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 function matchPrecache(
   request: string | Request,

--- a/packages/workbox-precaching/src/precache.ts
+++ b/packages/workbox-precaching/src/precache.ts
@@ -13,17 +13,17 @@ import './_version.js';
 /**
  * Adds items to the precache list, removing any duplicates and
  * stores the files in the
- * ["precache cache"]{@link module:workbox-core.cacheNames} when the service
+ * {@link workbox-core.cacheNames|"precache cache"} when the service
  * worker installs.
  *
  * This method can be called multiple times.
  *
  * Please note: This method **will not** serve any of the cached files for you.
  * It only precaches files. To respond to a network request you call
- * [addRoute()]{@link module:workbox-precaching.addRoute}.
+ * {@link workbox-precaching.addRoute}.
  *
  * If you have a single array of files to precache, you can just call
- * [precacheAndRoute()]{@link module:workbox-precaching.precacheAndRoute}.
+ * {@link workbox-precaching.precacheAndRoute}.
  *
  * @param {Array<Object|string>} [entries=[]] Array of entries to precache.
  *

--- a/packages/workbox-precaching/src/precache.ts
+++ b/packages/workbox-precaching/src/precache.ts
@@ -27,7 +27,7 @@ import './_version.js';
  *
  * @param {Array<Object|string>} [entries=[]] Array of entries to precache.
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 function precache(entries: Array<PrecacheEntry | string>): void {
   const precacheController = getOrCreatePrecacheController();

--- a/packages/workbox-precaching/src/precacheAndRoute.ts
+++ b/packages/workbox-precaching/src/precacheAndRoute.ts
@@ -16,12 +16,12 @@ import './_version.js';
  * respond to fetch events.
  *
  * This is a convenience method that will call
- * [precache()]{@link module:workbox-precaching.precache} and
- * [addRoute()]{@link module:workbox-precaching.addRoute} in a single call.
+ * {@link workbox-precaching.precache} and
+ * {@link workbox-precaching.addRoute} in a single call.
  *
  * @param {Array<Object|string>} entries Array of entries to precache.
- * @param {Object} [options] See
- * [PrecacheRoute options]{@link module:workbox-precaching.PrecacheRoute}.
+ * @param {Object} [options] See the
+ * {@link workbox-precaching.PrecacheRoute} options.
  *
  * @memberof module:workbox-precaching
  */

--- a/packages/workbox-precaching/src/precacheAndRoute.ts
+++ b/packages/workbox-precaching/src/precacheAndRoute.ts
@@ -23,7 +23,7 @@ import './_version.js';
  * @param {Object} [options] See the
  * {@link workbox-precaching.PrecacheRoute} options.
  *
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 function precacheAndRoute(
   entries: Array<PrecacheEntry | string>,

--- a/packages/workbox-precaching/src/utils/createCacheKey.ts
+++ b/packages/workbox-precaching/src/utils/createCacheKey.ts
@@ -25,7 +25,7 @@ const REVISION_SEARCH_PARAM = '__WB_REVISION__';
  * @return {string} A URL with versioning info.
  *
  * @private
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 export function createCacheKey(entry: PrecacheEntry | string): CacheKey {
   if (!entry) {

--- a/packages/workbox-precaching/src/utils/deleteOutdatedCaches.ts
+++ b/packages/workbox-precaching/src/utils/deleteOutdatedCaches.ts
@@ -29,7 +29,7 @@ const SUBSTRING_TO_FIND = '-precache-';
  * @return {Array<string>} A list of all the cache names that were deleted.
  *
  * @private
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 const deleteOutdatedCaches = async (
   currentPrecacheName: string,

--- a/packages/workbox-precaching/src/utils/generateURLVariations.ts
+++ b/packages/workbox-precaching/src/utils/generateURLVariations.ts
@@ -18,7 +18,7 @@ import '../_version.js';
  * @param {Object} options
  *
  * @private
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 export function* generateURLVariations(
   url: string,

--- a/packages/workbox-precaching/src/utils/printCleanupDetails.ts
+++ b/packages/workbox-precaching/src/utils/printCleanupDetails.ts
@@ -29,7 +29,7 @@ const logGroup = (groupTitle: string, deletedURLs: string[]) => {
  * @param {Array<string>} deletedURLs
  *
  * @private
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 export function printCleanupDetails(deletedURLs: string[]): void {
   const deletionCount = deletedURLs.length;

--- a/packages/workbox-precaching/src/utils/printInstallDetails.ts
+++ b/packages/workbox-precaching/src/utils/printInstallDetails.ts
@@ -34,7 +34,7 @@ function _nestedGroup(groupTitle: string, urls: string[]): void {
  * @param {Array<string>} urlsAlreadyPrecached
  *
  * @private
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 export function printInstallDetails(
   urlsToPrecache: string[],

--- a/packages/workbox-precaching/src/utils/removeIgnoredSearchParams.ts
+++ b/packages/workbox-precaching/src/utils/removeIgnoredSearchParams.ts
@@ -18,7 +18,7 @@ import '../_version.js';
  * @return {URL} The URL with any ignored search parameters removed.
  *
  * @private
- * @memberof module:workbox-precaching
+ * @memberof workbox-precaching
  */
 export function removeIgnoredSearchParams(
   urlObject: URL,

--- a/packages/workbox-range-requests/src/RangeRequestsPlugin.ts
+++ b/packages/workbox-range-requests/src/RangeRequestsPlugin.ts
@@ -17,7 +17,7 @@ import './_version.js';
  * It does this by intercepting the `cachedResponseWillBeUsed` plugin callback
  * and returning the appropriate subset of the cached response body.
  *
- * @memberof module:workbox-range-requests
+ * @memberof workbox-range-requests
  */
 class RangeRequestsPlugin implements WorkboxPlugin {
   /**

--- a/packages/workbox-range-requests/src/createPartialResponse.ts
+++ b/packages/workbox-range-requests/src/createPartialResponse.ts
@@ -29,7 +29,7 @@ import './_version.js';
  * `Range:` header, or a `416 Range Not Satisfiable` response if the
  * conditions of the `Range:` header can't be met.
  *
- * @memberof module:workbox-range-requests
+ * @memberof workbox-range-requests
  */
 async function createPartialResponse(
   request: Request,

--- a/packages/workbox-recipes/src/googleFontsCache.ts
+++ b/packages/workbox-recipes/src/googleFontsCache.ts
@@ -22,7 +22,7 @@ export interface GoogleFontCacheOptions {
 /**
  * An implementation of the [Google fonts]{@link https://developers.google.com/web/tools/workbox/guides/common-recipes#google_fonts} caching recipe
  *
- * @memberof module:workbox-recipes
+ * @memberof workbox-recipes
  *
  * @param {Object} [options]
  * @param {string} [options.cachePrefix] Cache prefix for caching stylesheets and webfonts. Defaults to google-fonts

--- a/packages/workbox-recipes/src/imageCache.ts
+++ b/packages/workbox-recipes/src/imageCache.ts
@@ -30,7 +30,7 @@ export interface ImageCacheOptions {
 /**
  * An implementation of the [image caching recipe]{@link https://developers.google.com/web/tools/workbox/guides/common-recipes#caching_images}
  *
- * @memberof module:workbox-recipes
+ * @memberof workbox-recipes
  *
  * @param {Object} [options]
  * @param {string} [options.cacheName] Name for cache. Defaults to images

--- a/packages/workbox-recipes/src/offlineFallback.ts
+++ b/packages/workbox-recipes/src/offlineFallback.ts
@@ -23,7 +23,7 @@ declare let self: ServiceWorkerGlobalScope;
 /**
  * An implementation of the [comprehensive fallbacks recipe]{@link https://developers.google.com/web/tools/workbox/guides/advanced-recipes#comprehensive_fallbacks}. Be sure to include the fallbacks in your precache injection
  *
- * @memberof module:workbox-recipes
+ * @memberof workbox-recipes
  *
  * @param {Object} [options]
  * @param {string} [options.pageFallback] Precache name to match for pag fallbacks. Defaults to offline.html

--- a/packages/workbox-recipes/src/pageCache.ts
+++ b/packages/workbox-recipes/src/pageCache.ts
@@ -28,7 +28,7 @@ export interface ImageCacheOptions {
 /**
  * An implementation of a page caching recipe with a network timeout
  *
- * @memberof module:workbox-recipes
+ * @memberof workbox-recipes
  *
  * @param {Object} [options]
  * @param {string} [options.cacheName] Name for cache. Defaults to pages

--- a/packages/workbox-recipes/src/staticResourceCache.ts
+++ b/packages/workbox-recipes/src/staticResourceCache.ts
@@ -27,7 +27,7 @@ export interface StaticResourceOptions {
 /**
  * An implementation of the [CSS and JavaScript files recipe]{@link https://developers.google.com/web/tools/workbox/guides/common-recipes#cache_css_and_javascript_files}
  *
- * @memberof module:workbox-recipes
+ * @memberof workbox-recipes
  *
  * @param {Object} [options]
  * @param {string} [options.cacheName] Name for cache. Defaults to static-resources

--- a/packages/workbox-recipes/src/warmStrategyCache.ts
+++ b/packages/workbox-recipes/src/warmStrategyCache.ts
@@ -11,7 +11,7 @@ export interface WarmStrategyCacheOptions {
 declare let self: ServiceWorkerGlobalScope;
 
 /**
- * @memberof module:workbox-recipes
+ * @memberof workbox-recipes
  
  * @param {Object} options 
  * @param {string[]} options.urls Paths to warm the strategy's cache with

--- a/packages/workbox-routing/src/NavigationRoute.ts
+++ b/packages/workbox-routing/src/NavigationRoute.ts
@@ -21,11 +21,11 @@ export interface NavigationRouteMatchOptions {
 
 /**
  * NavigationRoute makes it easy to create a
- * [Route]{@link module:workbox-routing.Route} that matches for browser
+ * {@link workbox-routing.Route} that matches for browser
  * [navigation requests]{@link https://developers.google.com/web/fundamentals/primers/service-workers/high-performance-loading#first_what_are_navigation_requests}.
  *
  * It will only match incoming Requests whose
- * [`mode`]{@link https://fetch.spec.whatwg.org/#concept-request-mode}
+ * {@link https://fetch.spec.whatwg.org/#concept-request-mode|mode}
  * is set to `navigate`.
  *
  * You can optionally only apply this route to a subset of navigation requests

--- a/packages/workbox-routing/src/NavigationRoute.ts
+++ b/packages/workbox-routing/src/NavigationRoute.ts
@@ -48,7 +48,7 @@ class NavigationRoute extends Route {
    * and [`search`]{@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/search}
    * portions of the requested URL.
    *
-   * @param {module:workbox-routing~handlerCallback} handler A callback
+   * @param {workbox-routing~handlerCallback} handler A callback
    * function that returns a Promise resulting in a Response.
    * @param {Object} options
    * @param {Array<RegExp>} [options.denylist] If any of these patterns match,

--- a/packages/workbox-routing/src/NavigationRoute.ts
+++ b/packages/workbox-routing/src/NavigationRoute.ts
@@ -31,8 +31,8 @@ export interface NavigationRouteMatchOptions {
  * You can optionally only apply this route to a subset of navigation requests
  * by using one or both of the `denylist` and `allowlist` parameters.
  *
- * @memberof module:workbox-routing
- * @extends module:workbox-routing.Route
+ * @memberof workbox-routing
+ * @extends workbox-routing.Route
  */
 class NavigationRoute extends Route {
   private readonly _allowlist: RegExp[];

--- a/packages/workbox-routing/src/RegExpRoute.ts
+++ b/packages/workbox-routing/src/RegExpRoute.ts
@@ -21,7 +21,7 @@ import './_version.js';
 
 /**
  * RegExpRoute makes it easy to create a regular expression based
- * [Route]{@link module:workbox-routing.Route}.
+ * {@link workbox-routing.Route}.
  *
  * For same-origin requests the RegExp only needs to match part of the URL. For
  * requests against third-party servers, you must define a RegExp that matches
@@ -37,7 +37,7 @@ class RegExpRoute extends Route {
    * If the regular expression contains
    * [capture groups]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#grouping-back-references},
    * the captured values will be passed to the
-   * [handler's]{@link module:workbox-routing~handlerCallback} `params`
+   * {@link workbox-routing~handlerCallback} `params`
    * argument.
    *
    * @param {RegExp} regExp The regular expression to match against URLs.

--- a/packages/workbox-routing/src/RegExpRoute.ts
+++ b/packages/workbox-routing/src/RegExpRoute.ts
@@ -29,8 +29,8 @@ import './_version.js';
  *
  * [See the module docs for info.]{@link https://developers.google.com/web/tools/workbox/modules/workbox-routing}
  *
- * @memberof module:workbox-routing
- * @extends module:workbox-routing.Route
+ * @memberof workbox-routing
+ * @extends workbox-routing.Route
  */
 class RegExpRoute extends Route {
   /**

--- a/packages/workbox-routing/src/RegExpRoute.ts
+++ b/packages/workbox-routing/src/RegExpRoute.ts
@@ -41,7 +41,7 @@ class RegExpRoute extends Route {
    * argument.
    *
    * @param {RegExp} regExp The regular expression to match against URLs.
-   * @param {module:workbox-routing~handlerCallback} handler A callback
+   * @param {workbox-routing~handlerCallback} handler A callback
    * function that returns a Promise resulting in a Response.
    * @param {string} [method='GET'] The HTTP method to match the Route
    * against.

--- a/packages/workbox-routing/src/Route.ts
+++ b/packages/workbox-routing/src/Route.ts
@@ -23,7 +23,7 @@ import './_version.js';
  * is called when there is a match and should return a Promise that resolves
  * to a `Response`.
  *
- * @memberof module:workbox-routing
+ * @memberof workbox-routing
  */
 class Route {
   handler: RouteHandlerObject;

--- a/packages/workbox-routing/src/Route.ts
+++ b/packages/workbox-routing/src/Route.ts
@@ -34,10 +34,10 @@ class Route {
   /**
    * Constructor for Route class.
    *
-   * @param {module:workbox-routing~matchCallback} match
+   * @param {workbox-routing~matchCallback} match
    * A callback function that determines whether the route matches a given
    * `fetch` event by returning a non-falsy value.
-   * @param {module:workbox-routing~handlerCallback} handler A callback
+   * @param {workbox-routing~handlerCallback} handler A callback
    * function that returns a Promise resolving to a Response.
    * @param {string} [method='GET'] The HTTP method to match the Route
    * against.
@@ -69,7 +69,7 @@ class Route {
 
   /**
    *
-   * @param {module:workbox-routing-handlerCallback} handler A callback
+   * @param {workbox-routing-handlerCallback} handler A callback
    * function that returns a Promise resolving to a Response
    */
   setCatchHandler(handler: RouteHandler): void {

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -62,7 +62,7 @@ class Router {
   }
 
   /**
-   * @return {Map<string, Array<module:workbox-routing.Route>>} routes A `Map` of HTTP
+   * @return {Map<string, Array<workbox-routing.Route>>} routes A `Map` of HTTP
    * method name ('GET', etc.) to an array of all the corresponding `Route`
    * instances that are registered.
    */
@@ -390,7 +390,7 @@ class Router {
    * Without a default handler, unmatched requests will go against the
    * network as if there were no service worker present.
    *
-   * @param {module:workbox-routing~handlerCallback} handler A callback
+   * @param {workbox-routing~handlerCallback} handler A callback
    * function that returns a Promise resulting in a Response.
    * @param {string} [method='GET'] The HTTP method to associate with this
    * default handler. Each method has its own default.
@@ -406,7 +406,7 @@ class Router {
    * If a Route throws an error while handling a request, this `handler`
    * will be called and given a chance to provide a response.
    *
-   * @param {module:workbox-routing~handlerCallback} handler A callback
+   * @param {workbox-routing~handlerCallback} handler A callback
    * function that returns a Promise resulting in a Response.
    */
   setCatchHandler(handler: RouteHandler): void {
@@ -416,7 +416,7 @@ class Router {
   /**
    * Registers a route with the router.
    *
-   * @param {module:workbox-routing.Route} route The route to register.
+   * @param {workbox-routing.Route} route The route to register.
    */
   registerRoute(route: Route): void {
     if (process.env.NODE_ENV !== 'production') {
@@ -468,7 +468,7 @@ class Router {
   /**
    * Unregisters a route with the router.
    *
-   * @param {module:workbox-routing.Route} route The route to unregister.
+   * @param {workbox-routing.Route} route The route to unregister.
    */
   unregisterRoute(route: Route): void {
     if (!this._routes.has(route.method)) {

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -32,8 +32,8 @@ interface CacheURLsMessageData {
 }
 
 /**
- * The Router can be used to process a FetchEvent through one or more
- * [Routes]{@link module:workbox-routing.Route} responding  with a Request if
+ * The Router can be used to process a `FetchEvent` using one or more
+ * {@link workbox-routing.Route}, responding with a `Response` if
  * a matching route exists.
  *
  * If no route matches a given a request, the Router will use a "default"

--- a/packages/workbox-routing/src/Router.ts
+++ b/packages/workbox-routing/src/Router.ts
@@ -46,7 +46,7 @@ interface CacheURLsMessageData {
  * If a request matches multiple routes, the **earliest** registered route will
  * be used to respond to the request.
  *
- * @memberof module:workbox-routing
+ * @memberof workbox-routing
  */
 class Router {
   private readonly _routes: Map<HTTPMethod, Route[]>;

--- a/packages/workbox-routing/src/_types.ts
+++ b/packages/workbox-routing/src/_types.ts
@@ -24,7 +24,7 @@ import './_version.js';
  * object will always be available.
  *
  * If the match callback returns a truthy value, the matching route's
- * [handler callback]{@link module:workbox-routing~handlerCallback} will be
+ * {@link workbox-routing~handlerCallback} will be
  * invoked immediately. If the value returned is a non-empty array or object,
  * that value will be set on the handler's `context.params` argument.
  *
@@ -43,12 +43,12 @@ import './_version.js';
 
 /**
  * The "handler" callback is invoked whenever a `Router` matches a URL to a
- * `Route` via its [match]{@link module:workbox-routing~handlerCallback}
+ * `Route` via its {@link workbox-routing~matchCallback}
  * callback. This callback should return a Promise that resolves with a
  * `Response`.
  *
  * If a non-empty array or object is returned by the
- * [match callback]{@link module:workbox-routing~matchCallback} it
+ * {@link workbox-routing~matchCallback} it
  * will be passed in as the handler's `context.params` argument.
  *
  * @callback ~handlerCallback
@@ -58,7 +58,7 @@ import './_version.js';
  * @param {ExtendableEvent} context.event The corresponding event that triggered
  *     the request.
  * @param {Object} [context.params] Array or Object parameters returned by the
- *     Route's [match callback]{@link module:workbox-routing~matchCallback}.
+ *     Route's {@link workbox-routing~matchCallback}.
  *     This will be undefined if an empty array or object were returned.
  * @return {Promise<Response>} The response that will fulfill the request.
  *

--- a/packages/workbox-routing/src/_types.ts
+++ b/packages/workbox-routing/src/_types.ts
@@ -38,7 +38,7 @@ import './_version.js';
  *     against the current origin.
  * @return {*} To signify a match, return a truthy value.
  *
- * @memberof module:workbox-routing
+ * @memberof workbox-routing
  */
 
 /**
@@ -62,5 +62,5 @@ import './_version.js';
  *     This will be undefined if an empty array or object were returned.
  * @return {Promise<Response>} The response that will fulfill the request.
  *
- * @memberof module:workbox-routing
+ * @memberof workbox-routing
  */

--- a/packages/workbox-routing/src/registerRoute.ts
+++ b/packages/workbox-routing/src/registerRoute.ts
@@ -24,14 +24,14 @@ import './_version.js';
  * This method will generate a Route for you if needed and
  * call {@link workbox-routing.Router#registerRoute}.
  *
- * @param {RegExp|string|module:workbox-routing.Route~matchCallback|module:workbox-routing.Route} capture
+ * @param {RegExp|string|workbox-routing.Route~matchCallback|workbox-routing.Route} capture
  * If the capture param is a `Route`, all other arguments will be ignored.
- * @param {module:workbox-routing~handlerCallback} [handler] A callback
+ * @param {workbox-routing~handlerCallback} [handler] A callback
  * function that returns a Promise resulting in a Response. This parameter
  * is required if `capture` is not a `Route` object.
  * @param {string} [method='GET'] The HTTP method to match the Route
  * against.
- * @return {module:workbox-routing.Route} The generated `Route`(Useful for
+ * @return {workbox-routing.Route} The generated `Route`(Useful for
  * unregistering).
  *
  * @memberof workbox-routing

--- a/packages/workbox-routing/src/registerRoute.ts
+++ b/packages/workbox-routing/src/registerRoute.ts
@@ -34,7 +34,7 @@ import './_version.js';
  * @return {module:workbox-routing.Route} The generated `Route`(Useful for
  * unregistering).
  *
- * @memberof module:workbox-routing
+ * @memberof workbox-routing
  */
 function registerRoute(
   capture: RegExp | string | RouteMatchCallback | Route,

--- a/packages/workbox-routing/src/registerRoute.ts
+++ b/packages/workbox-routing/src/registerRoute.ts
@@ -22,7 +22,7 @@ import './_version.js';
  * strategy to a singleton Router instance.
  *
  * This method will generate a Route for you if needed and
- * call [registerRoute()]{@link module:workbox-routing.Router#registerRoute}.
+ * call {@link workbox-routing.Router#registerRoute}.
  *
  * @param {RegExp|string|module:workbox-routing.Route~matchCallback|module:workbox-routing.Route} capture
  * If the capture param is a `Route`, all other arguments will be ignored.

--- a/packages/workbox-routing/src/setCatchHandler.ts
+++ b/packages/workbox-routing/src/setCatchHandler.ts
@@ -19,7 +19,7 @@ import './_version.js';
  * @param {module:workbox-routing~handlerCallback} handler A callback
  * function that returns a Promise resulting in a Response.
  *
- * @memberof module:workbox-routing
+ * @memberof workbox-routing
  */
 function setCatchHandler(handler: RouteHandler): void {
   const defaultRouter = getOrCreateDefaultRouter();

--- a/packages/workbox-routing/src/setCatchHandler.ts
+++ b/packages/workbox-routing/src/setCatchHandler.ts
@@ -16,7 +16,7 @@ import './_version.js';
  * If a Route throws an error while handling a request, this `handler`
  * will be called and given a chance to provide a response.
  *
- * @param {module:workbox-routing~handlerCallback} handler A callback
+ * @param {workbox-routing~handlerCallback} handler A callback
  * function that returns a Promise resulting in a Response.
  *
  * @memberof workbox-routing

--- a/packages/workbox-routing/src/setDefaultHandler.ts
+++ b/packages/workbox-routing/src/setDefaultHandler.ts
@@ -22,7 +22,7 @@ import './_version.js';
  * @param {module:workbox-routing~handlerCallback} handler A callback
  * function that returns a Promise resulting in a Response.
  *
- * @memberof module:workbox-routing
+ * @memberof workbox-routing
  */
 function setDefaultHandler(handler: RouteHandler): void {
   const defaultRouter = getOrCreateDefaultRouter();

--- a/packages/workbox-routing/src/setDefaultHandler.ts
+++ b/packages/workbox-routing/src/setDefaultHandler.ts
@@ -19,7 +19,7 @@ import './_version.js';
  * Without a default handler, unmatched requests will go against the
  * network as if there were no service worker present.
  *
- * @param {module:workbox-routing~handlerCallback} handler A callback
+ * @param {workbox-routing~handlerCallback} handler A callback
  * function that returns a Promise resulting in a Response.
  *
  * @memberof workbox-routing

--- a/packages/workbox-strategies/src/CacheFirst.ts
+++ b/packages/workbox-strategies/src/CacheFirst.ts
@@ -33,7 +33,7 @@ class CacheFirst extends Strategy {
   /**
    * @private
    * @param {Request|string} request A request to run this strategy for.
-   * @param {module:workbox-strategies.StrategyHandler} handler The event that
+   * @param {workbox-strategies.StrategyHandler} handler The event that
    *     triggered the request.
    * @return {Promise<Response>}
    */

--- a/packages/workbox-strategies/src/CacheFirst.ts
+++ b/packages/workbox-strategies/src/CacheFirst.ts
@@ -26,8 +26,8 @@ import './_version.js';
  * If the network request fails, and there is no cache match, this will throw
  * a `WorkboxError` exception.
  *
- * @extends module:workbox-strategies.Strategy
- * @memberof module:workbox-strategies
+ * @extends workbox-strategies.Strategy
+ * @memberof workbox-strategies
  */
 class CacheFirst extends Strategy {
   /**

--- a/packages/workbox-strategies/src/CacheOnly.ts
+++ b/packages/workbox-strategies/src/CacheOnly.ts
@@ -32,7 +32,7 @@ class CacheOnly extends Strategy {
   /**
    * @private
    * @param {Request|string} request A request to run this strategy for.
-   * @param {module:workbox-strategies.StrategyHandler} handler The event that
+   * @param {workbox-strategies.StrategyHandler} handler The event that
    *     triggered the request.
    * @return {Promise<Response>}
    */

--- a/packages/workbox-strategies/src/CacheOnly.ts
+++ b/packages/workbox-strategies/src/CacheOnly.ts
@@ -25,8 +25,8 @@ import './_version.js';
  *
  * If there is no cache match, this will throw a `WorkboxError` exception.
  *
- * @extends module:workbox-strategies.Strategy
- * @memberof module:workbox-strategies
+ * @extends workbox-strategies.Strategy
+ * @memberof workbox-strategies
  */
 class CacheOnly extends Strategy {
   /**

--- a/packages/workbox-strategies/src/NetworkFirst.ts
+++ b/packages/workbox-strategies/src/NetworkFirst.ts
@@ -33,8 +33,8 @@ export interface NetworkFirstOptions extends StrategyOptions {
  * If the network request fails, and there is no cache match, this will throw
  * a `WorkboxError` exception.
  *
- * @extends module:workbox-strategies.Strategy
- * @memberof module:workbox-strategies
+ * @extends workbox-strategies.Strategy
+ * @memberof workbox-strategies
  */
 class NetworkFirst extends Strategy {
   private readonly _networkTimeoutSeconds: number;

--- a/packages/workbox-strategies/src/NetworkFirst.ts
+++ b/packages/workbox-strategies/src/NetworkFirst.ts
@@ -43,7 +43,7 @@ class NetworkFirst extends Strategy {
    * @param {Object} [options]
    * @param {string} [options.cacheName] Cache name to store and retrieve
    * requests. Defaults to cache names provided by
-   * [workbox-core]{@link module:workbox-core.cacheNames}.
+   * {@link workbox-core.cacheNames}.
    * @param {Array<Object>} [options.plugins] [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
    * to use in conjunction with this caching strategy.
    * @param {Object} [options.fetchOptions] Values passed along to the

--- a/packages/workbox-strategies/src/NetworkFirst.ts
+++ b/packages/workbox-strategies/src/NetworkFirst.ts
@@ -83,7 +83,7 @@ class NetworkFirst extends Strategy {
   /**
    * @private
    * @param {Request|string} request A request to run this strategy for.
-   * @param {module:workbox-strategies.StrategyHandler} handler The event that
+   * @param {workbox-strategies.StrategyHandler} handler The event that
    *     triggered the request.
    * @return {Promise<Response>}
    */

--- a/packages/workbox-strategies/src/NetworkOnly.ts
+++ b/packages/workbox-strategies/src/NetworkOnly.ts
@@ -31,8 +31,8 @@ interface NetworkOnlyOptions
  *
  * If the network request fails, this will throw a `WorkboxError` exception.
  *
- * @extends module:workbox-strategies.Strategy
- * @memberof module:workbox-strategies
+ * @extends workbox-strategies.Strategy
+ * @memberof workbox-strategies
  */
 class NetworkOnly extends Strategy {
   private readonly _networkTimeoutSeconds: number;

--- a/packages/workbox-strategies/src/NetworkOnly.ts
+++ b/packages/workbox-strategies/src/NetworkOnly.ts
@@ -57,7 +57,7 @@ class NetworkOnly extends Strategy {
   /**
    * @private
    * @param {Request|string} request A request to run this strategy for.
-   * @param {module:workbox-strategies.StrategyHandler} handler The event that
+   * @param {workbox-strategies.StrategyHandler} handler The event that
    *     triggered the request.
    * @return {Promise<Response>}
    */

--- a/packages/workbox-strategies/src/StaleWhileRevalidate.ts
+++ b/packages/workbox-strategies/src/StaleWhileRevalidate.ts
@@ -64,7 +64,7 @@ class StaleWhileRevalidate extends Strategy {
   /**
    * @private
    * @param {Request|string} request A request to run this strategy for.
-   * @param {module:workbox-strategies.StrategyHandler} handler The event that
+   * @param {workbox-strategies.StrategyHandler} handler The event that
    *     triggered the request.
    * @return {Promise<Response>}
    */

--- a/packages/workbox-strategies/src/StaleWhileRevalidate.ts
+++ b/packages/workbox-strategies/src/StaleWhileRevalidate.ts
@@ -42,7 +42,7 @@ class StaleWhileRevalidate extends Strategy {
    * @param {Object} [options]
    * @param {string} [options.cacheName] Cache name to store and retrieve
    * requests. Defaults to cache names provided by
-   * [workbox-core]{@link module:workbox-core.cacheNames}.
+   * {@link workbox-core.cacheNames}.
    * @param {Array<Object>} [options.plugins] [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
    * to use in conjunction with this caching strategy.
    * @param {Object} [options.fetchOptions] Values passed along to the

--- a/packages/workbox-strategies/src/StaleWhileRevalidate.ts
+++ b/packages/workbox-strategies/src/StaleWhileRevalidate.ts
@@ -34,8 +34,8 @@ import './_version.js';
  * If the network request fails, and there is no cache match, this will throw
  * a `WorkboxError` exception.
  *
- * @extends module:workbox-strategies.Strategy
- * @memberof module:workbox-strategies
+ * @extends workbox-strategies.Strategy
+ * @memberof workbox-strategies
  */
 class StaleWhileRevalidate extends Strategy {
   /**

--- a/packages/workbox-strategies/src/Strategy.ts
+++ b/packages/workbox-strategies/src/Strategy.ts
@@ -282,7 +282,7 @@ export {Strategy};
  * @abstract
  * @function
  * @param {Request} request
- * @param {module:workbox-strategies.StrategyHandler} handler
+ * @param {workbox-strategies.StrategyHandler} handler
  * @return {Promise<Response>}
  *
  * @memberof workbox-strategies.Strategy

--- a/packages/workbox-strategies/src/Strategy.ts
+++ b/packages/workbox-strategies/src/Strategy.ts
@@ -30,7 +30,7 @@ export interface StrategyOptions {
 /**
  * An abstract base class that all other strategy classes must extend from:
  *
- * @memberof module:workbox-strategies
+ * @memberof workbox-strategies
  */
 abstract class Strategy implements RouteHandlerObject {
   cacheName: string;
@@ -285,5 +285,5 @@ export {Strategy};
  * @param {module:workbox-strategies.StrategyHandler} handler
  * @return {Promise<Response>}
  *
- * @memberof module:workbox-strategies.Strategy
+ * @memberof workbox-strategies.Strategy
  */

--- a/packages/workbox-strategies/src/Strategy.ts
+++ b/packages/workbox-strategies/src/Strategy.ts
@@ -54,7 +54,7 @@ abstract class Strategy implements RouteHandlerObject {
    * @param {Object} [options]
    * @param {string} [options.cacheName] Cache name to store and retrieve
    * requests. Defaults to the cache names provided by
-   * [workbox-core]{@link module:workbox-core.cacheNames}.
+   * {@link workbox-core.cacheNames}.
    * @param {Array<Object>} [options.plugins] [Plugins]{@link https://developers.google.com/web/tools/workbox/guides/using-plugins}
    * to use in conjunction with this caching strategy.
    * @param {Object} [options.fetchOptions] Values passed along to the
@@ -69,7 +69,7 @@ abstract class Strategy implements RouteHandlerObject {
     /**
      * Cache name to store and retrieve
      * requests. Defaults to the cache names provided by
-     * [workbox-core]{@link module:workbox-core.cacheNames}.
+     * {@link workbox-core.cacheNames}.
      *
      * @type {string}
      */
@@ -105,7 +105,7 @@ abstract class Strategy implements RouteHandlerObject {
    * a `Response`, invoking all relevant plugin callbacks.
    *
    * When a strategy instance is registered with a Workbox
-   * [route]{@link module:workbox-routing.Route}, this method is automatically
+   * {@link workbox-routing.Route}, this method is automatically
    * called when the route matches.
    *
    * Alternatively, this method can be used in a standalone `FetchEvent`
@@ -125,9 +125,9 @@ abstract class Strategy implements RouteHandlerObject {
   }
 
   /**
-   * Similar to [`handle()`]{@link module:workbox-strategies.Strategy~handle}, but
+   * Similar to {@link workbox-strategies.Strategy~handle}, but
    * instead of just returning a `Promise` that resolves to a `Response` it
-   * it will return an tuple of [response, done] promises, where the former
+   * it will return an tuple of `[response, done]` promises, where the former
    * (`response`) is equivalent to what `handle()` returns, and the latter is a
    * Promise that will resolve once any promises that were added to
    * `event.waitUntil()` as part of performing the strategy have completed.
@@ -272,7 +272,7 @@ export {Strategy};
 
 /**
  * Classes extending the `Strategy` based class should implement this method,
- * and leverage the [`handler`]{@link module:workbox-strategies.StrategyHandler}
+ * and leverage the {@link workbox-strategies.StrategyHandler}
  * arg to perform all fetching and cache logic, which will ensure all relevant
  * cache, cache options, fetch options and plugins are used (per the current
  * strategy instance).

--- a/packages/workbox-strategies/src/StrategyHandler.ts
+++ b/packages/workbox-strategies/src/StrategyHandler.ts
@@ -58,7 +58,7 @@ class StrategyHandler {
    * The constructor also initializes the state that will be passed to each of
    * the plugins handling this request.
    *
-   * @param {module:workbox-strategies.Strategy} strategy
+   * @param {workbox-strategies.Strategy} strategy
    * @param {Object} options
    * @param {Request|string} options.request A request to run this strategy for.
    * @param {ExtendableEvent} options.event The event associated with the

--- a/packages/workbox-strategies/src/StrategyHandler.ts
+++ b/packages/workbox-strategies/src/StrategyHandler.ts
@@ -30,8 +30,8 @@ function toRequest(input: RequestInfo) {
 
 /**
  * A class created every time a Strategy instance instance calls
- * [handle()]{@link module:workbox-strategies.Strategy~handle} or
- * [handleAll()]{@link module:workbox-strategies.Strategy~handleAll} that wraps all fetch and
+ * {@link workbox-strategies.Strategy~handle} or
+ * {@link workbox-strategies.Strategy~handleAll} that wraps all fetch and
  * cache actions around plugin callbacks and keeps track of when the strategy
  * is "done" (i.e. all added `event.waitUntil()` promises have resolved).
  *
@@ -64,9 +64,8 @@ class StrategyHandler {
    * @param {ExtendableEvent} options.event The event associated with the
    *     request.
    * @param {URL} [options.url]
-   * @param {*} [options.params]
-   *     [match callback]{@link module:workbox-routing~matchCallback},
-   *     (if applicable).
+   * @param {*} [options.params] The return value from the
+   *     {@link workbox-routing~matchCallback} (if applicable).
    */
   constructor(strategy: Strategy, options: HandlerCallbackOptions) {
     /**
@@ -99,7 +98,7 @@ class StrategyHandler {
      * `handle()` or `handleAll()` method).
      * Note: the `param` param will be present if the strategy was invoked
      * from a workbox `Route` object and the
-     * [match callback]{@link module:workbox-routing~matchCallback} returned
+     * {@link workbox-routing~matchCallback} returned
      * a truthy value (it will be that value).
      * @name params
      * @instance
@@ -484,7 +483,7 @@ class StrategyHandler {
    * Note: since this method runs all plugins, it's not suitable for cases
    * where the return value of a callback needs to be applied prior to calling
    * the next callback. See
-   * [`iterateCallbacks()`]{@link module:workbox-strategies.StrategyHandler#iterateCallbacks}
+   * {@link workbox-strategies.StrategyHandler#iterateCallbacks}
    * below for how to handle that case.
    *
    * @param {string} name The name of the callback to run within each plugin.
@@ -539,7 +538,7 @@ class StrategyHandler {
    * `FetchEvent`).
    *
    * Note: you can await
-   * [`doneWaiting()`]{@link module:workbox-strategies.StrategyHandler~doneWaiting}
+   * {@link workbox-strategies.StrategyHandler~doneWaiting}
    * to know when all added promises have settled.
    *
    * @param {Promise} promise A promise to add to the extend lifetime promises
@@ -552,7 +551,7 @@ class StrategyHandler {
 
   /**
    * Returns a promise that resolves once all promises passed to
-   * [`waitUntil()`]{@link module:workbox-strategies.StrategyHandler~waitUntil}
+   * {@link workbox-strategies.StrategyHandler~waitUntil}
    * have settled.
    *
    * Note: any work done after `doneWaiting()` settles should be manually

--- a/packages/workbox-strategies/src/StrategyHandler.ts
+++ b/packages/workbox-strategies/src/StrategyHandler.ts
@@ -35,7 +35,7 @@ function toRequest(input: RequestInfo) {
  * cache actions around plugin callbacks and keeps track of when the strategy
  * is "done" (i.e. all added `event.waitUntil()` promises have resolved).
  *
- * @memberof module:workbox-strategies
+ * @memberof workbox-strategies
  */
 class StrategyHandler {
   public request!: Request;
@@ -74,14 +74,14 @@ class StrategyHandler {
      * @name request
      * @instance
      * @type {Request}
-     * @memberof module:workbox-strategies.StrategyHandler
+     * @memberof workbox-strategies.StrategyHandler
      */
     /**
      * The event associated with this request.
      * @name event
      * @instance
      * @type {ExtendableEvent}
-     * @memberof module:workbox-strategies.StrategyHandler
+     * @memberof workbox-strategies.StrategyHandler
      */
     /**
      * A `URL` instance of `request.url` (if passed to the strategy's
@@ -91,7 +91,7 @@ class StrategyHandler {
      * @name url
      * @instance
      * @type {URL|undefined}
-     * @memberof module:workbox-strategies.StrategyHandler
+     * @memberof workbox-strategies.StrategyHandler
      */
     /**
      * A `param` value (if passed to the strategy's
@@ -103,7 +103,7 @@ class StrategyHandler {
      * @name params
      * @instance
      * @type {*|undefined}
-     * @memberof module:workbox-strategies.StrategyHandler
+     * @memberof workbox-strategies.StrategyHandler
      */
     if (process.env.NODE_ENV !== 'production') {
       assert!.isInstance(options.event, ExtendableEvent, {

--- a/packages/workbox-streams/src/_types.ts
+++ b/packages/workbox-streams/src/_types.ts
@@ -19,5 +19,5 @@ export type StreamSource = Response | ReadableStream | BodyInit;
 
 /**
  * @typedef {Response|ReadableStream|BodyInit} StreamSource
- * @memberof module:workbox-streams
+ * @memberof workbox-streams
  */

--- a/packages/workbox-streams/src/concatenate.ts
+++ b/packages/workbox-streams/src/concatenate.ts
@@ -17,7 +17,7 @@ import './_version.js';
  * [BodyInit](https://fetch.spec.whatwg.org/#bodyinit) and returns the
  * ReadableStreamReader object associated with it.
  *
- * @param {module:workbox-streams.StreamSource} source
+ * @param {workbox-streams.StreamSource} source
  * @return {ReadableStreamReader}
  * @private
  */
@@ -41,7 +41,7 @@ function _getReaderFromSource(
  * data returned in sequence, along with a Promise which signals when the
  * stream is finished (useful for passing to a FetchEvent's waitUntil()).
  *
- * @param {Array<Promise<module:workbox-streams.StreamSource>>} sourcePromises
+ * @param {Array<Promise<workbox-streams.StreamSource>>} sourcePromises
  * @return {Object<{done: Promise, stream: ReadableStream}>}
  *
  * @memberof workbox-streams

--- a/packages/workbox-streams/src/concatenate.ts
+++ b/packages/workbox-streams/src/concatenate.ts
@@ -44,7 +44,7 @@ function _getReaderFromSource(
  * @param {Array<Promise<module:workbox-streams.StreamSource>>} sourcePromises
  * @return {Object<{done: Promise, stream: ReadableStream}>}
  *
- * @memberof module:workbox-streams
+ * @memberof workbox-streams
  */
 function concatenate(sourcePromises: Promise<StreamSource>[]): {
   done: Promise<void>;

--- a/packages/workbox-streams/src/concatenateToResponse.ts
+++ b/packages/workbox-streams/src/concatenateToResponse.ts
@@ -26,7 +26,7 @@ import './_version.js';
  * `'text/html'` will be used by default.
  * @return {Object<{done: Promise, response: Response}>}
  *
- * @memberof module:workbox-streams
+ * @memberof workbox-streams
  */
 function concatenateToResponse(
   sourcePromises: Promise<StreamSource>[],

--- a/packages/workbox-streams/src/concatenateToResponse.ts
+++ b/packages/workbox-streams/src/concatenateToResponse.ts
@@ -21,7 +21,7 @@ import './_version.js';
  * stream's data returned in sequence, along with a Promise which signals when
  * the stream is finished (useful for passing to a FetchEvent's waitUntil()).
  *
- * @param {Array<Promise<module:workbox-streams.StreamSource>>} sourcePromises
+ * @param {Array<Promise<workbox-streams.StreamSource>>} sourcePromises
  * @param {HeadersInit} [headersInit] If there's no `Content-Type` specified,
  * `'text/html'` will be used by default.
  * @return {Object<{done: Promise, response: Response}>}

--- a/packages/workbox-streams/src/isSupported.ts
+++ b/packages/workbox-streams/src/isSupported.ts
@@ -18,7 +18,7 @@ import './_version.js';
  * @return {boolean} `true`, if the current browser meets the requirements for
  * streaming responses, and `false` otherwise.
  *
- * @memberof module:workbox-streams
+ * @memberof workbox-streams
  */
 function isSupported(): boolean {
   return canConstructReadableStream();

--- a/packages/workbox-streams/src/strategy.ts
+++ b/packages/workbox-streams/src/strategy.ts
@@ -37,7 +37,7 @@ interface StreamsHandlerCallback {
  * @param {HeadersInit} [headersInit] If there's no `Content-Type` specified,
  * `'text/html'` will be used by default.
  * @return {module:workbox-routing~handlerCallback}
- * @memberof module:workbox-streams
+ * @memberof workbox-streams
  */
 function strategy(
   sourceFunctions: StreamsHandlerCallback[],

--- a/packages/workbox-streams/src/strategy.ts
+++ b/packages/workbox-streams/src/strategy.ts
@@ -36,7 +36,7 @@ interface StreamsHandlerCallback {
  * Promise which resolves to one).
  * @param {HeadersInit} [headersInit] If there's no `Content-Type` specified,
  * `'text/html'` will be used by default.
- * @return {module:workbox-routing~handlerCallback}
+ * @return {workbox-routing~handlerCallback}
  * @memberof workbox-streams
  */
 function strategy(

--- a/packages/workbox-streams/src/strategy.ts
+++ b/packages/workbox-streams/src/strategy.ts
@@ -31,8 +31,8 @@ interface StreamsHandlerCallback {
  * and create a final response that concatenates their values together.
  *
  * @param {Array<function({event, request, url, params})>} sourceFunctions
- * An array of functions similar to {@link module:workbox-routing~handlerCallback}
- * but that instead return a {@link module:workbox-streams.StreamSource} (or a
+ * An array of functions similar to {@link workbox-routing~handlerCallback}
+ * but that instead return a {@link workbox-streams.StreamSource} (or a
  * Promise which resolves to one).
  * @param {HeadersInit} [headersInit] If there's no `Content-Type` specified,
  * `'text/html'` will be used by default.

--- a/packages/workbox-streams/src/utils/createHeaders.ts
+++ b/packages/workbox-streams/src/utils/createHeaders.ts
@@ -20,7 +20,7 @@ import '../_version.js';
  * @return {boolean} `true`, if the current browser meets the requirements for
  * streaming responses, and `false` otherwise.
  *
- * @memberof module:workbox-streams
+ * @memberof workbox-streams
  */
 function createHeaders(headersInit = {}): Headers {
   // See https://github.com/GoogleChrome/workbox/issues/1461

--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -35,12 +35,12 @@ const SKIP_WAITING_MESSAGE = {type: 'SKIP_WAITING'};
  * A class to aid in handling service worker registration, updates, and
  * reacting to service worker lifecycle events.
  *
- * @fires [message]{@link module:workbox-window.Workbox#message}
- * @fires [installed]{@link module:workbox-window.Workbox#installed}
- * @fires [waiting]{@link module:workbox-window.Workbox#waiting}
- * @fires [controlling]{@link module:workbox-window.Workbox#controlling}
- * @fires [activated]{@link module:workbox-window.Workbox#activated}
- * @fires [redundant]{@link module:workbox-window.Workbox#redundant}
+ * @fires {@link workbox-window.Workbox#message}
+ * @fires {@link workbox-window.Workbox#installed}
+ * @fires {@link workbox-window.Workbox#waiting}
+ * @fires {@link workbox-window.Workbox#controlling}
+ * @fires {@link workbox-window.Workbox#activated}
+ * @fires {@link workbox-window.Workbox#redundant}
  * @memberof module:workbox-window
  */
 class Workbox extends WorkboxEventTarget {
@@ -298,7 +298,7 @@ class Workbox extends WorkboxEventTarget {
 
   /**
    * Sends the passed data object to the service worker registered by this
-   * instance (via [`getSW()`]{@link module:workbox-window.Workbox#getSW}) and resolves
+   * instance (via {@link workbox-window.Workbox#getSW}) and resolves
    * with a response (if any).
    *
    * A response can be set in a message handler in the service worker by
@@ -633,8 +633,8 @@ export {Workbox};
 
 /**
  * The `installed` event is dispatched if the state of a
- * [`Workbox`]{@link module:workbox-window.Workbox} instance's
- * [registered service worker]{@link https://developers.google.com/web/tools/workbox/modules/workbox-precaching#def-registered-sw}
+ * {@link workbox-window.Workbox} instance's
+ * {@link https://developers.google.com/web/tools/workbox/modules/workbox-precaching#def-registered-sw|registered service worker}
  * changes to `installed`.
  *
  * Then can happen either the very first time a service worker is installed,
@@ -656,12 +656,12 @@ export {Workbox};
 
 /**
  * The `waiting` event is dispatched if the state of a
- * [`Workbox`]{@link module:workbox-window.Workbox} instance's
+ * {@link workbox-window.Workbox} instance's
  * [registered service worker]{@link https://developers.google.com/web/tools/workbox/modules/workbox-precaching#def-registered-sw}
  * changes to `installed` and then doesn't immediately change to `activating`.
  * It may also be dispatched if a service worker with the same
  * [`scriptURL`]{@link https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker/scriptURL}
- * was already waiting when the [`register()`]{@link module:workbox-window.Workbox#register}
+ * was already waiting when the {@link workbox-window.Workbox#register}
  * method was called.
  *
  * @event module:workbox-window.Workbox#waiting
@@ -706,8 +706,8 @@ export {Workbox};
 
 /**
  * The `activated` event is dispatched if the state of a
- * [`Workbox`]{@link module:workbox-window.Workbox} instance's
- * [registered service worker]{@link https://developers.google.com/web/tools/workbox/modules/workbox-precaching#def-registered-sw}
+ * {@link workbox-window.Workbox} instance's
+ * {@link https://developers.google.com/web/tools/workbox/modules/workbox-precaching#def-registered-sw|registered service worker}
  * changes to `activated`.
  *
  * @event module:workbox-window.Workbox#activated
@@ -725,7 +725,7 @@ export {Workbox};
 
 /**
  * The `redundant` event is dispatched if the state of a
- * [`Workbox`]{@link module:workbox-window.Workbox} instance's
+ * {@link workbox-window.Workbox} instance's
  * [registered service worker]{@link https://developers.google.com/web/tools/workbox/modules/workbox-precaching#def-registered-sw}
  * changes to `redundant`.
  *

--- a/packages/workbox-window/src/Workbox.ts
+++ b/packages/workbox-window/src/Workbox.ts
@@ -41,7 +41,7 @@ const SKIP_WAITING_MESSAGE = {type: 'SKIP_WAITING'};
  * @fires {@link workbox-window.Workbox#controlling}
  * @fires {@link workbox-window.Workbox#activated}
  * @fires {@link workbox-window.Workbox#redundant}
- * @memberof module:workbox-window
+ * @memberof workbox-window
  */
 class Workbox extends WorkboxEventTarget {
   private readonly _scriptURL: string | TrustedScriptURL;
@@ -621,7 +621,7 @@ export {Workbox};
 /**
  * The `message` event is dispatched any time a `postMessage` is received.
  *
- * @event module:workbox-window.Workbox#message
+ * @event workbox-window.Workbox#message
  * @type {WorkboxEvent}
  * @property {*} data The `data` property from the original `message` event.
  * @property {Event} originalEvent The original [`message`]{@link https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent}
@@ -641,7 +641,7 @@ export {Workbox};
  * or after an update to the current service worker is found. In the case
  * of an update being found, the event's `isUpdate` property will be `true`.
  *
- * @event module:workbox-window.Workbox#installed
+ * @event workbox-window.Workbox#installed
  * @type {WorkboxEvent}
  * @property {ServiceWorker} sw The service worker instance.
  * @property {Event} originalEvent The original [`statechange`]{@link https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker/onstatechange}
@@ -664,7 +664,7 @@ export {Workbox};
  * was already waiting when the {@link workbox-window.Workbox#register}
  * method was called.
  *
- * @event module:workbox-window.Workbox#waiting
+ * @event workbox-window.Workbox#waiting
  * @type {WorkboxEvent}
  * @property {ServiceWorker} sw The service worker instance.
  * @property {Event|undefined} originalEvent The original
@@ -691,7 +691,7 @@ export {Workbox};
  * matches the `scriptURL` of the `Workbox` instance's
  * [registered service worker]{@link https://developers.google.com/web/tools/workbox/modules/workbox-precaching#def-registered-sw}.
  *
- * @event module:workbox-window.Workbox#controlling
+ * @event workbox-window.Workbox#controlling
  * @type {WorkboxEvent}
  * @property {ServiceWorker} sw The service worker instance.
  * @property {Event} originalEvent The original [`controllerchange`]{@link https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/oncontrollerchange}
@@ -710,7 +710,7 @@ export {Workbox};
  * {@link https://developers.google.com/web/tools/workbox/modules/workbox-precaching#def-registered-sw|registered service worker}
  * changes to `activated`.
  *
- * @event module:workbox-window.Workbox#activated
+ * @event workbox-window.Workbox#activated
  * @type {WorkboxEvent}
  * @property {ServiceWorker} sw The service worker instance.
  * @property {Event} originalEvent The original [`statechange`]{@link https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker/onstatechange}
@@ -729,7 +729,7 @@ export {Workbox};
  * [registered service worker]{@link https://developers.google.com/web/tools/workbox/modules/workbox-precaching#def-registered-sw}
  * changes to `redundant`.
  *
- * @event module:workbox-window.Workbox#redundant
+ * @event workbox-window.Workbox#redundant
  * @type {WorkboxEvent}
  * @property {ServiceWorker} sw The service worker instance.
  * @property {Event} originalEvent The original [`statechange`]{@link https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker/onstatechange}

--- a/packages/workbox-window/src/messageSW.ts
+++ b/packages/workbox-window/src/messageSW.ts
@@ -20,7 +20,7 @@ import './_version.js';
  * @param {ServiceWorker} sw The service worker to send the message to.
  * @param {Object} data An object to send to the service worker.
  * @return {Promise<Object|undefined>}
- * @memberof module:workbox-window
+ * @memberof workbox-window
  */
 // Better not change type of data.
 // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
This is mostly automated, with a little manual intervention, cleanup of our existing JSDoc comments to remove the `module:` prefix and a couple of other syntax choices that don't play well with the forthcoming docs migration.