### PR TITLE
Fix/precache cleanupresult compat

### DIFF
--- a/packages/workbox-precaching/src/PrecacheController.ts
+++ b/packages/workbox-precaching/src/PrecacheController.ts
@@ -264,7 +264,10 @@ class PrecacheController {
         printCleanupDetails(deletedURLs);
       }
 
-      return {deletedURLs};
+      return {
+        deletedURLs,
+        deletedCacheRequests: deletedURLs,
+      };
     });
   }
 

--- a/packages/workbox-precaching/src/_types.ts
+++ b/packages/workbox-precaching/src/_types.ts
@@ -14,7 +14,12 @@ export interface InstallResult {
 }
 
 export interface CleanupResult {
-  deletedCacheRequests: string[];
+  deletedURLs: string[];
+  /**
+   * @deprecated Use `deletedURLs` instead.
+   * TODO: Remove in the next major release.
+   */
+  deletedCacheRequests?: string[];
 }
 
 export declare interface PrecacheEntry {
@@ -51,8 +56,10 @@ export type urlManipulation = ({url}: {url: URL}) => URL[];
 
 /**
  * @typedef {Object} CleanupResult
- * @property {Array<string>} deletedCacheRequests List of URLs that were deleted
- * while cleaning up the cache.
+ * @property {Array<string>} deletedURLs List of URLs that were deleted while
+ * cleaning up the cache.
+ * @property {Array<string>} [deletedCacheRequests] Deprecated alias for
+ * deletedURLs.
  *
  * @memberof workbox-precaching
  */

--- a/packages/workbox-precaching/src/_types.ts
+++ b/packages/workbox-precaching/src/_types.ts
@@ -19,7 +19,7 @@ export interface CleanupResult {
    * @deprecated Use `deletedURLs` instead.
    * TODO: Remove in the next major release.
    */
-  deletedCacheRequests?: string[];
+  deletedCacheRequests: string[];
 }
 
 export declare interface PrecacheEntry {
@@ -58,7 +58,7 @@ export type urlManipulation = ({url}: {url: URL}) => URL[];
  * @typedef {Object} CleanupResult
  * @property {Array<string>} deletedURLs List of URLs that were deleted while
  * cleaning up the cache.
- * @property {Array<string>} [deletedCacheRequests] Deprecated alias for
+ * @property {Array<string>} deletedCacheRequests Deprecated alias for
  * deletedURLs.
  *
  * @memberof workbox-precaching

--- a/test/workbox-precaching/sw/test-PrecacheController.mjs
+++ b/test/workbox-precaching/sw/test-PrecacheController.mjs
@@ -834,7 +834,11 @@ describe(`PrecacheController`, function () {
         activateEvent,
       );
       expect(cleanupDetailsTwo.deletedURLs.length).to.equal(1);
+      expect(cleanupDetailsTwo.deletedCacheRequests.length).to.equal(1);
       expect(cleanupDetailsTwo.deletedURLs[0]).to.eql(
+        `${location.origin}/scripts/index.js?__WB_REVISION__=1234`,
+      );
+      expect(cleanupDetailsTwo.deletedCacheRequests[0]).to.eql(
         `${location.origin}/scripts/index.js?__WB_REVISION__=1234`,
       );
 
@@ -891,6 +895,10 @@ describe(`PrecacheController`, function () {
         activateEvent,
       );
       expect(cleanupDetailsTwo.deletedURLs).to.have.members([
+        `${location.origin}/index.1234.html`,
+        `${location.origin}/scripts/stress.js?test=search&foo=bar&__WB_REVISION__=1234`,
+      ]);
+      expect(cleanupDetailsTwo.deletedCacheRequests).to.have.members([
         `${location.origin}/index.1234.html`,
         `${location.origin}/scripts/stress.js?test=search&foo=bar&__WB_REVISION__=1234`,
       ]);


### PR DESCRIPTION
Fixes #3400

### Summary

This PR resolves a mismatch between the declared `CleanupResult` type and the actual runtime behavior of `PrecacheController.activate()`.

Currently:

* The type defines `deletedCacheRequests`
* The implementation returns `deletedURLs`
* Tests and runtime behavior already rely on `deletedURLs`

This leads to an inconsistent public API where TypeScript users are guided to use a property that does not exist at runtime.

---

### Changes

* **Align runtime and types**

  * `deletedURLs` is now treated as the canonical field
* **Add backward compatibility**

  * `deletedCacheRequests` is returned as an alias pointing to the same array
* **Update type definition**

  * Include both fields in `CleanupResult`
  * Mark `deletedCacheRequests` as deprecated
* **Update JSDoc**

  * Reflect `deletedURLs` as the primary field
  * Document deprecation of `deletedCacheRequests`
* **Add test coverage**

  * Verify both `deletedURLs` and `deletedCacheRequests` return consistent values

---

### Rationale

* Runtime behavior and existing tests already establish `deletedURLs` as the de facto API
* Renaming runtime to match types would risk breaking existing JavaScript consumers
* Removing `deletedCacheRequests` from types would break existing TypeScript users

This approach:

* aligns types with actual behavior
* avoids breaking changes
* provides a clear migration path

---

### Notes

* `deletedCacheRequests` is now deprecated and can be removed in a future major release
* `deletedURLs` is more semantically accurate (array of URL strings rather than Request objects)

---

### Testing

* Existing tests pass unchanged
* Added assertions to ensure both properties return identical values

---

### Risk

Low , this is an additive, backward-compatible change with no impact on runtime logic or precaching behavior
