### PR TITLE
Add declare to RouteHandlerCallbackOptions

### DIFF
--- a/packages/workbox-core/src/types.ts
+++ b/packages/workbox-core/src/types.ts
@@ -46,7 +46,7 @@ export interface RouteMatchCallback {
 /**
  * Options passed to a `RouteHandlerCallback` function.
  */
-export interface RouteHandlerCallbackOptions {
+export declare interface RouteHandlerCallbackOptions {
   event: ExtendableEvent;
   request: Request;
   url: URL;


### PR DESCRIPTION
R: @tropicadri

This resolves an issue in which the properties in the `RouteHandlerCallbackOptions` object could be renamed via an aggressive minifier, leading to logic errors elsewhere in the code.