### PR TITLE
Add composite to compilerOptions in the TypeScript config for packages that reference other packages

### DIFF
--- a/packages/workbox-background-sync/tsconfig.json
+++ b/packages/workbox-background-sync/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./",
     "rootDir": "./src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"

--- a/packages/workbox-broadcast-update/tsconfig.json
+++ b/packages/workbox-broadcast-update/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./",
     "rootDir": "./src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"

--- a/packages/workbox-build/tsconfig.json
+++ b/packages/workbox-build/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "composite": true,
     "esModuleInterop": true,
     "module": "CommonJS",
     "outDir": "./build",

--- a/packages/workbox-cacheable-response/tsconfig.json
+++ b/packages/workbox-cacheable-response/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./",
     "rootDir": "./src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"

--- a/packages/workbox-core/tsconfig.json
+++ b/packages/workbox-core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./",
     "rootDir": "./src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"

--- a/packages/workbox-expiration/tsconfig.json
+++ b/packages/workbox-expiration/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./",
     "rootDir": "./src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"

--- a/packages/workbox-google-analytics/tsconfig.json
+++ b/packages/workbox-google-analytics/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./",
     "rootDir": "./src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"

--- a/packages/workbox-routing/tsconfig.json
+++ b/packages/workbox-routing/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./",
     "rootDir": "./src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"

--- a/packages/workbox-strategies/tsconfig.json
+++ b/packages/workbox-strategies/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./",
     "rootDir": "./src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"


### PR DESCRIPTION
Fixes #3401

See https://www.typescriptlang.org/docs/handbook/project-references.html#composite
