### PR TITLE
docs(module link): fix broken link

### DIFF
--- a/packages/workbox-build/README.md
+++ b/packages/workbox-build/README.md
@@ -1,1 +1,1 @@
-This module's documentation can be found at https://developers.google.com/web/tools/workbox/modules/workbox-build
+This module's documentation can be found at https://developer.chrome.com/docs/workbox/modules/workbox-build/


### PR DESCRIPTION
Fixes N/A

_Description of what's changed/fixed._

previous link points to landing page and isn't super helpful

also see https://github.com/GoogleChrome/workbox/pull/3150

