### PR TITLE
Better error for opaque stream sources

### DIFF
--- a/infra/testing/server/cross-origin-server.js
+++ b/infra/testing/server/cross-origin-server.js
@@ -1,0 +1,46 @@
+/*
+  Copyright 2021 Google LLC
+
+  Use of this source code is governed by an MIT-style
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/MIT.
+*/
+
+const express = require('express');
+
+const PORT = 3010;
+
+let app;
+let server;
+
+function initApp(staticDir) {
+  app = express();
+  app.use(express.static(staticDir));
+}
+
+function start(staticDir) {
+  if (!app) {
+    initApp(staticDir);
+  }
+
+  return new Promise((resolve, reject) => {
+    server = app.listen(PORT, (error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(`http://localhost:${PORT}`);
+      }
+    });
+  });
+}
+
+function stop() {
+  if (server) {
+    server.close();
+  }
+}
+
+module.exports = {
+  start,
+  stop,
+};

--- a/packages/workbox-core/src/models/messages/messages.ts
+++ b/packages/workbox-core/src/models/messages/messages.ts
@@ -366,4 +366,17 @@ export const messages: MessageMap = {
       `responses. It was passed a response with origin ${origin}.`
     );
   },
+
+  'opaque-streams-source': ({type}) => {
+    const message =
+      `One of the workbox-streams sources resulted in an ` +
+      `'${type}' response.`;
+    if (type === 'opaqueredirect') {
+      return (
+        `${message} Please do not use a navigation request that results ` +
+        `in a redirect as a source.`
+      );
+    }
+    return `${message} Please ensure your sources are CORS-enabled.`;
+  },
 };

--- a/packages/workbox-streams/src/concatenate.ts
+++ b/packages/workbox-streams/src/concatenate.ts
@@ -6,10 +6,12 @@
   https://opensource.org/licenses/MIT.
 */
 
-import {logger} from 'workbox-core/_private/logger.js';
 import {assert} from 'workbox-core/_private/assert.js';
 import {Deferred} from 'workbox-core/_private/Deferred.js';
+import {logger} from 'workbox-core/_private/logger.js';
 import {StreamSource} from './_types.js';
+import {WorkboxError} from 'workbox-core/_private/WorkboxError.js';
+
 import './_version.js';
 
 /**
@@ -25,7 +27,11 @@ function _getReaderFromSource(
   source: StreamSource,
 ): ReadableStreamReader<unknown> {
   if (source instanceof Response) {
-    return source.body!.getReader();
+    // See https://github.com/GoogleChrome/workbox/issues/2998
+    if (source.body) {
+      return source.body.getReader();
+    }
+    throw new WorkboxError('opaque-streams-source', {type: source.type});
   }
   if (source instanceof ReadableStream) {
     return source.getReader();


### PR DESCRIPTION
R: @tropicadri

Fixes #2998

It's not possible to mix an opaque response in with other non-opaque streaming sources in `workbox-streams`. Previously, this would lead to an ambiguous runtime exception. This PR adds some specific detection for it and throws a more meaningful error.