### PR TITLE
Fix extending webpack plugin

### DIFF
--- a/packages/workbox-webpack-plugin/src/generate-sw.ts
+++ b/packages/workbox-webpack-plugin/src/generate-sw.ts
@@ -69,7 +69,7 @@ export interface GenerateSWConfig extends WebpackGenerateSWOptions {
  * @memberof module:workbox-webpack-plugin
  */
 class GenerateSW {
-  private config: GenerateSWConfig;
+  protected config: GenerateSWConfig;
   private alreadyCalled: boolean;
 
   /**

--- a/packages/workbox-webpack-plugin/src/inject-manifest.ts
+++ b/packages/workbox-webpack-plugin/src/inject-manifest.ts
@@ -54,7 +54,7 @@ const {RawSource} = webpack.sources || require('webpack-sources');
  * @memberof module:workbox-webpack-plugin
  */
 class InjectManifest {
-  private config: WebpackInjectManifestOptions;
+  protected config: WebpackInjectManifestOptions;
   private alreadyCalled: boolean;
 
   /**


### PR DESCRIPTION
R: @jeffposnick @tropicadri

Fixes #3039 

Made the `config` property of the webpack plugins `protected`.
This will allow child classes to access and modify the config property if necessary.


PS:
Ran into an issue while running the commands mentioned in `contrbuting.md`. The commands ran fine and modified a bunch of files (mostly `package.json`s and `content not modified`s), but when I tried to commit these extra changes, it gave me an error about husky. After that, the changes disappeared as well. I am not familiar with husky so I could not figure out what to do even after reading the docs. Re-running the commands did not make the changes come back either. So I made the changes on github.com in the browser itself and fetched the commits back. Given the nature of the changes I made, I assume that it does not really matter? Still worth mentioning, just in case.