### PR TITLE
docs: update navigation requests link

### DIFF
--- a/packages/workbox-build/src/schema/GenerateSWOptions.json
+++ b/packages/workbox-build/src/schema/GenerateSWOptions.json
@@ -145,7 +145,7 @@
       ]
     },
     "navigateFallback": {
-      "description": "If specified, all\n[navigation requests](https://developers.google.com/web/fundamentals/primers/service-workers/high-performance-loading#first_what_are_navigation_requests)\nfor URLs that aren't precached will be fulfilled with the HTML at the URL\nprovided. You must pass in the URL of an HTML document that is listed in\nyour precache manifest. This is meant to be used in a Single Page App\nscenario, in which you want all navigations to use common\n[App Shell HTML](https://developers.google.com/web/fundamentals/architecture/app-shell).",
+      "description": "If specified, all\n[navigation requests](https://web.dev/articles/handling-navigation-requests)\nfor URLs that aren't precached will be fulfilled with the HTML at the URL\nprovided. You must pass in the URL of an HTML document that is listed in\nyour precache manifest. This is meant to be used in a Single Page App\nscenario, in which you want all navigations to use common\n[App Shell HTML](https://developers.google.com/web/fundamentals/architecture/app-shell).",
       "default": null,
       "type": [
         "null",

--- a/packages/workbox-build/src/schema/WebpackGenerateSWOptions.json
+++ b/packages/workbox-build/src/schema/WebpackGenerateSWOptions.json
@@ -127,7 +127,7 @@
       "type": "boolean"
     },
     "navigateFallback": {
-      "description": "If specified, all\n[navigation requests](https://developers.google.com/web/fundamentals/primers/service-workers/high-performance-loading#first_what_are_navigation_requests)\nfor URLs that aren't precached will be fulfilled with the HTML at the URL\nprovided. You must pass in the URL of an HTML document that is listed in\nyour precache manifest. This is meant to be used in a Single Page App\nscenario, in which you want all navigations to use common\n[App Shell HTML](https://developers.google.com/web/fundamentals/architecture/app-shell).",
+      "description": "If specified, all\n[navigation requests](https://web.dev/articles/handling-navigation-requests)\nfor URLs that aren't precached will be fulfilled with the HTML at the URL\nprovided. You must pass in the URL of an HTML document that is listed in\nyour precache manifest. This is meant to be used in a Single Page App\nscenario, in which you want all navigations to use common\n[App Shell HTML](https://developers.google.com/web/fundamentals/architecture/app-shell).",
       "default": null,
       "type": [
         "null",

--- a/packages/workbox-build/src/types.ts
+++ b/packages/workbox-build/src/types.ts
@@ -263,7 +263,7 @@ export interface GeneratePartial {
   mode?: string | null;
   /**
    * If specified, all
-   * [navigation requests](https://developers.google.com/web/fundamentals/primers/service-workers/high-performance-loading#first_what_are_navigation_requests)
+   * [navigation requests](https://web.dev/articles/handling-navigation-requests)
    * for URLs that aren't precached will be fulfilled with the HTML at the URL
    * provided. You must pass in the URL of an HTML document that is listed in
    * your precache manifest. This is meant to be used in a Single Page App

--- a/packages/workbox-routing/src/NavigationRoute.ts
+++ b/packages/workbox-routing/src/NavigationRoute.ts
@@ -22,7 +22,7 @@ export interface NavigationRouteMatchOptions {
 /**
  * NavigationRoute makes it easy to create a
  * {@link workbox-routing.Route} that matches for browser
- * [navigation requests]{@link https://developers.google.com/web/fundamentals/primers/service-workers/high-performance-loading#first_what_are_navigation_requests}.
+ * [navigation requests]{@link https://web.dev/articles/handling-navigation-requests}.
  *
  * It will only match incoming Requests whose
  * {@link https://fetch.spec.whatwg.org/#concept-request-mode|mode}


### PR DESCRIPTION
## Summary
- Replace the outdated `developers.google.com/web/fundamentals` navigation requests link with the current web.dev article.
- Update all four occurrences listed in #3536.

Fixes #3536.

## Validation
- Confirmed the old URL no longer appears in the four referenced files.
- Confirmed `https://web.dev/articles/handling-navigation-requests` returns HTTP 200.
- Parsed the two updated JSON schema files with Node.js.
- Ran `git diff --check`.