### PR TITLE
Typo fixup: branch version in PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-**Prior to creating a pull request, please follow all the steps in the [contributing guide](https://github.com/GoogleChrome/workbox/blob/v6/CONTRIBUTING.md).**
+**Prior to creating a pull request, please follow all the steps in the [contributing guide](https://github.com/GoogleChrome/workbox/blob/v7/CONTRIBUTING.md).**
 
 Fixes #_issue number_
 


### PR DESCRIPTION
Updates an outdated reference to the `v6` branch in the GitHub pull request markdown template.

Resolves #3471.