### PR TITLE
ci: configure grouped updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
         dependency-type: 'production'
       devDependencies:
         dependency-type: 'development'
+    cooldown:
+      default-days: 14
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,21 @@ updates:
       - '/packages'
     schedule:
       interval: 'monthly'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
+    groups:
+      dependencies:
+        dependency-type: 'production'
+      devDependencies:
+        dependency-type: 'development'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'monthly'
     open-pull-requests-limit: 1
+    groups:
+      actions:
+        patterns:
+          - '*'
     cooldown:
       default-days: 14

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: '.nvmrc'
 
@@ -17,7 +17,7 @@ jobs:
         id: npm-cache
         run: |
           echo "::set-output name=dir::$(npm config get cache)"
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -35,20 +35,20 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: '.nvmrc'
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.selenium-assistant
           key: ${{ runner.os }}-selenium-assistant-${{ github.run_id }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,9 @@ name: Test Suite
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   Node_Tests_Windows:
     runs-on: windows-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,6 +8,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
@@ -36,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:


### PR DESCRIPTION
Stacked on #3556.

Consolidates Dependabot version updates into grouped pull requests for both npm dependencies and GitHub Actions workflows:

* Groups npm updates into `dependencies` and `devDependencies` across scanned directories (`/` and `/packages`).
* Groups GitHub Actions updates into a single PR (`actions`).
* Lowers `open-pull-requests-limit` from 5 to 2 for npm (matching the 2 groups) and keeps GitHub Actions at 1.

This halts individual PR spam and prevents conflicting `package-lock.json` churn across packages.