### PR TITLE
Use workbox-build 7.1.1 (fixes test failures)

### DIFF
--- a/packages/workbox-cli/package.json
+++ b/packages/workbox-cli/package.json
@@ -41,7 +41,7 @@
     "stringify-object": "^3.3.0",
     "upath": "^1.2.0",
     "update-notifier": "^4.1.0",
-    "workbox-build": "7.1.0"
+    "workbox-build": "7.1.1"
   },
   "workbox": {
     "packageType": "node_ts"

--- a/packages/workbox-webpack-plugin/package.json
+++ b/packages/workbox-webpack-plugin/package.json
@@ -25,7 +25,7 @@
     "pretty-bytes": "^5.4.1",
     "upath": "^1.2.0",
     "webpack-sources": "^1.4.3",
-    "workbox-build": "7.1.0"
+    "workbox-build": "7.1.1"
   },
   "peerDependencies": {
     "webpack": "^4.4.0 || ^5.91.0"


### PR DESCRIPTION
These [tests](https://github.com/GoogleChrome/workbox/blob/b001f20c408a738159ea63b78d8c4cdb49721415/test/workbox-cli/node/app.js#L101) started failing in https://github.com/GoogleChrome/workbox/commit/e679d30d9bd8bda03239e20466f7a3931e4fc4f8.