### PR TITLE
Update `minimist` to a non-vulnerable version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "lerna": "^3.22.1",
         "lint-staged": "^11.1.2",
         "memory-fs": "^0.5.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "mocha": "^8.1.1",
         "module-alias": "^2.2.2",
         "nunjucks": "^3.2.2",
@@ -16977,9 +16977,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/minimist-options": {
@@ -38776,9 +38776,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minimist-options": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lerna": "^3.22.1",
     "lint-staged": "^11.1.2",
     "memory-fs": "^0.5.0",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.6",
     "mocha": "^8.1.1",
     "module-alias": "^2.2.2",
     "nunjucks": "^3.2.2",


### PR DESCRIPTION
- This addresses an `npm audit` vulnerability alert for projects using `workbox`, which in turn depends on `minimist@1.2.5`: https://github.com/advisories/GHSA-xvch-5gv4-984h

**Prior to creating a pull request, please follow all the steps in the [contributing guide](https://github.com/GoogleChrome/workbox/blob/v6/CONTRIBUTING.md).**

R: @jeffposnick @tropicadri
