### PR TITLE
Add a waitUntil() to the SWR strategy

### DIFF
--- a/packages/workbox-strategies/src/StaleWhileRevalidate.ts
+++ b/packages/workbox-strategies/src/StaleWhileRevalidate.ts
@@ -84,6 +84,7 @@ class StaleWhileRevalidate extends Strategy {
       // Swallow this error because a 'no-response' error will be thrown in
       // main handler return flow. This will be in the `waitUntil()` flow.
     });
+    void handler.waitUntil(fetchAndCachePromise);
 
     let response = await handler.cacheMatch(request);
 


### PR DESCRIPTION
R: @tropicadri @philipwalton 
CC: @Snugug 

Fixes #2883

This additional `waitUntil()` is needed because otherwise, by the time a navigation preload response might be consumed, the `FetchEvent` will have already completed execution. When S-W-R is used in a navigation route with navigation preload enabled, this could cause an initially cached response to never get revalidated.

(I spent a few hours trying to put together an integration test that would have caught the initial problem, but I did not have any luck, so I'm just checking in the fix that I manually verified.)