### PR TITLE
CI: Fix Chrome version discrepancy

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -51,7 +51,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.selenium-assistant
-          key: ${{ runner.os }}
+          key: ${{ runner.os }}-selenium-assistant-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-selenium-assistant-
 
       - name: Setup
         run: |

--- a/gulp-tasks/test-integration.js
+++ b/gulp-tasks/test-integration.js
@@ -109,17 +109,34 @@ async function test_integration() {
     return;
   }
 
-  // Install the latest Chrome and Firefox webdrivers without referencing
-  // package-lock.json, to ensure that they're up to date.
-  await execa('npm', ['install', '--no-save', 'chromedriver', 'geckodriver'], {
-    preferLocal: true,
-  });
-
   logHelper.log(`Downloading browsers...`);
   const expiration = 24;
   // We are only running tests in stable, see bellow for reasons.
   await seleniumAssistant.downloadLocalBrowser('chrome', 'stable', expiration);
   await seleniumAssistant.downloadLocalBrowser('firefox', 'stable', expiration);
+
+  // Determine downloaded Chrome version to match ChromeDriver
+  const chromeBrowser = seleniumAssistant.getLocalBrowser('chrome', 'stable');
+  let chromedriverSpec = 'chromedriver';
+  if (chromeBrowser && chromeBrowser.isValid()) {
+    const version = chromeBrowser.getVersionNumber();
+    if (version !== -1) {
+      chromedriverSpec = `chromedriver@${version}`;
+      logHelper.log(
+        `Matched Chrome version ${version}, installing ${chromedriverSpec}`,
+      );
+    }
+  }
+
+  // Install the matching Chrome and latest Firefox webdrivers without referencing
+  // package-lock.json, to ensure that they're up to date.
+  await execa(
+    'npm',
+    ['install', '--no-save', chromedriverSpec, 'geckodriver'],
+    {
+      preferLocal: true,
+    },
+  );
 
   const packagesToTest = globSync(`test/${global.packageOrStar}/integration`);
   if (packagesToTest.length === 0) {


### PR DESCRIPTION
The workbox integration tests fail in CI when chromedriver (updated via `npm install --no-save`) is newer than the Chrome browser version cached by selenium-assistant.

The current cache key is static (`${{ runner.os }}`), meaning once the cache is created, it is never updated with newer browser versions.

I first addressed this by making the cache key more dynamic, but that wasn't good enough. The main change now is that the browser is first installed via selenium-assistant and then the matching chromedriver verison is installed.

To verify: tests should now pass again.