### PR TITLE
fix: navigateFallback by default is undefined

### DIFF
--- a/packages/workbox-build/src/types.ts
+++ b/packages/workbox-build/src/types.ts
@@ -269,7 +269,6 @@ export interface GeneratePartial {
    * your precache manifest. This is meant to be used in a Single Page App
    * scenario, in which you want all navigations to use common
    * [App Shell HTML](https://developers.google.com/web/fundamentals/architecture/app-shell).
-   * @default null
    */
   navigateFallback?: string | null;
   /**


### PR DESCRIPTION
**Prior to creating a pull request, please follow all the steps in the [contributing guide](https://github.com/GoogleChrome/workbox/blob/v6/CONTRIBUTING.md).**

R: @jeffposnick @tropicadri

Fixes N/A

This fixes a type documentation issue where `navigateFallback` is being set to `undefined` by default, but the docs say it was `null`. The two values have different behaviours internally.
