### PR TITLE
Re-add the default export to the webpack plugin

### DIFF
--- a/packages/workbox-webpack-plugin/src/index.ts
+++ b/packages/workbox-webpack-plugin/src/index.ts
@@ -12,8 +12,8 @@ import {InjectManifest} from './inject-manifest';
 /**
  * @module workbox-webpack-plugin
  */
+export {GenerateSW, InjectManifest};
 
-export {
-  GenerateSW,
-  InjectManifest,
-};
+// TODO: remove this in v7.
+// See https://github.com/GoogleChrome/workbox/issues/3033
+export default {GenerateSW, InjectManifest};


### PR DESCRIPTION
R: @tropicadri

Fixes #3033

This temporarily re-adds the `default` export to the new `workbox-webpack-plugin` module. We can switch to exclusively using named exports in Workbox v7.
