### PR TITLE
Don't use unknown for workbox-build method config

### DIFF
--- a/packages/workbox-build/src/generate-sw.ts
+++ b/packages/workbox-build/src/generate-sw.ts
@@ -8,7 +8,7 @@
 
 import upath from 'upath';
 
-import {BuildResult, GetManifestOptions} from './types';
+import {BuildResult, GetManifestOptions, GenerateSWOptions} from './types';
 import {getFileManifestEntries} from './lib/get-file-manifest-entries';
 import {rebasePath} from './lib/rebase-path';
 import {validateGenerateSWOptions} from './lib/validate-options';
@@ -193,7 +193,9 @@ import {writeSWUsingDefaultTemplate} from './lib/write-sw-using-default-template
  *
  * @memberof workbox-build
  */
-export async function generateSW(config: unknown): Promise<BuildResult> {
+export async function generateSW(
+  config: GenerateSWOptions,
+): Promise<BuildResult> {
   const options = validateGenerateSWOptions(config);
   let entriesResult;
 

--- a/packages/workbox-build/src/get-manifest.ts
+++ b/packages/workbox-build/src/get-manifest.ts
@@ -7,7 +7,7 @@
 */
 
 import {getFileManifestEntries} from './lib/get-file-manifest-entries';
-import {GetManifestResult} from './types';
+import {GetManifestOptions, GetManifestResult} from './types';
 import {validateGetManifestOptions} from './lib/validate-options';
 
 // eslint-disable-next-line jsdoc/newline-after-description
@@ -88,7 +88,9 @@ import {validateGetManifestOptions} from './lib/validate-options';
  *
  * @memberof workbox-build
  */
-export async function getManifest(config: unknown): Promise<GetManifestResult> {
+export async function getManifest(
+  config: GetManifestOptions,
+): Promise<GetManifestResult> {
   const options = validateGetManifestOptions(config);
 
   return await getFileManifestEntries(options);

--- a/packages/workbox-build/src/inject-manifest.ts
+++ b/packages/workbox-build/src/inject-manifest.ts
@@ -12,7 +12,7 @@ import fse from 'fs-extra';
 import stringify from 'fast-json-stable-stringify';
 import upath from 'upath';
 
-import {BuildResult} from './types';
+import {BuildResult, InjectManifestOptions} from './types';
 import {errors} from './lib/errors';
 import {escapeRegExp} from './lib/escape-regexp';
 import {getFileManifestEntries} from './lib/get-file-manifest-entries';
@@ -117,7 +117,9 @@ import {validateInjectManifestOptions} from './lib/validate-options';
  *
  * @memberof workbox-build
  */
-export async function injectManifest(config: unknown): Promise<BuildResult> {
+export async function injectManifest(
+  config: InjectManifestOptions,
+): Promise<BuildResult> {
   const options = validateInjectManifestOptions(config);
 
   // Make sure we leave swSrc and swDest out of the precache manifest.

--- a/packages/workbox-cli/src/app.ts
+++ b/packages/workbox-cli/src/app.ts
@@ -23,7 +23,7 @@ import {SupportedFlags} from './bin.js';
 
 interface BuildCommand {
   command: 'generateSW' | 'injectManifest';
-  config: workboxBuild.GenerateSWOptions | workboxBuild.InjectManifestOptions;
+  config: any;
   watch: boolean;
 }
 

--- a/packages/workbox-cli/src/app.ts
+++ b/packages/workbox-cli/src/app.ts
@@ -23,7 +23,7 @@ import {SupportedFlags} from './bin.js';
 
 interface BuildCommand {
   command: 'generateSW' | 'injectManifest';
-  config: any;
+  config: workboxBuild.GenerateSWOptions | workboxBuild.InjectManifestOptions;
   watch: boolean;
 }
 
@@ -34,7 +34,7 @@ interface BuildCommand {
  */
 async function runBuildCommand({command, config, watch}: BuildCommand) {
   const {count, filePaths, size, warnings} = await workboxBuild[command](
-    config,
+    config as any,
   );
 
   for (const warning of warnings) {


### PR DESCRIPTION
Prior to this, the `getManifest()`, `generateSW()`, and `injectManifest()` methods of `workbox-build` were marked as taking in a configuration object with type `unknown`. The idea was that prior to validating the configuration (which happens immediately), we should treat the object as potentially anything.

Unfortunately, this leads to a bad experience in our [TSDocs](https://developer.chrome.com/docs/workbox/reference/workbox-build/#method-generateSW), and likely for users who rely on TypeScript code completion.

Additionally, if you actually attempt to pass in anything other than the support options, the validation step should immediately throw, so passing in just anything didn't actually "work." Because of this, I consider adding in explicit types for the config to be a bug fix rather than a breaking change, as we never should have had `unknown` to begin with.