### PR TITLE
Regenerate/update NPM lockfile by running: npm install --include=dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/eslint": "^8.56.10",
         "@types/estree": "^1.0.5",
         "@types/fs-extra": "^9.0.13",
+        "@types/lodash": "^4.17.0",
         "@types/node": "^20.14.8",
         "@types/stringify-object": "^3.3.1",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -5628,6 +5629,13 @@
     },
     "node_modules/@types/linkify-it": {
       "version": "3.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -29387,6 +29395,12 @@
     },
     "@types/linkify-it": {
       "version": "3.0.2",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "dev": true
     },
     "@types/markdown-it": {


### PR DESCRIPTION
During environment configuration to develop a possible rollback of the template engine from `eta` to `lodash` for #3529 I began by running `npm ci --include=dev`, intending to install a close-match of the base dependencies of `workbox.git` (in order to achieve more reliable/repeatable local development and test results).

However, the following error appeared:

```
Missing: @types/lodash@4.17.24 from lock file
```

NB: This appeared with NPM CLI version 11.3.0 as shown below:

```sh
$ npm --version
11.13.0
```

Discovered during preparation for work on #3529.

The NPM lockfile (`package-lock.json`) has been regenerated; in this case, this only added/updated one dependency record, `@types/lodash`.