### PR TITLE
add a condition for checking bodyUsed property to post request

### DIFF
--- a/packages/workbox-google-analytics/src/initialize.ts
+++ b/packages/workbox-google-analytics/src/initialize.ts
@@ -54,9 +54,9 @@ const createOnSyncCallback = (config: GoogleAnalyticsInitializeOptions) => {
 
       try {
         // Measurement protocol requests can set their payload parameters in
-        // either the URL query string (for GET requests) or the POST body.
+        // either the URL query string (for GET requests) or the POST body if bodyUsed is true.
         const params =
-          request.method === 'POST'
+          request.method === 'POST' && request.bodyUsed
             ? new URLSearchParams(await request.clone().text())
             : url.searchParams;
 


### PR DESCRIPTION
R: @philipwalton @jeffposnick @tropicadri 

Fixes [#2552](https://github.com/GoogleChrome/workbox/issues/2552)

It seems `analytics.js` used to send GET request so it didn't have any problem. However, it has been changed to POST request only. As a result, it sends an empty payload. 

Solution: Check the bodyUsed property and if it is false, make it to use `url.searchParams`.

<img width="895" alt="Screen_Shot_2022-03-21_at_12_00_41_PM" src="https://user-images.githubusercontent.com/59935686/159345429-ebd6345f-42b6-4190-90c4-2dbdb2bcc3bb.png">

<img width="906" alt="Screen_Shot_2022-03-21_at_12_01_14_PM" src="https://user-images.githubusercontent.com/59935686/159345448-61bede9d-1d0c-48af-88f6-3dc7420863b1.png">

