### PR TITLE
Update engines.node in packages and node-version in pull-request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Get npm cache directory
         id: npm-cache
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - uses: actions/cache@v2
         with:

--- a/packages/workbox-build/package-lock.json
+++ b/packages/workbox-build/package-lock.json
@@ -51,7 +51,7 @@
         "@types/node": "^18.15.11"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -12,7 +12,7 @@
     "file manifest"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "author": "Google's Web DevRel Team and Google's Aurora Team",
   "license": "MIT",

--- a/packages/workbox-cli/package-lock.json
+++ b/packages/workbox-cli/package-lock.json
@@ -34,7 +34,7 @@
         "@types/update-notifier": "^4.1.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/packages/workbox-cli/package.json
+++ b/packages/workbox-cli/package.json
@@ -18,7 +18,7 @@
     "build"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "author": "Google's Web DevRel Team and Google's Aurora Team",
   "license": "MIT",

--- a/packages/workbox-webpack-plugin/package-lock.json
+++ b/packages/workbox-webpack-plugin/package-lock.json
@@ -20,7 +20,7 @@
         "@types/webpack": "^5.28.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "webpack": "^4.4.0 || ^5.91.0"

--- a/packages/workbox-webpack-plugin/package.json
+++ b/packages/workbox-webpack-plugin/package.json
@@ -18,7 +18,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "fast-json-stable-stringify": "^2.1.0",


### PR DESCRIPTION
This is a follow-up to https://github.com/GoogleChrome/workbox/pull/3387 and https://github.com/GoogleChrome/workbox/pull/3392. I neglected to update `engines.node` in the latter as I had done in the former. This version of node corresponds with the oldest version of node currently in LTS maintenance. 

This also updates the `node-version` in the `pull-request` workflow.